### PR TITLE
Restriction bug

### DIFF
--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -489,7 +489,7 @@ module HO : sig
 
   (* lift/restriction/heapification with occur_check *)
   val move : 
-    adepth:int -> env -> ?avoid:uvar_body -> ?depth:int ->
+    adepth:int -> env -> ?avoid:uvar_body ->
     from:int -> to_:int -> term -> term
   
   (* like move but for heap terms (no heapification) *)
@@ -696,7 +696,7 @@ let mkAppArg i fromdepth xxs' =
    
 *)
 
-let rec move ~adepth:argsdepth e ?avoid ?(depth=0) ~from ~to_ t =
+let rec move ~adepth:argsdepth e ?avoid ~from ~to_ t =
 (* TODO: to disable occur_check add something like: let avoid = None in *)
  let delta = from - to_ in
  let rc =
@@ -852,7 +852,7 @@ let rec move ~adepth:argsdepth e ?avoid ?(depth=0) ~from ~to_ t =
        end
   end]
   in
-   maux e depth t
+   maux e 0 t
   end
  in
   [%spy "move-output" (ppterm to_ [] argsdepth e) rc];

--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -1384,9 +1384,9 @@ let rec unif matching depth adepth a bdepth b e =
      when r1 == r2 && !!r1 == C.dummy -> args1 == args2
      (* XXX this would be a type error *)
    | UVar(r1,vd,xs), AppUVar(r2,_,ys)
-     when r1 == r2 && !!r1 == C.dummy -> unif matching depth adepth (AppUVar(r1,vd,List.init xs (fun i -> mkConst (vd+i)))) bdepth b e
+     when r1 == r2 && !!r1 == C.dummy -> unif matching depth adepth (AppUVar(r1,vd,C.mkinterval vd xs 0)) bdepth b e
    | AppUVar(r1,vd,xs), UVar(r2,_,ys)
-     when r1 == r2 && !!r1 == C.dummy -> unif matching depth adepth a bdepth (AppUVar(r1,vd,List.init ys (fun i -> mkConst (vd+i)))) e
+     when r1 == r2 && !!r1 == C.dummy -> unif matching depth adepth a bdepth (AppUVar(r1,vd,C.mkinterval vd ys 0)) e
    | AppUVar(r1,vd,xs), AppUVar(r2,_,ys)
      when r1 == r2 && !!r1 == C.dummy ->
        let pruned = ref false in

--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -1494,16 +1494,17 @@ let rec unif matching depth adepth a bdepth b e =
       unif matching depth adepth a bdepth b e
    | UVar({ rest = [] },_,a1), UVar ({ rest = _ :: _ },_,a2) when a1 + a2 > 0 -> unif matching depth bdepth b adepth a e
    | AppUVar({ rest = [] },_,_), UVar ({ rest = _ :: _ },_,a2) when  a2 > 0 -> unif matching depth bdepth b adepth a e
-   | _, UVar (r,origdepth,args) when args > 0 ->
+
+   | _, UVar (r,origdepth,args) when args > 0 && match a with UVar(r1,_,_) | AppUVar(r1,_,_) -> r != r1 | _ -> true ->
       let v = fst (make_lambdas origdepth args) in
