### PR TITLE
API: flexible terms are at lvl 0

### DIFF
--- a/src/API.mli
+++ b/src/API.mli
@@ -595,12 +595,11 @@ module FlexibleData : sig
   (** key for Elpi's flexible data *)
   module Elpi : sig
     type t
-    val make : ?name:string -> lvl:int -> Data.state -> Data.state * t
+    val make : ?name:string -> Data.state -> Data.state * t
     val get : name:string -> Data.state -> t option
     val pp :  Format.formatter -> t -> unit
     val show :  t -> string
     val equal : t -> t -> bool
-    val lvl : t -> int
   end
 
   module type Host = sig
@@ -622,7 +621,7 @@ module FlexibleData : sig
     val filter : (Host.t -> Elpi.t -> bool) -> t -> t
 
     (* The eventual body at its depth *)
-    val fold : (Host.t -> Elpi.t -> (int * Data.term) option -> 'a -> 'a) -> t -> 'a -> 'a
+    val fold : (Host.t -> Elpi.t -> Data.term option -> 'a -> 'a) -> t -> 'a -> 'a
 
     val elpi   : Host.t -> t -> Elpi.t
     val host : Elpi.t -> t -> Host.t

--- a/src/builtin.ml
+++ b/src/builtin.ml
@@ -853,7 +853,7 @@ X == Y :- same_term X Y.
     Out(any, "T",
     Full "unify T with a variable that has no eigenvariables in scope"),
   (fun _ ~depth _ _ state ->
-      let state, k = FlexibleData.Elpi.make ~lvl:0 state in
+      let state, k = FlexibleData.Elpi.make state in
       state, !:(mkUnifVar k ~args:[] state), [])),
   DocAbove);
 

--- a/src/data.ml
+++ b/src/data.ml
@@ -817,7 +817,7 @@ let rec readback_args : type a m t.
 
 and readback : type t.
   look:(depth:int -> term -> term) ->
-  alloc:(?name:string -> lvl:int -> state -> state * 'uk) ->
+  alloc:(?name:string -> state -> state * 'uk) ->
   mkUnifVar:('uk -> args:term list -> state -> term) ->
   Conversion.ty_ast -> t compiled_adt -> depth:int -> hyps -> constraints -> state -> term ->
     state * t * extra_goals
@@ -834,8 +834,9 @@ and readback : type t.
       readback_args ~look ty ~depth hyps constraints state [] t args read [t]
   | Discard ->
       let CK(args,read,_) = Constants.Map.find (Constants.from_stringc "uvar") adt in
-      let state, k = alloc ~lvl:depth state in
-      readback_args ~look ty ~depth hyps constraints state [] t args read [mkUnifVar k ~args:[] state]
+      let state, k = alloc state in
+      readback_args ~look ty ~depth hyps constraints state [] t args read
+        [mkUnifVar k ~args:(Constants.mkinterval 0 depth 0) state]
   | _ -> raise (Conversion.TypeErr(ty,depth,t))
   with Not_found -> raise (Conversion.TypeErr(ty,depth,t))
 

--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -3278,4 +3278,14 @@ let hmove = HO.hmove
 let make_index = make_index
 let clausify1 = Clausify.clausify1
 
+let expand_uv ~depth r ~lvl ~ano =
+  let t, assignment = HO.expand_uv ~depth r ~lvl ~ano in
+  option_iter (fun (r,_,assignment) -> r @:= assignment) assignment;
+  t
+let expand_appuv ~depth r ~lvl ~args =
+  let t, assignment = HO.expand_appuv ~depth r ~lvl ~args in
+  option_iter (fun (r,_,assignment) -> r @:= assignment) assignment;
+  t
+
+
 (* vim: set foldmethod=marker: *)

--- a/src/runtime.mli
+++ b/src/runtime.mli
@@ -24,6 +24,9 @@ val deref_head : depth:int -> term -> term
 val is_flex : depth:int -> term -> uvar_body option
 val pp_stuck_goal : Fmt.formatter -> stuck_goal -> unit
 
+val expand_uv : depth:int -> uvar_body -> lvl:int -> ano:int -> term
+val expand_appuv : depth:int -> uvar_body -> lvl:int -> args:term list -> term
+
 val lp_list_to_list : depth:int -> term -> term list
 val list_to_lp_list : term list -> term
 


### PR DESCRIPTION
This simplifies the API by hiding an implementation detail.
Fix #38 