### PR TITLE
Replace sha1sum with shasum in ppxfindcache_aux.ml

### DIFF
--- a/ppxfindcache/ppxfindcache_aux.ml
+++ b/ppxfindcache/ppxfindcache_aux.ml
@@ -63,7 +63,7 @@ let common () =
   let flag = !flag in
   let cache x = List.mem (path_sanitize x) !cache in
 
-  let sha = must @@ exec "sha1sum" [|"-b";file|] in
+  let sha = must @@ exec "shasum" [|"-b";file|] in
   let sha = String.sub sha 0 (String.length sha - 1) in
   let sha = Printf.sprintf "(*%s %s*)\n" sha (String.concat " " (Array.to_list flag)) in
 


### PR DESCRIPTION
ppxfindcache_aux.ml uses `sha1sum` which is fairly old and not available on Mac by default (it can be installed with homebrew or Macports). `shasum` is a replacement available on Mac, Linux (tested on Ubuntu 18.04) and Cygwin. Without additional options it should be identical to sha1sum.