### PR TITLE
Avoid build failures when the camlp5 binary changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - rm -rf $HOME/.opam
   - echo "installing cache"
   - cp -r $HOME/opam-cache/.opam $HOME/.opam
+  - opam update
 
 matrix:
   include:

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.6)
+(lang dune 2.2)
 (name elpi)

--- a/elpi.opam
+++ b/elpi.opam
@@ -22,7 +22,7 @@ depends: [
   "re" {>= "1.7.2"}
   "ANSITerminal" {with-test}
   "cmdliner" {with-test}
-  "dune" {>= "1.6"}
+  "dune" {>= "2.2.0"}
   "conf-time" {with-test}
 ]
 synopsis: "ELPI - Embeddable λProlog Interpreter"

--- a/src/dune
+++ b/src/dune
@@ -5,7 +5,7 @@
     ((pps ppx_deriving.std) API util ast data compiler)
     ((pps ppx_deriving.std elpi.trace_ppx --trace_ppx-on) runtime_trace_on)
     ((pps ppx_deriving.std elpi.trace_ppx --trace_ppx-off) runtime_trace_off)
-    ((action (system "camlp5o -I . -I +camlp5 pa_extend.cmo pa_lexer.cmo %{input-file}")) parser)
+    ((action (run camlp5o -I . -I +camlp5 pa_extend.cmo pa_lexer.cmo %{input-file})) parser)
     ))
   (libraries re.str camlp5.gramlib unix)
   (flags -linkall)


### PR DESCRIPTION
When elpi is built in one opam switch then rebuilt in another, the build fails because dune does not know camlp5 has changed.

Test case:
```
$ opam switch 4.08
$ dune build
$ opam switch 4.10
$ dune build
-     ocamldep src/.elpi.objs/parser.pp.mli.d (exit 2)
- (cd _build/default && /home/opam/.opam/4.10.0+trunk/bin/ocamldep.opt -modules -intf src/parser.pp.mli) > _build/default/src/.elpi.objs/parser.pp.mli.d
- >> Fatal error: OCaml and preprocessor have incompatible versions
- Fatal error: exception Misc.Fatal_error
-     ocamldep src/.elpi.objs/parser.pp.ml.d (exit 2)
- (cd _build/default && /home/opam/.opam/4.10.0+trunk/bin/ocamldep.opt -modules -impl src/parser.pp.ml) > _build/default/src/.elpi.objs/parser.pp.ml.d
- >> Fatal error: OCaml and preprocessor have incompatible versions
- Fatal error: exception Misc.Fatal_error
-       ocamlc src/.elpi.objs/byte/elpi__Builtin.{cmo,cmt}
```
This is because `(system "...")` is opaque from dune's point of vue and it cannot deduce the dependencies of the rule used to build `parser.ml`, which in this case is the `camlp5o` binary. To fix this we use the `(run ...)` command which is analysed by dune to deduce its dependencies.
Related issue: https://github.com/ocaml/dune/issues/3050

However, this PR does not work in dune currently as dune automatically appends the `.opt` suffix when available, this should be fixed in dune 2.2.0 hopefully, once https://github.com/ocaml/dune/pull/3051 has been merged.