-      [%spy "assign" (fun fmt _ -> Fmt.fprintf fmt "%a := %a"
+      [%spy "assign (simplify)" (fun fmt _ -> Fmt.fprintf fmt "%a := %a"
         (uppterm depth [] bdepth e) (UVar(r,origdepth,0))
         (uppterm depth [] bdepth e) v) ()];
       r @:= v;
       unif matching depth adepth a bdepth b e
-   | UVar (r,origdepth,args), _ when args > 0 ->
+   | UVar (r,origdepth,args), _ when args > 0 && match b with UVar(r1,_,_) | AppUVar(r1,_,_) -> r != r1 | _ -> true ->
       let v = fst (make_lambdas origdepth args) in
-      [%spy "assign" (fun fmt _ -> Fmt.fprintf fmt "%a := %a"
+      [%spy "assign (simplify)" (fun fmt _ -> Fmt.fprintf fmt "%a := %a"
          (uppterm depth [] adepth e) (UVar(r,origdepth,0))
          (uppterm depth [] adepth e) v) ()];
       r @:= v;

--- a/src/runtime.mli
+++ b/src/runtime.mli
@@ -32,7 +32,7 @@ val split_conj : depth:int -> term -> term list
 val mkAppArg : int -> int -> term list -> term
 val move : 
   adepth:int -> env ->
-  ?avoid:uvar_body -> ?depth:int ->
+  ?avoid:uvar_body ->
   from:int -> to_:int -> term -> term
 val hmove : 
   ?avoid:uvar_body ->

--- a/src/util.ml
+++ b/src/util.ml
@@ -228,6 +228,7 @@ let option_map f = function Some x -> Some (f x) | None -> None
 let option_mapacc f acc = function
   | Some x -> let acc, y = f acc x in acc, Some y
   | None -> acc, None
+let option_iter f = function None -> () | Some x -> f x
 
 module Option = struct
   type 'a t = 'a option = None | Some of 'a [@@deriving show]

--- a/src/util.mli
+++ b/src/util.mli
@@ -120,6 +120,7 @@ val pp_option :
   (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a option -> unit
 val option_mapacc :
   ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a option -> 'acc * 'b option
+val option_iter : ('a -> unit) -> 'a option -> unit
 
 (***************** Unique ID ****************)
 

--- a/tests/sources/restriction4.elpi
+++ b/tests/sources/restriction4.elpi
@@ -1,0 +1,3 @@
+main :-
+    pi x\ sigma Y Z\ pi y\
+      std.spy(X x = f (Y y) e\ (Z y e)).

--- a/tests/sources/restriction5.elpi
+++ b/tests/sources/restriction5.elpi
@@ -1,0 +1,3 @@
+main :-
+  pi x y z u w\
+    std.spy(X x y = X u w).

--- a/tests/sources/restriction6.elpi
+++ b/tests/sources/restriction6.elpi
@@ -1,0 +1,3 @@
+main :-
+  pi x\ sigma Y\ pi y\ sigma Z\
+      std.spy(X x = f (Y y) l\e\ (Z e)).

--- a/tests/suite/correctness_HO.ml
+++ b/tests/suite/correctness_HO.ml
@@ -94,6 +94,10 @@ let () = declare "restriction3"
   ~source_elpi:"restriction3.elpi"
   ~description:"HO unification scope checking"
   ()
+let () = declare "restriction5"
+  ~source_elpi:"restriction5.elpi"
+  ~description:"HO unification scope checking"
+  ()
 let () = declare "restriction"
   ~source_elpi:"restriction.elpi"
   ~description:"HO unification scope checking"

--- a/tests/suite/correctness_HO.ml
+++ b/tests/suite/correctness_HO.ml
@@ -94,8 +94,16 @@ let () = declare "restriction3"
   ~source_elpi:"restriction3.elpi"
   ~description:"HO unification scope checking"
   ()
+let () = declare "restriction4"
+  ~source_elpi:"restriction4.elpi"
+  ~description:"HO unification scope checking"
+  ()
 let () = declare "restriction5"
   ~source_elpi:"restriction5.elpi"
+  ~description:"HO unification scope checking"
+  ()
+let () = declare "restriction6"
+  ~source_elpi:"restriction6.elpi"
   ~description:"HO unification scope checking"
   ()
 let () = declare "restriction"


### PR DESCRIPTION
This is mostly to make @sacerdot aware.

The commit history should be clear and I've added a test for each piece of code I've touched.

Note: the code containing "(*CSC: XXX why vardepth and not to_ ? *)" has been rewritten, and indeed we use `to_` all the time