### PR TITLE
CHR: new syntax and implementation

### DIFF
--- a/bench/sources/chr.elpi
+++ b/bench/sources/chr.elpi
@@ -1,61 +1,36 @@
-% Examples that must succeed:
-% term (lam x \ X x) (arr A nat), term (lam x \ X x) (arr bool B).
-% term (lam x \ lam y \ X (app x y)) (arr (arr A Y) (arr A nat)), term (lam x \ X x) (arr bool B).
-
-% Examples that must fail:
-% term (lam x \ X x) (arr A nat), term (lam x \ X) (arr bool B).
-% term (lam x \ X x) (arr nat nat), term (lam x \ X x) (arr bool B).
-% term (lam x \ lam y \ X (app x y)) (arr X (arr A nat)), term (lam x \ X x) (arr bool B).
-% -- reason: (app x y) is not well typed when X and A are frozen
-
 mode (term i o).
+term (app HD ARG) TGT :- term HD (arr SRC TGT), term ARG SRC.
+term (lam F) (arr SRC TGT) :- pi x\ term x SRC => term (F x) TGT.
+term (?? as X) T :- declare_constraint (term X T) [X].
 
-term (app X Y) B :- term X (arr A B), term Y A.
-term (lam F) (arr A B) :- pi x\ term x A => term (F x) B.
-term (?? as X) A :-declare_constraint (term X A) X.
-
-infixr ====> 126. % Implication where the l.h.s. is a list of propositions.
+len [] 0.
+len [_|XS] N :- len XS M, N is M + 1.
 
 constraint term {
-  rule (GX ?- term (?? as X) TX)
-     \ (GY ?- term (?? as Y) TY)
-     > X = Y
-     | (X = uvar _ XL, Y = uvar _ YL,
-        compatible GX LX GY LY CTXCONSTR)
+  rule
+     \ (term (uvar K LX) _) (term (uvar _ LY) _)
+     | (len LX N, len LY M, not(N = M))
+   <=> (print "wrong arity" K, false).
+
+  rule (GX ?- term (uvar _ LX) TX)
+     \ (GY ?- term (uvar _ LY) TY)
+     > LX ~ LY
+     | (compatible GX LX GY LY CTXCONSTR)
    <=> (CTXCONSTR, TX = TY).
+
 }
 
-%compatible A B C D E :- print "##" (compatible A B C D E), fail.
 compatible _ [] _ [] true :- !.
 compatible GX [X|XS] GY [Y|YS] (TX = TY, K) :-
- (GX ====> term X TX),
- (GY ====> term Y TY),
+ (GX => term X TX),
+ (GY => term Y TY),
  !,
  compatible GX XS GY YS K.
 compatible _ _ _ _ false.
 
-    [] ====> T :- T.
-[X|XS] ====> T :- X => (XS ====> T).
+main :-
+  (term (lam x\ lam y\ app (app (F x y) x) y) T1, term (lam y\ lam x\ app (app (F x y) y) x) T2),
+  (term (lam x \ X x) (arr A nat), term (lam x \ X x) (arr bool B)),
+  not(term (lam x \ Y x) (arr C nat), term (lam x \ Y) (arr bool C)),
+  not(term (lam x \ Z x) (arr nat nat), term (lam x \ Z x) (arr bool D)).
 
-spy P :- print "[" P, P, print "]ok", !.
-spy P :- print "]fail", fail.
-
-main :- 
-  (sigma X\
-    term b2n (arr bool nat) =>
-      (term (lam x \ X x) (arr A nat),
-       term (lam x \ X x) (arr bool B),
-       spy (not(X = x\x)),
-       spy (X = x\ app b2n x))),
-
-  (sigma X\sigma T1\sigma T2\sigma TY1\sigma TY2\
-    term b2n (arr bool nat) =>
-     (T1 = (lam f \ lam y \ X (app f y)), TY1 = (arr (arr A Y) (arr A nat)),
-      T2 = (lam x \ X x), TY2 = (arr bool B),
-      term T1 TY1, term T2 TY2,
-      spy (not(X = x\x)),
-      spy (X = x\ app b2n x),
-      print T1 ":" TY1,
-      print T2 ":" TY2)),
-
-  true.

