### PR TITLE
FFI: contextual conversion of arguments

### DIFF
--- a/elpi_REPL.ml
+++ b/elpi_REPL.ml
@@ -21,14 +21,14 @@ let print_solution time = function
    Format.eprintf "Interrupted (no more steps)@\n%!"
 | API.Execute.Failure -> Format.eprintf "Failure@\n%!"
 | API.Execute.Success {
-    API.Data.assignments; constraints; state; _ } ->
+    API.Data.assignments; constraints; state; pp_ctx; _ } ->
   Format.eprintf "@\nSuccess:@\n%!" ;
   API.Data.StrMap.iter (fun name v ->
     Format.eprintf "  @[<hov 1>%s = %a@]@\n%!" name
-      API.Pp.term v) assignments;
+      (API.Pp.term pp_ctx) v) assignments;
   Format.eprintf "@\nTime: %5.3f@\n%!" time;
   Format.eprintf "@\nConstraints:@\n%a@\n%!"
-    API.Pp.constraints constraints;
+    (API.Pp.constraints pp_ctx) constraints;
   Format.eprintf "@\nState:@\n%a@\n%!"
     API.Pp.state state;
 ;;

--- a/src/API.mli
+++ b/src/API.mli
@@ -100,6 +100,9 @@ module Data : sig
   (* user defined state (not goals) *)
   type state
 
+  (* Pass it to function in the Pp module *)
+  type pretty_printer_context
+
   (* a solution is an assignment map from query variables (name) to terms,
    * plus the goals that were suspended and the user defined constraints *)
   type 'a solution = {
@@ -107,6 +110,7 @@ module Data : sig
     constraints : constraints;
     state : state;
     output : 'a;
+    pp_ctx : pretty_printer_context;
   }
 
   (* Hypothetical context *)
@@ -182,9 +186,10 @@ end
 
 module Pp : sig
 
-  val term : Format.formatter -> Data.term -> unit
-  val constraints : Format.formatter -> Data.constraints -> unit
+  val term : Data.pretty_printer_context -> Format.formatter -> Data.term -> unit
+  val constraints : Data.pretty_printer_context -> Format.formatter -> Data.constraints -> unit
   val state : Format.formatter -> Data.state -> unit
+
   val query : Format.formatter -> 'a Compile.query -> unit
 
   module Ast : sig
@@ -1044,6 +1049,8 @@ module RawPp : sig
    * can cause the pruning of the unification variable.
    * This behavior shall be cleaned up in the future *)
   val term : (*depth*)int -> Format.formatter -> Data.term -> unit
+
+  val constraints : Format.formatter -> Data.constraints -> unit
 
   val list : ?max:int -> ?boxed:bool ->
     (Format.formatter -> 'a -> unit) ->

--- a/src/API.mli
+++ b/src/API.mli
@@ -257,10 +257,15 @@ module ContextualConversion : sig
     Data.state -> Data.state * 'hyps * 'constraints * Conversion.extra_goals
 
   val unit_ctx : (unit,unit) ctx_readback
+  val raw_ctx : (Data.hyps,Data.constraints) ctx_readback
 
-  (* casts *)
-  val (!>) : 'a Conversion.t -> ('a,'hyps,'constraints) t
+  (* cast *)
   val (!<) : ('a,unit,unit) t -> 'a Conversion.t
+
+  (* morphisms *)
+  val (!>)   : 'a Conversion.t -> ('a,'hyps,'constraints) t
+  val (!>>)  : ('a Conversion.t -> 'b Conversion.t) -> ('a,'hyps,'constraints) t -> ('b,'hyps,'constraints) t
+  val (!>>>) : ('a Conversion.t -> 'b Conversion.t -> 'c Conversion.t) -> ('a,'hyps,'constraints) t -> ('b,'hyps,'constraints) t -> ('c,'hyps,'constraints) t
 
 end
 
@@ -274,8 +279,6 @@ module BuiltInData : sig
   val string : string Conversion.t
   val list   : 'a Conversion.t -> 'a list Conversion.t
   val loc    : Ast.Loc.t Conversion.t
-
-  val listC   : ('a,'h,'c) ContextualConversion.t -> ('a list,'h,'c) ContextualConversion.t
 
   (* poly "A" is what one would use for, say, [type eq A -> A -> prop] *)
   val poly   : string -> Data.term Conversion.t

--- a/src/API.mli
+++ b/src/API.mli
@@ -210,11 +210,11 @@ module Conversion : sig
   type extra_goals = Data.term list
 
   type 'a embedding =