--- a/bench/sources/chrGCD.elpi
+++ b/bench/sources/chrGCD.elpi
@@ -1,6 +1,9 @@
 mode (gcd i i).
+kind group type.
+type group-1 group.
+type group-2 group.
 
-gcd A (?? as B) :- declare_constraint (gcd A B) B.
+gcd A (?? as B) :- !, declare_constraint (gcd A B) B.
 
 % assert result is OK
 gcd 11 group-1 :- print "group 1 solved".
@@ -11,6 +14,7 @@ main :- gcd 99 X, gcd 66 X, gcd 14 Y, gcd 22 X, gcd 77 Y,
         X = group-1, Y = group-2.
 
 constraint gcd {
-  rule (gcd A X) \ (gcd B Y) > X ~ Y | (A = B).
-  rule (gcd A X) \ (gcd B Y) > X ~ Y | (A < B) <=> (C is (B - A), gcd C X).
+  rule (gcd A _) \ (gcd B _) | (A = B).
+  rule (gcd A _) \ (gcd B X) | (A < B) <=> (C is (B - A), gcd C X).
 }
+

--- a/bench/sources/llamchr.elpi
+++ b/bench/sources/llamchr.elpi
@@ -11,10 +11,10 @@ term succ (arr nat nat).
 infixr ====> 126. % Implication where the l.h.s. is a list of propositions.
 
 constraint term {
-  rule (GX ?- term (?? as KX) TX)
-     \ (GY ?- term (?? as KY) TY)
-     > KX ~ KY
-     | (KX = uvar _ LX, KY = uvar _ LY, compatible GX LX GY LY CTXCONSTR)
+  rule (GX ?- term (uvar _ LX) TX)
+     \ (GY ?- term (uvar _ LY) TY)
+     > LX ~ LY
+     | (compatible GX LX GY LY CTXCONSTR)
    <=> (CTXCONSTR, TX = TY).
 }
 

--- a/src/elpi_API.ml
+++ b/src/elpi_API.ml
@@ -131,8 +131,8 @@ module Extend = struct
       goal : int * term
     }
     let constraints = Elpi_util.map_filter (function
-      | { kind = Constraint { depth; goal; pdiff } } ->
-          Some { context = pdiff ; goal = (depth, goal) }
+      | { kind = Constraint { cdepth; conclusion; context } } ->
+          Some { context ; goal = (cdepth, conclusion) }
       | _ -> None)
   end
 

--- a/src/elpi_ast.ml
+++ b/src/elpi_ast.ml
@@ -98,16 +98,13 @@ type clause = {
   body : term;
 }[@@deriving show]
 