-    depth:int -> Data.hyps -> Data.constraints ->
+    depth:int ->
     Data.state -> 'a -> Data.state * Data.term * extra_goals
     
   type 'a readback =
-    depth:int -> Data.hyps -> Data.constraints ->
+    depth:int ->
     Data.state -> Data.term -> Data.state * 'a * extra_goals
 
   type 'a t = {
@@ -228,6 +228,43 @@ module Conversion : sig
   exception TypeErr of ty_ast * int (*depth*) * Data.term (* a type error at data conversion time *)
 end
 
+(** This module defines what embedding and readback functions are
+    for datatypes that need the context of the program (hypothetical clauses and
+    constraints) *)
+module ContextualConversion : sig
+
+  type ty_ast = Conversion.ty_ast = TyName of string | TyApp of string * ty_ast * ty_ast list
+
+
+  type ('a,'hyps,'constraints) embedding =
+    depth:int -> 'hyps -> 'constraints ->
+    Data.state -> 'a -> Data.state * Data.term * Conversion.extra_goals
+    
+  type ('a,'hyps,'constraints) readback =
+    depth:int -> 'hyps -> 'constraints ->
+    Data.state -> Data.term -> Data.state * 'a * Conversion.extra_goals
+
+  type ('a,'h,'c) t = {
+    ty : ty_ast;
+    pp_doc : Format.formatter -> unit -> unit;
+    pp : Format.formatter -> 'a -> unit;
+    embed : ('a,'h,'c) embedding;   (* 'a -> term *)
+    readback : ('a,'h,'c) readback; (* term -> 'a *)
+  }
+
+  type ('hyps,'constraints) ctx_readback =
+    depth:int -> Data.hyps -> Data.constraints ->
+    Data.state -> Data.state * 'hyps * 'constraints * Conversion.extra_goals
+
+  val unit_ctx : (unit,unit) ctx_readback
+
+  (* casts *)
+  val (!>) : 'a Conversion.t -> ('a,'hyps,'constraints) t
+  val (!<) : ('a,unit,unit) t -> 'a Conversion.t
+
+end
+
+
 (** Conversion for Elpi's built-in data types *)
 module BuiltInData : sig
 
@@ -237,6 +274,8 @@ module BuiltInData : sig
   val string : string Conversion.t
   val list   : 'a Conversion.t -> 'a list Conversion.t
   val loc    : Ast.Loc.t Conversion.t
+
+  val listC   : ('a,'h,'c) ContextualConversion.t -> ('a list,'h,'c) ContextualConversion.t
 
   (* poly "A" is what one would use for, say, [type eq A -> A -> prop] *)
   val poly   : string -> Data.term Conversion.t
@@ -334,32 +373,36 @@ module AlgebraicData : sig
       - S stands for self
       - C stands for container
   *)
-  type ('stateful_builder,'builder, 'stateful_matcher, 'matcher,  'self) constructor_arguments =
+  type ('stateful_builder,'builder, 'stateful_matcher, 'matcher,  'self, 'hyps,'constraints) constructor_arguments =
     (* No arguments *)
-    | N : (Data.state -> Data.state * 'self, 'self, Data.state -> Data.state * Data.term * Conversion.extra_goals, Data.term, 'self) constructor_arguments
+    | N : (Data.state -> Data.state * 'self, 'self, Data.state -> Data.state * Data.term * Conversion.extra_goals, Data.term, 'self, 'hyps,'constraints) constructor_arguments
     (* An argument of type 'a *)
-    | A : 'a Conversion.t * ('bs,'b, 'ms,'m, 'self) constructor_arguments -> ('a -> 'bs, 'a -> 'b, 'a -> 'ms, 'a -> 'm, 'self) constructor_arguments
+    | A : 'a Conversion.t * ('bs,'b, 'ms,'m, 'self, 'hyps,'constraints) constructor_arguments -> ('a -> 'bs, 'a -> 'b, 'a -> 'ms, 'a -> 'm, 'self, 'hyps,'constraints) constructor_arguments
+    (* An argument of type 'a in context 'hyps,'constraints *)
+    | CA : ('a,'hyps,'constraints) ContextualConversion.t * ('bs,'b, 'ms,'m, 'self, 'hyps,'constraints) constructor_arguments -> ('a -> 'bs, 'a -> 'b, 'a -> 'ms, 'a -> 'm, 'self, 'hyps,'constraints) constructor_arguments
     (* An argument of type 'self *)
-    | S : ('bs,'b, 'ms, 'm, 'self) constructor_arguments -> ('self -> 'bs, 'self -> 'b, 'self -> 'ms, 'self -> 'm, 'self) constructor_arguments
+    | S : ('bs,'b, 'ms, 'm, 'self, 'hyps,'constraints) constructor_arguments -> ('self -> 'bs, 'self -> 'b, 'self -> 'ms, 'self -> 'm, 'self, 'hyps,'constraints) constructor_arguments
     (* An argument of type `T 'self` for a constainer `T`, like a `list 'self`.
-       `S args` above is a shortcut for `C(fun x -> x, args)` *)
-    | C : ('self Conversion.t -> 'a Conversion.t) * ('bs,'b,'ms,'m,'self) constructor_arguments -> ('a -> 'bs, 'a -> 'b, 'a -> 'ms,'a -> 'm, 'self) constructor_arguments
-  
-  type 't constructor =
+      `S args` above is a shortcut for `C(fun x -> x, args)` *)
+    | C : (('self,'hyps,'constraints) ContextualConversion.t -> ('a,'hyps,'constraints) ContextualConversion.t) * ('bs,'b,'ms,'m,'self, 'hyps,'constraints) constructor_arguments -> ('a -> 'bs, 'a -> 'b, 'a -> 'ms,'a -> 'm, 'self, 'hyps,'constraints) constructor_arguments
+
+
+
+  type ('t,'h,'c) constructor =
     K : name * doc *
-        ('build_stateful_t,'build_t,'match_stateful_t,'match_t,'t) constructor_arguments *   (* args ty *)
+        ('build_stateful_t,'build_t,'match_stateful_t,'match_t,'t,'h,'c) constructor_arguments *   (* args ty *)
         ('build_stateful_t,'build_t) build_t *
         ('match_stateful_t,'match_t,'t) match_t
-      -> 't constructor
+      -> ('t,'h,'c) constructor
       
-  type 't declaration = {
+  type ('t,'h,'c) declaration = {
     ty : Conversion.ty_ast;
     doc : doc;
     pp : Format.formatter -> 't -> unit;
-    constructors : 't constructor list;
+    constructors : ('t,'h,'c) constructor list;
   }
 
-  val declare : 'a declaration -> 'a Conversion.t
+  val declare : ('t,'h,'c) declaration -> ('t,'h,'c) ContextualConversion.t
 
 end
 
@@ -433,18 +476,31 @@ module BuiltInPredicate : sig
   type 'a oarg = Keep | Discard
   type 'a ioarg = Data of 'a | NoData
 
-  type ('function_type, 'inernal_outtype_in) ffi =
-    | In   : 't Conversion.t * doc * ('i, 'o) ffi -> ('t -> 'i,'o) ffi
-    | Out  : 't Conversion.t * doc * ('i, 'o * 't option) ffi -> ('t oarg -> 'i,'o) ffi
-    | InOut  : 't Conversion.t * doc * ('i, 'o * 't option) ffi -> ('t ioarg -> 'i,'o) ffi
-    | Easy : doc -> (depth:int -> 'o, 'o) ffi
-    | Read : doc -> (depth:int -> Data.hyps -> Data.constraints -> Data.state -> 'o, 'o) ffi
-    | Full : doc -> (depth:int -> Data.hyps -> Data.constraints -> Data.state -> Data.state * 'o * Conversion.extra_goals, 'o) ffi
-    | VariadicIn : 't Conversion.t * doc -> ('t list -> depth:int -> Data.hyps -> Data.constraints -> Data.state -> Data.state * 'o, 'o) ffi
-    | VariadicOut : 't Conversion.t * doc -> ('t oarg list -> depth:int -> Data.hyps -> Data.constraints -> Data.state -> Data.state * ('o * 't option list option), 'o) ffi
-    | VariadicInOut : 't Conversion.t * doc -> ('t ioarg list -> depth:int -> Data.hyps -> Data.constraints -> Data.state -> Data.state * ('o * 't option list option), 'o) ffi
+  type ('function_type, 'inernal_outtype_in, 'internal_hyps, 'internal_constraints) ffi =
+    (* Arguemnts that are translated independently of the program context *)
+    | In    : 't Conversion.t * doc * ('i, 'o,'h,'c) ffi -> ('t -> 'i,'o,'h,'c) ffi
+    | Out   : 't Conversion.t * doc * ('i, 'o * 't option,'h,'c) ffi -> ('t oarg -> 'i,'o,'h,'c) ffi
+    | InOut : 't Conversion.t * doc * ('i, 'o * 't option,'h,'c) ffi -> ('t ioarg -> 'i,'o,'h,'c) ffi
 
-  type t = Pred : name * ('a,unit) ffi * 'a -> t
+    (* Arguemnts that are translated looking at the program context *)
+    | CIn    : ('t,'h,'c) ContextualConversion.t * doc * ('i, 'o,'h,'c) ffi -> ('t -> 'i,'o,'h,'c) ffi
+    | COut   : ('t,'h,'c) ContextualConversion.t * doc * ('i, 'o * 't option,'h,'c) ffi -> ('t oarg -> 'i,'o,'h,'c) ffi
+    | CInOut : ('t,'h,'c) ContextualConversion.t * doc * ('i, 'o * 't option,'h,'c) ffi -> ('t ioarg -> 'i,'o,'h,'c) ffi
+
+    (* The easy case: all arguments are context independent *)
+    | Easy : doc -> (depth:int -> 'o, 'o, unit, unit) ffi
+
+    (* The advanced case: arguments are context dependent, here we provide the
+      context readback function *)
+    | Read : ('h,'c) ContextualConversion.ctx_readback * doc -> (depth:int -> 'h -> 'c -> Data.state -> 'o, 'o,'h,'c) ffi
+    | Full : ('h,'c) ContextualConversion.ctx_readback * doc -> (depth:int -> 'h -> 'c -> Data.state -> Data.state * 'o * Conversion.extra_goals, 'o,'h,'c) ffi
+    | VariadicIn    : ('h,'c) ContextualConversion.ctx_readback * ('t,'h,'c) ContextualConversion.t * doc -> ('t list -> depth:int -> 'h -> 'c -> Data.state -> Data.state * 'o, 'o,'h,'c) ffi
+    | VariadicOut   : ('h,'c) ContextualConversion.ctx_readback * ('t,'h,'c) ContextualConversion.t * doc -> ('t oarg list -> depth:int -> 'h -> 'c -> Data.state -> Data.state * ('o * 't option list option), 'o,'h,'c) ffi
+    | VariadicInOut : ('h,'c) ContextualConversion.ctx_readback * ('t,'h,'c) ContextualConversion.t * doc -> ('t ioarg list -> depth:int -> 'h -> 'c -> Data.state -> Data.state * ('o * 't option list option), 'o,'h,'c) ffi
+
+  type t = Pred : name * ('a,unit,'h,'c) ffi * 'a -> t
+
+
   module Notation : sig
 
     (* Handy notation to construct the value generated by built-in predicates.
@@ -492,6 +548,7 @@ module BuiltIn : sig
     | MLCode of BuiltInPredicate.t * doc_spec
     (* Declaration of an OCaml data *)
     | MLData : 'a Conversion.t -> declaration
+    | MLDataC : ('a,'h,'c) ContextualConversion.t -> declaration
     (* Extra doc *)
     | LPDoc  of string
     (* Sometimes you wrap OCaml code in regular predicates in order

--- a/src/builtin.ml
+++ b/src/builtin.ml
@@ -219,16 +219,6 @@ let pair a b = let open AlgebraicData in declare {
       M (fun ~ok ~ko:_ -> function (a,b) -> ok a b));
   ]
 } |> ContextualConversion.(!<)
-let pairC a b = let open AlgebraicData in declare {
-  ty = TyApp ("pair",a.ContextualConversion.ty,[b.ContextualConversion.ty]);
-  doc = "Pair: the constructor is pr, since ',' is for conjunction";
-  pp = (fun fmt o -> Format.fprintf fmt "%a" (Util.pp_pair a.ContextualConversion.pp b.ContextualConversion.pp) o);
-  constructors = [
-    K("pr","",CA(a,CA(b,N)),
-      B (fun a b -> (a,b)),
-      M (fun ~ok ~ko:_ -> function (a,b) -> ok a b));
-  ]
-}
 
 let option a = let open AlgebraicData in declare {
   ty = TyApp("option",a.Conversion.ty,[]);
@@ -243,19 +233,6 @@ let option a = let open AlgebraicData in declare {
       M (fun ~ok ~ko -> function Some x -> ok x | _ -> ko ())); 
   ]
 } |> ContextualConversion.(!<)
-let optionC a = let open AlgebraicData in declare {
-  ty = TyApp("option",a.ContextualConversion.ty,[]);
-  doc = "The option type (aka Maybe)";
-  pp = (fun fmt o -> Format.fprintf fmt "%a" (Util.pp_option a.ContextualConversion.pp) o);
-  constructors = [
-    K("none","",N,
-      B None,
-      M (fun ~ok ~ko -> function None -> ok | _ -> ko ())); 
-    K("some","",CA(a,N),
-      B (fun x -> Some x),
-      M (fun ~ok ~ko -> function Some x -> ok x | _ -> ko ())); 
-  ]
-}
 
 (** Core built-in ********************************************************* *)
 

--- a/src/builtin.mli
+++ b/src/builtin.mli
@@ -49,10 +49,6 @@ val pair : 'a API.Conversion.t -> 'b API.Conversion.t -> ('a * 'b) API.Conversio
 val option : 'a API.Conversion.t -> 'a option API.Conversion.t
 val bool : bool API.Conversion.t
 
-val pairC : ('a,'h,'c) API.ContextualConversion.t -> ('b,'h,'c) API.ContextualConversion.t -> ('a * 'b,'h,'c) API.ContextualConversion.t
-val optionC : ('a,'h,'c) API.ContextualConversion.t -> ('a option,'h,'c) API.ContextualConversion.t
-
-
 (* The string is the "file name" *)
 val in_stream  : (in_channel * string) API.Conversion.t
 val out_stream : (out_channel * string) API.Conversion.t

--- a/src/builtin.mli
+++ b/src/builtin.mli
@@ -49,6 +49,10 @@ val pair : 'a API.Conversion.t -> 'b API.Conversion.t -> ('a * 'b) API.Conversio
 val option : 'a API.Conversion.t -> 'a option API.Conversion.t
 val bool : bool API.Conversion.t
 
+val pairC : ('a,'h,'c) API.ContextualConversion.t -> ('b,'h,'c) API.ContextualConversion.t -> ('a * 'b,'h,'c) API.ContextualConversion.t
+val optionC : ('a,'h,'c) API.ContextualConversion.t -> ('a option,'h,'c) API.ContextualConversion.t
+
+
 (* The string is the "file name" *)
 val in_stream  : (in_channel * string) API.Conversion.t
 val out_stream : (out_channel * string) API.Conversion.t

--- a/src/data.ml
+++ b/src/data.ml
@@ -1290,6 +1290,7 @@ type 'a solution = {
   constraints : constraints;
   state : state;
   output : 'a;
+  pp_ctx : (string PtrMap.t * int) ref;
 }
 type 'a outcome = Success of 'a solution | Failure | NoMoreSteps
 

--- a/src/runtime.mli
+++ b/src/runtime.mli
@@ -6,12 +6,13 @@ open Data
 
 module Pp : sig
   val ppterm :
-    ?min_prec:int -> int -> string list -> int -> env ->
+    ?pp_ctx:(string Util.PtrMap.t * int) ref -> ?min_prec:int -> int -> string list -> int -> env ->
        Format.formatter -> term -> unit
   val uppterm :
-    ?min_prec:int -> int -> string list -> int -> env ->
+    ?pp_ctx:(string Util.PtrMap.t * int) ref -> ?min_prec:int -> int -> string list -> int -> env ->
        Format.formatter -> term -> unit
 end
+val pp_stuck_goal : ?pp_ctx:(string Util.PtrMap.t * int) ref -> Fmt.formatter -> stuck_goal -> unit
 
 (* Interpreter API *)
 val execute_once : ?max_steps:int -> ?delay_outside_fragment:bool -> 'a executable -> 'a outcome
@@ -22,7 +23,6 @@ val deref_uv : ?avoid:uvar_body -> from:constant -> to_:constant -> int -> term 
 val deref_appuv : ?avoid:uvar_body -> from:constant -> to_:constant -> term list -> term -> term
 val deref_head : depth:int -> term -> term
 val is_flex : depth:int -> term -> uvar_body option
-val pp_stuck_goal : Fmt.formatter -> stuck_goal -> unit
 
 val expand_uv : depth:int -> uvar_body -> lvl:int -> ano:int -> term
 val expand_appuv : depth:int -> uvar_body -> lvl:int -> args:term list -> term

--- a/src/util.ml
+++ b/src/util.ml
@@ -527,6 +527,7 @@ module PtrMap = struct
   }
 
   let empty () = { cache = IntMap.empty; authoritative = [] }
+  let is_empty { authoritative } = authoritative = []
 
   let address_of =
     match Sys.backend_type with

--- a/src/util.mli
+++ b/src/util.mli
@@ -67,6 +67,7 @@ module PtrMap : sig
   type 'a t
 
   val empty : unit -> 'a t
+  val is_empty : 'a t -> bool
   val find : 'block -> 'a t -> 'a
   val add : 'block -> 'a -> 'a t -> 'a t
   val remove : 'block -> 'a t -> 'a t


### PR DESCRIPTION
When converting arguments of a built in predicate depend on the
context of the program (hypotheses and constraints) we can now
provide a conversion function for the context that is run once
and forall and whose output is the passed to the conversion functions
of the arguments.

Limitation: for each built in only one context conversion function is
allowed.

Fix: #40 