-type 'func alignement =  'func list * [ `Spread | `Align ]
-[@@deriving show]
-type ('term,'func_t) chr = {
-  to_match : ('term * 'term) list;
-  to_remove : ('term * 'term) list;
-  alignement : 'func_t alignement [@default ([],`Align)];
-  guard : 'term option;
-  new_goal : 'term option;
-  depth : int [@default 0];
-  nargs : int [@default 0];
+type sequent = { eigen : term; context : term; conclusion : term }
+and chr_rule = {
+  to_match : sequent list [@default []];
+  to_remove : sequent list [@default []];
+  alignment : Func.t list [@default []];
+  guard : term option [@default None];
+  new_goal : sequent option [@default None];
 }
 [@@deriving show, create]
 
@@ -118,7 +115,7 @@ type decl =
  | End
  | Mode of (Func.t * bool list * (Func.t * (Func.t * Func.t) list) option) list
  | Constraint of Func.t list
- | Chr of (term, Func.t) chr
+ | Chr of chr_rule
  | Accumulated of decl list
  | Macro of Ploc.t * Func.t * term
  | Type of bool * Func.t * term

--- a/src/elpi_ast.mli
+++ b/src/elpi_ast.mli
@@ -60,32 +60,26 @@ type clause = {
   insert : ([ `Before | `After ] * string) option;
   body : term;
 }
-type 'func alignement =  'func list * [ `Spread | `Align ]
-type ('term,'func_t) chr = {
-  to_match : ('term * 'term) list;
-  to_remove : ('term * 'term) list;
-  alignement : 'func_t alignement;
-  guard : 'term option;
-  new_goal : 'term option;
-  depth : int; (* not parsed *)
-  nargs : int; (* not parsed *)
+type sequent = { eigen : term; context : term; conclusion : term }
+and chr_rule = {
+  to_match : sequent list;
+  to_remove : sequent list;
+  alignment : Func.t list;
+  guard : term option;
+  new_goal : sequent option;
 }
+[@@deriving show, create]
 
-val create_chr :
-  ?to_match:('a * 'a) list ->
-  ?to_remove:('a * 'a) list ->
-  ?alignement:'b alignement ->
-  ?guard:'a ->
-  ?new_goal:'a -> ?depth:int -> ?nargs:int -> unit -> ('a, 'b) chr
+val create_chr_rule :
+  ?to_match: sequent list ->
+  ?to_remove: sequent list ->
+  ?alignment:Func.t list ->
+  ?guard:term option ->
+  ?new_goal: sequent option ->
+  unit -> chr_rule
 
-val pp_chr : 
-  (Format.formatter -> 'term -> unit) ->
-  (Format.formatter -> 'func_t -> unit) ->
-     Format.formatter -> ('term,'func_t) chr -> unit
-val show_chr :
-  (Format.formatter -> 'term -> unit) ->
-  (Format.formatter -> 'func_t -> unit) ->
-     ('term,'func_t) chr -> string
+val pp_chr_rule : Format.formatter -> chr_rule -> unit
+val show_chr_rule : chr_rule -> string
 
 type decl =
    Clause of clause
@@ -94,7 +88,7 @@ type decl =
  | End
  | Mode of (Func.t * bool list * (Func.t * (Func.t * Func.t) list) option) list
  | Constraint of Func.t list
- | Chr of (term, Func.t) chr
+ | Chr of chr_rule
  | Accumulated of decl list
  | Macro of Ploc.t * Func.t * term
  | Type of bool(*external?*) * Func.t * term

--- a/src/elpi_runtime.ml
+++ b/src/elpi_runtime.ml
@@ -416,16 +416,16 @@ let undo ~old_trail ?old_constraints () =
 let print fmt =
   let pp_depth fmt d =
     if d > 0 then
-      Fmt.fprintf fmt "{%a} : "
+      Fmt.fprintf fmt "{%a} :@ "
         (pplist (uppterm d [] 0 empty_env) "") (C.mkinterval 0 d 0) in
   let pp_ctx fmt ctx =
     if ctx <> [] then
-    Fmt.fprintf fmt "%a ?- "
+     Fmt.fprintf fmt "@[<hov 2>%a@]@ ?- "
       (pplist (fun fmt (d,t) -> uppterm d [] 0 empty_env fmt t) ",") ctx in
   let pp_goal depth g = (uppterm depth [] 0 empty_env) g in
   List.iter (fun { cdepth=depth; context=pdiff; conclusion = g } ->
       Fmt.fprintf fmt
-        "@[<hov 2>%a%a%a@]" pp_depth depth pp_ctx pdiff (pp_goal depth) g)
+        "@[<hov 2>%a%a%a@]@ " pp_depth depth pp_ctx pdiff (pp_goal depth) g)
 
 let pp_stuck_goal_kind fmt = function
    | Unification { adepth = ad; env = e; bdepth = bd; a; b } ->
@@ -2482,11 +2482,7 @@ let exec_custom_predicate c ~depth idx args =
        if c == C.declare_constraintc then begin
                declare_constraint ~depth idx args; [] end
   else if c == C.print_constraintsc then begin
-               let b = Buffer.create 1024 in
-               let fmt = Format.formatter_of_buffer b in
-               CS.print fmt (CS.contents ());
-               Format.fprintf fmt "%!";
-               printf "%s%!" (Buffer.contents b);
+               printf "@[<hov 0>%a@]%!" CS.print (CS.contents ());
                [] 
   end else
     let f = try lookup_custom c with Not_found -> anomaly"no such custom" in

--- a/src/elpi_runtime.ml
+++ b/src/elpi_runtime.ml
@@ -1256,8 +1256,9 @@ let bind r gamma l a d delta b left t e =
               (* This should be the beta reduct. One could also
                * return the non reduced but bound as in the other if branch *)
               mkAppUVar r' lvl args_here
+        end else begin
+          mkAppUVar r lvl (List.map (bind b delta w) orig_args)
         end
-          else raise RestrictionFailure
   end] in
   try
     let v = mknLam new_lams (bind b delta 0 t) in

--- a/src/elpi_runtime.ml
+++ b/src/elpi_runtime.ml
@@ -2562,29 +2562,6 @@ let mk_permutations quick_filter len pivot pivot_position rest =
      when matched against chr rules;
    the two lists in output are the constraints to be removed and added *)
 let propagate { CS.cstr; cstr_position; cstr_main_key } history =
-(*
- let rec find_entails nargs_ref max_depth n = function
-   | Lam t -> find_entails nargs_ref max_depth (n+1) t
-   | App(c,x,[g]) when c == C.entailsc -> n, x, g
-   | t ->
-      let i = !nargs_ref in
-      incr nargs_ref; 
-      n, Arg(i,0), t in
- let sequent_of_pat nargs_ref max_depth ruledepth = function
-   | App(c,x,[]) when c == C.nablac ->
-       let min_depth, ctx, g = find_entails nargs_ref max_depth ruledepth x in
-       (min_depth, ctx, g)
-   | Lam _ -> error "syntax error in propagate"
-   | x -> 
-       let min_depth, ctx, g = find_entails nargs_ref max_depth ruledepth x in
-       (min_depth, ctx, g) in
-*)
- (*Fmt.fprintf Fmt.std_formatter "PROPAGATION %d\n%!" cstr_position;*)
- (* CSC: INVARIANT: propagate clauses can never be assumed using
-    implication. Otherwise ~depth:0 is wrong and I do not see any
-    reasonable semantics (i.e. a semantics where the scoping is not
-    violated). For the same reason I took the propagate clauses from
-    the !orig_prolog_program. *)
 
  let rules = CHR.rules_for (head_of cstr.conclusion) !chrules in
  let initial_program = Elpi_data.wrap_prolog_prog !orig_prolog_program in
@@ -2621,7 +2598,6 @@ let propagate { CS.cstr; cstr_position; cstr_main_key } history =
      candidates |> map_exists (fun (constraints as orig_constraints) ->
       let hitem = HISTORY.({ propagation_rule; constraints }) in
       if HISTORY.mem history hitem then begin
-(*         Fmt.fprintf Fmt.std_formatter "pruned\n%!" ; *)
         None
         end
       else

--- a/src/elpi_util.ml
+++ b/src/elpi_util.ml
@@ -111,11 +111,15 @@ end
 module Int = struct
   type t = int [@@deriving show]
 end
+module String = struct
+  type t = string [@@deriving show]
+end
 module Pair = struct
   type ('a,'b) t = 'a * 'b [@@deriving show]
 end
 let pp_option = Option.pp
 let pp_int = Int.pp
+let pp_string = String.pp
 let pp_pair = Pair.pp
 
 let remove_from_list x =

--- a/src/elpi_util.mli
+++ b/src/elpi_util.mli
@@ -59,6 +59,7 @@ val pplist : ?max:int -> ?boxed:bool ->
   ?pplastelem:(Format.formatter -> 'a -> unit) -> string ->
     Format.formatter -> 'a list -> unit
 val pp_int : Format.formatter -> int -> unit
+val pp_string : Format.formatter -> string -> unit
 val pp_pair :
   (Format.formatter -> 'a -> unit) ->
   (Format.formatter -> 'b -> unit) ->


### PR DESCRIPTION
From the user perspective:
- patterns operate on frozen terms
- two alignment mode
  - auto for L\lambda
  - manual:
    - matched constraints are spread
    - one chooses in which context the new goal is injected
    - injection is manual
- less bugs, better error messages

Inside the engine:
- the new code is more clear
  - but makes many passes on the terms to shift them correctly
- all UVar that intervene are expanded to level 0
  - this may resume other goals that then would immediately
    be suspended