### PR TITLE
speedup compiler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## UNRELEASED
+- API:
+  - New `Compile.extend` to (quickly) add clauses to a program
+  - New argument `?follows:program` to `Compile.unit` to have the unit
+    be compiled using the very same symbol table (no new symbols can be
+    declared by the unit in this case)
+
 ## v1.11.4 (Aug 2020)
 
 - do not rely on /bin/bash in Makefile (helps on nix and freebsd)

--- a/src/.ppcache/API.mli
+++ b/src/.ppcache/API.mli
@@ -1,4 +1,4 @@
-(*2417a3f401bc77492de0e537d65272a6bd92bf00 *src/API.mli *)
+(*6a88959465e97646f052b66c5ac5eddbd9fa0079 *src/API.mli *)
 #1 "src/API.mli"
 [@@@ocaml.text " This module is the API for clients of the Elpi library. "]
 [@@@ocaml.text
@@ -99,8 +99,10 @@ sig
   val program : flags:flags -> elpi:Setup.elpi -> Ast.program list -> program
   type compilation_unit
   val unit :
-    elpi:Setup.elpi -> flags:flags -> Ast.program -> compilation_unit
+    ?follows:program ->
+      elpi:Setup.elpi -> flags:flags -> Ast.program -> compilation_unit
   val assemble : elpi:Setup.elpi -> compilation_unit list -> program
+  val extend : base:program -> compilation_unit list -> program
   val query : program -> Ast.query -> unit query
   val optimize : 'a query -> 'a executable
   val static_check : checker:program -> 'a query -> bool[@@ocaml.doc
@@ -388,7 +390,7 @@ sig
   val declare :
     name:string ->
       pp:(Format.formatter -> 'a -> unit) ->
-        init:(unit -> 'a) -> 'a component
+        init:(unit -> 'a) -> start:('a -> 'a) -> 'a component
   type t = Data.state
   val get : 'a component -> t -> 'a
   val set : 'a component -> t -> 'a -> t

--- a/src/.ppcache/compiler.ml
+++ b/src/.ppcache/compiler.ml
@@ -1,4 +1,4 @@
-(*3c44219c7a573d29c3590319b4e8b0034f4c7252 *src/compiler.ml *)
+(*8415557833045206e1e7b15948153af5d4f07307 *src/compiler.ml *)
 #1 "src/compiler.ml"
 open Util
 module F = Ast.Func
@@ -35,13 +35,10 @@ let default_flags =
 let compiler_flags =
   D.State.declare ~name:"elpi:compiler:flags" ~pp:pp_flags
     ~clause_compilation_is_over:(fun x -> x)
+    ~goal_compilation_begins:(fun x -> x)
     ~goal_compilation_is_over:(fun ~args:_ -> fun x -> Some x)
     ~compilation_is_over:(fun _ -> None) ~execution_is_over:(fun _ -> None)
     ~init:(fun () -> default_flags)
-let init_state flags =
-  let state = D.State.init () in
-  let state = D.State.set compiler_flags state flags in
-  let state = D.State.set D.while_compiling state true in state
 let rec filter_if ({ defined_variables } as flags) proj =
   function
   | [] -> []
@@ -68,6 +65,10 @@ module Symbols :
     type table
     val table : table D.State.component
     val compile_table : table -> D.symbol_table
+    val lock : table -> table
+    val unlock : table -> table
+    val locked : table -> bool
+    val equal : table -> table -> bool
     val build_shift :
       base:D.State.t -> table -> (D.State.t * D.constant D.Constants.Map.t)
   end =
@@ -78,12 +79,15 @@ module Symbols :
       c2s: string D.Constants.Map.t ;
       c2t: D.term D.Constants.Map.t ;
       last_global: int ;
-      locked: bool }[@@deriving show]
+      locked: bool ;
+      frozen: bool ;
+      uuid: Util.UUID.t }[@@deriving show]
     let rec pp_table :
       Ppx_deriving_runtime_proxy.Format.formatter ->
         table -> Ppx_deriving_runtime_proxy.unit
       =
-      let __5 () = D.Constants.Map.pp
+      let __6 () = Util.UUID.pp
+      and __5 () = D.Constants.Map.pp
       and __4 () = D.pp_term
       and __3 () = D.Constants.Map.pp
       and __2 () = F.Map.pp
@@ -93,47 +97,63 @@ module Symbols :
           fun fmt ->
             fun x ->
               Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[<2>{ ";
-              (((((Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ "
-                     "Compiler.Symbols.ast2ct";
-                   ((__2 ())
-                      (fun fmt ->
-                         fun (a0, a1) ->
-                           Ppx_deriving_runtime_proxy.Format.fprintf fmt "(@[";
-                           (((__0 ()) fmt) a0;
-                            Ppx_deriving_runtime_proxy.Format.fprintf fmt ",@ ";
-                            ((__1 ()) fmt) a1);
-                           Ppx_deriving_runtime_proxy.Format.fprintf fmt "@])") fmt)
-                     x.ast2ct;
+              (((((((Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ "
+                       "Compiler.Symbols.ast2ct";
+                     ((__2 ())
+                        (fun fmt ->
+                           fun (a0, a1) ->
+                             Ppx_deriving_runtime_proxy.Format.fprintf fmt "(@[";
+                             (((__0 ()) fmt) a0;
+                              Ppx_deriving_runtime_proxy.Format.fprintf fmt ",@ ";
+                              ((__1 ()) fmt) a1);
+                             Ppx_deriving_runtime_proxy.Format.fprintf fmt "@])")
+                        fmt) x.ast2ct;
+                     Ppx_deriving_runtime_proxy.Format.fprintf fmt "@]");
+                    Ppx_deriving_runtime_proxy.Format.fprintf fmt ";@ ";
+                    Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ " "c2s";
+                    ((__3 ())
+                       (fun fmt ->
+                          Ppx_deriving_runtime_proxy.Format.fprintf fmt "%S") fmt)
+                      x.c2s;
+                    Ppx_deriving_runtime_proxy.Format.fprintf fmt "@]");
+                   Ppx_deriving_runtime_proxy.Format.fprintf fmt ";@ ";
+                   Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ " "c2t";
+                   ((__5 ()) (fun fmt -> (__4 ()) fmt) fmt) x.c2t;
                    Ppx_deriving_runtime_proxy.Format.fprintf fmt "@]");
                   Ppx_deriving_runtime_proxy.Format.fprintf fmt ";@ ";
-                  Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ " "c2s";
-                  ((__3 ())
-                     (fun fmt -> Ppx_deriving_runtime_proxy.Format.fprintf fmt "%S")
-                     fmt) x.c2s;
+                  Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ "
+                    "last_global";
+                  (Ppx_deriving_runtime_proxy.Format.fprintf fmt "%d")
+                    x.last_global;
                   Ppx_deriving_runtime_proxy.Format.fprintf fmt "@]");
                  Ppx_deriving_runtime_proxy.Format.fprintf fmt ";@ ";
-                 Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ " "c2t";
-                 ((__5 ()) (fun fmt -> (__4 ()) fmt) fmt) x.c2t;
+                 Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ " "locked";
+                 (Ppx_deriving_runtime_proxy.Format.fprintf fmt "%B") x.locked;
                  Ppx_deriving_runtime_proxy.Format.fprintf fmt "@]");
                 Ppx_deriving_runtime_proxy.Format.fprintf fmt ";@ ";
-                Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ "
-                  "last_global";
-                (Ppx_deriving_runtime_proxy.Format.fprintf fmt "%d") x.last_global;
+                Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ " "frozen";
+                (Ppx_deriving_runtime_proxy.Format.fprintf fmt "%B") x.frozen;
                 Ppx_deriving_runtime_proxy.Format.fprintf fmt "@]");
                Ppx_deriving_runtime_proxy.Format.fprintf fmt ";@ ";
-               Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ " "locked";
-               (Ppx_deriving_runtime_proxy.Format.fprintf fmt "%B") x.locked;
+               Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ " "uuid";
+               ((__6 ()) fmt) x.uuid;
                Ppx_deriving_runtime_proxy.Format.fprintf fmt "@]");
               Ppx_deriving_runtime_proxy.Format.fprintf fmt "@ }@]")
         [@ocaml.warning "-A"])
     and show_table : table -> Ppx_deriving_runtime_proxy.string =
       fun x -> Ppx_deriving_runtime_proxy.Format.asprintf "%a" pp_table x[@@ocaml.warning
                                                                     "-32"]
+    let locked { locked } = locked
+    let lock t = { t with locked = true }
+    let unlock t = assert (locked t); { t with locked = false }
+    let uuid { uuid } = uuid
+    let equal t1 t2 = (locked t1) && ((locked t2) && ((uuid t1) = (uuid t2)))
     let table =
       D.State.declare ~name:"elpi:compiler:symbol_table" ~pp:pp_table
         ~clause_compilation_is_over:(fun x -> x)
+        ~goal_compilation_begins:(fun x -> x)
         ~goal_compilation_is_over:(fun ~args:_ -> fun x -> Some x)
-        ~compilation_is_over:(fun x -> Some { x with locked = true })
+        ~compilation_is_over:(fun x -> Some { x with frozen = true })
         ~execution_is_over:(fun _ -> None)
         ~init:(fun () ->
                  let (ast2ct, c2s, c2t) =
@@ -153,7 +173,9 @@ module Symbols :
                    last_global = (D.Global_symbols.table.last_global);
                    c2s;
                    c2t;
-                   locked = false
+                   locked = false;
+                   uuid = (Util.UUID.make ());
+                   frozen = false
                  })
     let compile_table t =
       let c2s = Hashtbl.create 37 in
@@ -162,14 +184,20 @@ module Symbols :
        D.Constants.Map.iter (Hashtbl.add c2t) t.c2t;
        { D.c2s = c2s; c2t; frozen_constants = (t.last_global) })
     let allocate_global_symbol_aux x
-      ({ c2s; c2t; ast2ct; last_global; locked } as table) =
+      ({ c2s; c2t; ast2ct; last_global; locked; frozen; uuid } as table) =
       try (table, (F.Map.find x ast2ct))
       with
       | Not_found ->
-          (if locked
+          (if frozen
            then
              error
-               ("allocating new global symbol " ^ ((F.show x) ^ "at runtime"));
+               ("allocating new global symbol '" ^
+                  ((F.show x) ^ "' at runtime"));
+           if locked
+           then
+             error
+               ("allocating new global symbol '" ^
+                  ((F.show x) ^ "' since the symbol table is locked"));
            (let last_global = last_global - 1 in
             let n = last_global in
             let xx = D.Term.Const n in
@@ -177,7 +205,7 @@ module Symbols :
             let c2s = D.Constants.Map.add n (F.show x) c2s in
             let c2t = D.Constants.Map.add n xx c2t in
             let ast2ct = F.Map.add x p ast2ct in
-            ({ c2s; c2t; ast2ct; last_global; locked }, p)))
+            ({ c2s; c2t; ast2ct; last_global; locked; frozen; uuid }, p)))
     let allocate_global_symbol state x =
       if not (D.State.get D.while_compiling state)
       then anomaly "global symbols can only be allocated during compilation";
@@ -195,18 +223,18 @@ module Symbols :
           then "c" ^ (string_of_int n)
           else "SYMBOL" ^ (string_of_int n)
     let allocate_bound_symbol_aux n
-      ({ c2s; c2t; ast2ct; last_global; locked } as table) =
+      ({ c2s; c2t; ast2ct; last_global; locked; frozen; uuid } as table) =
       try (table, (D.Constants.Map.find n c2t))
       with
       | Not_found ->
-          (if locked
+          (if frozen
            then
              error
-               ("allocating new global symbol " ^
-                  ((string_of_int n) ^ "at runtime"));
+               ("allocating new bound symbol 'c" ^
+                  ((string_of_int n) ^ "' at runtime"));
            (let xx = D.Term.Const n in
             let c2t = D.Constants.Map.add n xx c2t in
-            ({ c2s; c2t; ast2ct; last_global; locked }, xx)))
+            ({ c2s; c2t; ast2ct; last_global; locked; frozen; uuid }, xx)))
     let allocate_bound_symbol state n =
       if not (D.State.get D.while_compiling state)
       then anomaly "bound symbols can only be allocated during compilation";
@@ -287,6 +315,7 @@ module Builtins :
                    constants = D.Constants.Set.empty;
                    code = []
                  }) ~clause_compilation_is_over:(fun x -> x)
+        ~goal_compilation_begins:(fun x -> x)
         ~goal_compilation_is_over:(fun ~args -> fun x -> Some x)
         ~compilation_is_over:(fun x -> Some x)
         ~execution_is_over:(fun _ -> None)
@@ -1066,7 +1095,7 @@ module Assembled =
       {
       types: Structured.typ list ;
       type_abbrevs: type_abbrev_declaration C.Map.t ;
-      modes: mode C.Map.t ;
+      modes: (mode * Loc.t) C.Map.t ;
       clauses: (preterm, attribute) Ast.Clause.t list ;
       chr: (constant list * prechr_rule list) list ;
       local_names: int ;
@@ -1077,13 +1106,14 @@ module Assembled =
       Ppx_deriving_runtime_proxy.Format.formatter ->
         program -> Ppx_deriving_runtime_proxy.unit
       =
-      let __10 () = pp_macro_declaration
-      and __9 () = pp_prechr_rule
-      and __8 () = pp_constant
-      and __7 () = Ast.Clause.pp
-      and __6 () = pp_attribute
-      and __5 () = pp_preterm
-      and __4 () = C.Map.pp
+      let __11 () = pp_macro_declaration
+      and __10 () = pp_prechr_rule
+      and __9 () = pp_constant
+      and __8 () = Ast.Clause.pp
+      and __7 () = pp_attribute
+      and __6 () = pp_preterm
+      and __5 () = C.Map.pp
+      and __4 () = Loc.pp
       and __3 () = pp_mode
       and __2 () = C.Map.pp
       and __1 () = pp_type_abbrev_declaration
@@ -1116,7 +1146,15 @@ module Assembled =
                     Ppx_deriving_runtime_proxy.Format.fprintf fmt "@]");
                    Ppx_deriving_runtime_proxy.Format.fprintf fmt ";@ ";
                    Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ " "modes";
-                   ((__4 ()) (fun fmt -> (__3 ()) fmt) fmt) x.modes;
+                   ((__5 ())
+                      (fun fmt ->
+                         fun (a0, a1) ->
+                           Ppx_deriving_runtime_proxy.Format.fprintf fmt "(@[";
+                           (((__3 ()) fmt) a0;
+                            Ppx_deriving_runtime_proxy.Format.fprintf fmt ",@ ";
+                            ((__4 ()) fmt) a1);
+                           Ppx_deriving_runtime_proxy.Format.fprintf fmt "@])") fmt)
+                     x.modes;
                    Ppx_deriving_runtime_proxy.Format.fprintf fmt "@]");
                   Ppx_deriving_runtime_proxy.Format.fprintf fmt ";@ ";
                   Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ "
@@ -1131,8 +1169,8 @@ module Assembled =
                                 then
                                   Ppx_deriving_runtime_proxy.Format.fprintf fmt
                                     ";@ ";
-                                ((__7 ()) (fun fmt -> (__5 ()) fmt)
-                                   (fun fmt -> (__6 ()) fmt) fmt) x;
+                                ((__8 ()) (fun fmt -> (__6 ()) fmt)
+                                   (fun fmt -> (__7 ()) fmt) fmt) x;
                                 true) false x);
                       Ppx_deriving_runtime_proxy.Format.fprintf fmt "@,]@]"))
                     x.clauses;
@@ -1163,7 +1201,7 @@ module Assembled =
                                                   then
                                                     Ppx_deriving_runtime_proxy.Format.fprintf
                                                       fmt ";@ ";
-                                                  ((__8 ()) fmt) x;
+                                                  ((__9 ()) fmt) x;
                                                   true) false x);
                                         Ppx_deriving_runtime_proxy.Format.fprintf
                                           fmt "@,]@]")) a0;
@@ -1180,7 +1218,7 @@ module Assembled =
                                                   then
                                                     Ppx_deriving_runtime_proxy.Format.fprintf
                                                       fmt ";@ ";
-                                                  ((__9 ()) fmt) x;
+                                                  ((__10 ()) fmt) x;
                                                   true) false x);
                                         Ppx_deriving_runtime_proxy.Format.fprintf
                                           fmt "@,]@]")) a1);
@@ -1198,7 +1236,7 @@ module Assembled =
                Ppx_deriving_runtime_proxy.Format.fprintf fmt ";@ ";
                Ppx_deriving_runtime_proxy.Format.fprintf fmt "@[%s =@ "
                  "toplevel_macros";
-               ((__10 ()) fmt) x.toplevel_macros;
+               ((__11 ()) fmt) x.toplevel_macros;
                Ppx_deriving_runtime_proxy.Format.fprintf fmt "@]");
               Ppx_deriving_runtime_proxy.Format.fprintf fmt "@ }@]")
         [@ocaml.warning "-A"])
@@ -1230,6 +1268,16 @@ module Assembled =
     and show_attribute : attribute -> Ppx_deriving_runtime_proxy.string =
       fun x -> Ppx_deriving_runtime_proxy.Format.asprintf "%a" pp_attribute x
     [@@ocaml.warning "-32"]
+    let empty =
+      {
+        types = [];
+        type_abbrevs = C.Map.empty;
+        modes = C.Map.empty;
+        clauses = [];
+        chr = [];
+        local_names = 0;
+        toplevel_macros = F.Map.empty
+      }
   end
 type program = Assembled.program
 module WithMain =
@@ -1678,6 +1726,7 @@ module ToDBL :
       let argmap =
         State.declare ~name:"elpi:argmap" ~pp:(todopp "elpi:argmap")
           ~clause_compilation_is_over:(fun _ -> empty_amap)
+          ~goal_compilation_begins:(fun x -> x)
           ~goal_compilation_is_over:(fun ~args:_ -> fun _ -> None)
           ~compilation_is_over:(fun _ -> None)
           ~execution_is_over:(fun _ -> None) ~init:(fun () -> empty_amap) in
@@ -1688,6 +1737,7 @@ module ToDBL :
       let varmap =
         State.declare ~name:"elpi:varmap" ~pp:(todopp "elpi:varmap")
           ~clause_compilation_is_over:(fun x -> assert (F.Map.is_empty x); x)
+          ~goal_compilation_begins:(fun x -> assert (F.Map.is_empty x); x)
           ~goal_compilation_is_over:(fun ~args:_ -> fun _ -> None)
           ~compilation_is_over:(fun _ -> None)
           ~execution_is_over:(fun _ -> None) ~init:(fun () -> F.Map.empty) in
@@ -1699,9 +1749,10 @@ module ToDBL :
       let mtm =
         State.declare ~name:"elpi:mtm" ~pp:(todopp "elpi:mtm")
           ~clause_compilation_is_over:(fun _ -> None)
+          ~goal_compilation_begins:(fun x -> x)
           ~goal_compilation_is_over:(fun ~args:_ -> fun _ -> None)
-          ~compilation_is_over:(fun _ -> None)
-          ~execution_is_over:(fun _ -> None) ~init:(fun () -> None) in
+          ~compilation_is_over:(fun _ -> assert false)
+          ~execution_is_over:(fun _ -> assert false) ~init:(fun () -> None) in
       let open State in ((get mtm), (set mtm), (drop mtm))
     let temporary_compilation_at_runtime f s x =
       let s = State.set D.while_compiling s true in
@@ -1759,7 +1810,7 @@ module ToDBL :
         | Term.App (c, x, l) ->
             let (state, x) = hcons_alien_term state x in
             let (state, l) = map_acc hcons_alien_term state l in
-            (state, (Term.mkApp c x l))
+            (spy_spill c; (state, (Term.mkApp c x l)))
         | Term.Builtin (c, l) ->
             let (state, l) = map_acc hcons_alien_term state l in
             (state, (Term.mkBuiltin c l))
@@ -2710,10 +2761,12 @@ module Spill :
          { x with Ast.Clause.body = { term; amap; loc; spilling = false } })
     let run state ({ Assembled.clauses = clauses; modes; types; chr } as p) =
       let clauses =
-        List.map (spill_clause state (fun c -> C.Map.find c modes) types)
+        List.map
+          (spill_clause state (fun c -> fst @@ (C.Map.find c modes)) types)
           clauses in
       let chr =
-        List.map (spill_chr state (fun c -> C.Map.find c modes) types) chr in
+        List.map
+          (spill_chr state (fun c -> fst @@ (C.Map.find c modes)) types) chr in
       { p with Assembled.clauses = clauses; chr }
     let spill_preterm state types modes ({ term; amap; loc; spilling } as x)
       =
@@ -2730,14 +2783,28 @@ type compilation_unit =
   symbol_table: Symbols.table ;
   builtins: Builtins.t ;
   flags: flags }
+let init_state ?symbols_of  flags =
+  let state = D.State.init () in
+  let state = D.State.set compiler_flags state flags in
+  let state = D.State.set D.while_compiling state true in
+  let state =
+    match symbols_of with
+    | None -> state
+    | Some previous ->
+        D.State.set Symbols.table state
+          (Symbols.lock (D.State.get Symbols.table previous)) in
+  state
 module Assemble :
   sig
     val run :
       header:compilation_unit ->
         compilation_unit list -> (State.t * Assembled.program)
+    val extend :
+      (State.t * Assembled.program) ->
+        compilation_unit list -> (State.t * Assembled.program)
   end =
   struct
-    let sort_insertion l =
+    let sort_insertion old l =
       let add s { Ast.Clause.attributes = { Assembled.id = id }; loc } =
         match id with
         | None -> s
@@ -2773,9 +2840,46 @@ module Assemble :
             ->
             let x = compile_clause x in aux (add seen x) (insert i x acc) xs
         | x::xs -> let x = compile_clause x in aux (add seen x) (x :: acc) xs in
-      aux StrMap.empty [] l
+      aux StrMap.empty (List.rev old) l
     let clause_name
       { Ast.Clause.attributes = { Ast.Structured.ifexpr = ifexpr } } = ifexpr
+    let extend (state, (code : Assembled.program)) ul =
+      let (state, clauses_rev, types, type_abbrevs, modes, chr_rev) =
+        List.fold_left
+          (fun (state, cl1, t1, ta1, m1, c1) ->
+             fun { symbol_table; code; flags } ->
+               let (state,
+                    { Flat.clauses = cl2; types = t2; type_abbrevs = ta2;
+                      modes = m2; chr = c2; toplevel_macros = _ })
+                 =
+                 if
+                   Symbols.equal symbol_table (State.get Symbols.table state)
+                 then (state, code)
+                 else
+                   (let (state, shift) =
+                      Symbols.build_shift ~base:state symbol_table in
+                    let code = Flatten.relocate state shift code in
+                    (state, code)) in
+               let modes = ToDBL.merge_modes state m1 m2 in
+               let type_abbrevs = ToDBL.merge_type_abbrevs state ta1 ta2 in
+               let types = ToDBL.merge_types t1 t2 in
+               let cl2 = filter_if flags clause_name cl2 in
+               (state, (cl2 :: cl1), types, type_abbrevs, modes, (c2 :: c1)))
+          (state, [], (code.Assembled.types), (code.Assembled.type_abbrevs),
+            (code.Assembled.modes), []) ul in
+      let clauses = List.concat (List.rev clauses_rev) in
+      let clauses = sort_insertion code.clauses clauses in
+      let chr = List.concat ((code.Assembled.chr) :: (List.rev chr_rev)) in
+      (state,
+        {
+          Assembled.clauses = clauses;
+          types;
+          type_abbrevs;
+          modes;
+          chr;
+          local_names = (code.Assembled.local_names);
+          toplevel_macros = (code.Assembled.toplevel_macros)
+        })
     let run ~header:({ symbol_table; builtins; code; flags } as h)  ul =
       let nunits_with_locals =
         ((h :: ul) |>
@@ -2792,55 +2896,13 @@ module Assemble :
       (let state = init_state default_flags in
        let state = State.set Builtins.builtins state builtins in
        let state = State.set Symbols.table state symbol_table in
-       let (state,
-            { Flat.clauses = clauses; types; type_abbrevs; modes; chr;
-              local_names; toplevel_macros })
-         =
-         List.fold_left
-           (fun
-              (state,
-               { Flat.clauses = cl1; types = t1; type_abbrevs = ta1;
-                 modes = m1; chr = c1; toplevel_macros = tm1 })
-              ->
-              fun { symbol_table; code; flags } ->
-                let (state, shift) =
-                  Symbols.build_shift ~base:state symbol_table in
-                let { Flat.clauses = cl2; types = t2; type_abbrevs = ta2;
-                      modes = m2; chr = c2; toplevel_macros = _ } as xxx
-                  = Flatten.relocate state shift code in
-                let modes = ToDBL.merge_modes state m1 m2 in
-                let type_abbrevs = ToDBL.merge_type_abbrevs state ta1 ta2 in
-                let types = ToDBL.merge_types t1 t2 in
-                let chr = c1 @ c2 in
-                let toplevel_macros = tm1 in
-                let cl2 = filter_if flags clause_name cl2 in
-                (state,
-                  {
-                    Flat.clauses = (cl1 @ cl2);
-                    types;
-                    type_abbrevs;
-                    modes;
-                    chr;
-                    local_names = 0;
-                    toplevel_macros
-                  }))
-           (state,
-             {
-               code with
-               clauses = (filter_if flags clause_name code.Flat.clauses)
-             }) ul in
-       let clauses = sort_insertion clauses in
-       let modes = C.Map.map fst modes in
-       (state,
-         {
-           Assembled.clauses = clauses;
-           types;
-           type_abbrevs;
-           modes;
-           chr;
-           local_names;
-           toplevel_macros
-         }))
+       extend
+         (state,
+           {
+             Assembled.empty with
+             toplevel_macros = (code.toplevel_macros);
+             local_names = (code.local_names)
+           }) (h :: ul))
   end 
 let w_symbol_table s f x =
   let table = Symbols.compile_table @@ (State.get Symbols.table s) in
@@ -2891,9 +2953,15 @@ let assemble_units ~header  units =
    then
      Format.eprintf "== Spilled ================@\n@[<v 0>%a@]@\n"
        (w_symbol_table s Assembled.pp_program) p;
-   (s, p))
+   ((State.update Symbols.table s Symbols.lock), p))
 let program_of_ast s ~header  p =
   let u = unit_of_ast s p in assemble_units ~header [u]
+let extend (s, p) ul =
+  if ul = []
+  then (s, p)
+  else
+    (let (s, p) = Assemble.extend (s, p) ul in
+     let p = Spill.run s p in (s, p))
 let is_builtin state tname = Builtins.is_declared state tname
 let check_all_builtin_are_typed state types =
   Constants.Set.iter
@@ -2967,11 +3035,14 @@ let uvbodies_of_assignments assignments =
        (function | UVar (b, _, _)|AppUVar (b, _, _) -> b | _ -> assert false)
        assignments)
 let query_of_ast compiler_state assembled_program t =
+  let compiler_state = State.begin_goal_compilation compiler_state in
   let initial_depth = assembled_program.Assembled.local_names in
   let types = assembled_program.Assembled.types in
   let type_abbrevs = assembled_program.Assembled.type_abbrevs in
-  let modes = assembled_program.Assembled.modes in
+  let modes = C.Map.map fst assembled_program.Assembled.modes in
   let active_macros = assembled_program.Assembled.toplevel_macros in
+  let compiler_state =
+    State.update Symbols.table compiler_state Symbols.unlock in
   let (state, query) =
     ToDBL.query_preterm_of_ast ~depth:initial_depth active_macros
       compiler_state t in
@@ -2998,11 +3069,14 @@ let query_of_ast compiler_state assembled_program t =
     compiler_state = (state |> (uvbodies_of_assignments assignments))
   }
 let query_of_term compiler_state assembled_program f =
+  let compiler_state = State.begin_goal_compilation compiler_state in
   let initial_depth = assembled_program.Assembled.local_names in
   let types = assembled_program.Assembled.types in
   let type_abbrevs = assembled_program.Assembled.type_abbrevs in
-  let modes = assembled_program.Assembled.modes in
+  let modes = C.Map.map fst assembled_program.Assembled.modes in
   let active_macros = assembled_program.Assembled.toplevel_macros in
+  let compiler_state =
+    State.update Symbols.table compiler_state Symbols.unlock in
   let (state, query) =
     ToDBL.query_preterm_of_function ~depth:initial_depth active_macros
       compiler_state (f ~depth:initial_depth) in
@@ -3027,6 +3101,7 @@ let query_of_term compiler_state assembled_program f =
     compiler_state = (state |> (uvbodies_of_assignments assignments))
   }
 let query_of_data state p loc (Query.Query { arguments } as descr) =
+  let state = State.begin_goal_compilation state in
   let query =
     query_of_term state p
       (fun ~depth ->
@@ -3127,32 +3202,37 @@ module Compiler : sig val run : 'a query -> 'a executable end =
                   (List.fold_left (fun x -> fun y -> CHR.add_rule clique y x)
                      chr rules))) (state, CHR.empty) chr in
        let indexing =
-         let known =
-           let ty =
-             List.map (fun { Structured.decl = { tname } } -> tname) types in
-           let mo = (C.Map.bindings modes) |> (List.map fst) in
-           List.fold_right C.Set.add (mo @ ty) C.Set.empty in
-         C.Set.fold
-           (fun name ->
-              fun m ->
-                let mode = try C.Map.find name modes with | Not_found -> [] in
-                let index =
-                  let indexes =
-                    (map_filter
-                       (fun { Structured.decl = { tname }; tindex } ->
-                          match tindex with
-                          | Indexed l when tname == name -> Some l
-                          | _ -> None) types)
-                      |> uniq in
-                  match indexes with
-                  | [] -> [1]
-                  | x::[] -> x
-                  | _ ->
-                      error
-                        ("multiple and inconsistent indexing attributes for "
-                           ^ (Symbols.show state name)) in
-                C.Map.add name (mode, (chose_indexing state name index)) m)
-           known C.Map.empty in
+         let add_indexing_for name tindex map =
+           let mode = try C.Map.find name modes with | Not_found -> [] in
+           let (declare_index, index) =
+             match tindex with
+             | Some (Ast.Structured.Indexed l) ->
+                 (true, (chose_indexing state name l))
+             | _ -> (false, (chose_indexing state name [1])) in
+           try
+             let (_, old_tindex) = C.Map.find name map in
+             if old_tindex <> index
+             then
+               (if (old_tindex <> (MapOn 1)) && declare_index
+                then
+                  error
+                    ("multiple and inconsistent indexing attributes for " ^
+                       (Symbols.show state name))
+                else
+                  if declare_index
+                  then C.Map.add name (mode, index) map
+                  else map)
+             else map
+           with | Not_found -> C.Map.add name (mode, index) map in
+         let map =
+           List.fold_left
+             (fun acc ->
+                fun { Structured.decl = { tname }; tindex } ->
+                  add_indexing_for tname (Some tindex) acc) C.Map.empty types in
+         let map =
+           C.Map.fold (fun k -> fun _ -> fun m -> add_indexing_for k None m)
+             modes map in
+         map in
        let (state, clauses) =
          map_acc (compile_clause modes initial_depth) state clauses in
        let prolog_program =

--- a/src/.ppcache/compiler.mli
+++ b/src/.ppcache/compiler.mli
@@ -1,4 +1,4 @@
-(*d8234deab7c788c119394625649abaddbdc7ad33 *src/compiler.mli *)
+(*bef9b2a405cc0135c2a311e3f6e3dcdc2bb00acc *src/compiler.mli *)
 #1 "src/compiler.mli"
 open Util
 open Data
@@ -7,17 +7,19 @@ type flags = {
   print_passes: bool }
 val default_flags : flags
 val compiler_flags : flags State.component
-val init_state : flags -> State.t
 type program
 type 'a query
 exception CompileError of Loc.t option * string 
 type compilation_unit
+val init_state : ?symbols_of:State.t -> flags -> State.t
 val program_of_ast :
   State.t -> header:compilation_unit -> Ast.Program.t -> (State.t * program)
 val unit_of_ast :
   State.t -> ?header:compilation_unit -> Ast.Program.t -> compilation_unit
 val assemble_units :
   header:compilation_unit -> compilation_unit list -> (State.t * program)
+val extend :
+  (State.t * program) -> compilation_unit list -> (State.t * program)
 val query_of_ast : State.t -> program -> Ast.Goal.t -> unit query
 val query_of_term :
   State.t ->

--- a/src/.ppcache/runtime_trace_off.ml
+++ b/src/.ppcache/runtime_trace_off.ml
@@ -1,4 +1,4 @@
-(*d2284b18b7efca3e8e515d7da852773c403f167b *src/runtime_trace_off.ml --cookie elpi_trace="false"*)
+(*1be108d15a5f71fca4ad3b97c89762767b3578ba *src/runtime_trace_off.ml --cookie elpi_trace="false"*)
 #1 "src/runtime_trace_off.ml"
 module Fmt = Format
 module F = Ast.Func
@@ -367,8 +367,9 @@ module ConstraintStoreAndTrail :
       cstr_blockers: uvar_body list }
     let state =
       Fork.new_local
-        (((State.init ()) |> (State.end_goal_compilation StrMap.empty)) |>
-           State.end_compilation)
+        ((((State.init ()) |> State.begin_goal_compilation) |>
+            (State.end_goal_compilation StrMap.empty))
+           |> State.end_compilation)
     let read_custom_constraint ct = State.get ct (!state)
     let update_custom_constraint ct f = state := (State.update ct (!state) f)
     type trail_item =
@@ -2757,8 +2758,9 @@ module Constraints :
              initial_depth = max_depth;
              initial_runtime_state =
                (let open State in
-                  ((init ()) |> (end_goal_compilation StrMap.empty)) |>
-                    end_compilation);
+                  (((init ()) |> State.begin_goal_compilation) |>
+                     (end_goal_compilation StrMap.empty))
+                    |> end_compilation);
              query_arguments = Query.N;
              symbol_table = (!C.table);
              builtins = (!FFI.builtins)

--- a/src/.ppcache/runtime_trace_on.ml
+++ b/src/.ppcache/runtime_trace_on.ml
@@ -1,4 +1,4 @@
-(*d2284b18b7efca3e8e515d7da852773c403f167b *src/runtime_trace_on.ml --cookie elpi_trace="true"*)
+(*1be108d15a5f71fca4ad3b97c89762767b3578ba *src/runtime_trace_on.ml --cookie elpi_trace="true"*)
 #1 "src/runtime_trace_on.ml"
 module Fmt = Format
 module F = Ast.Func
@@ -368,8 +368,9 @@ module ConstraintStoreAndTrail :
       cstr_blockers: uvar_body list }
     let state =
       Fork.new_local
-        (((State.init ()) |> (State.end_goal_compilation StrMap.empty)) |>
-           State.end_compilation)
+        ((((State.init ()) |> State.begin_goal_compilation) |>
+            (State.end_goal_compilation StrMap.empty))
+           |> State.end_compilation)
     let read_custom_constraint ct = State.get ct (!state)
     let update_custom_constraint ct f = state := (State.update ct (!state) f)
     type trail_item =
@@ -3518,8 +3519,9 @@ module Constraints :
              initial_depth = max_depth;
              initial_runtime_state =
                (let open State in
-                  ((init ()) |> (end_goal_compilation StrMap.empty)) |>
-                    end_compilation);
+                  (((init ()) |> State.begin_goal_compilation) |>
+                     (end_goal_compilation StrMap.empty))
+                    |> end_compilation);
              query_arguments = Query.N;
              symbol_table = (!C.table);
              builtins = (!FFI.builtins)

--- a/src/API.mli
+++ b/src/API.mli
@@ -166,10 +166,14 @@ module Compile : sig
        visible in all units
      - types, type abbreviations and mode declarations from all units are
        merged at assembly time
+     - extending a program with a unit is fast if the unit follows it. A unit
+       following a program is not allowed to allocate new global symbol. The
+       typical example is a new clause for an exising predicate.
      *)
   type compilation_unit
-  val unit : elpi:Setup.elpi -> flags:flags -> Ast.program -> compilation_unit
+  val unit : ?follows:program -> elpi:Setup.elpi -> flags:flags -> Ast.program -> compilation_unit
   val assemble : elpi:Setup.elpi -> compilation_unit list -> program
+  val extend : base:program -> compilation_unit list -> program
 
   (* then compile the query *)
   val query : program -> Ast.query -> unit query
@@ -691,6 +695,8 @@ module State : sig
     name:string ->
     pp:(Format.formatter -> 'a -> unit) ->
     init:(unit -> 'a) ->
+    (* run just before the goal is compiled (but after the program is) *)
+    start:('a -> 'a) ->
       'a component
 
   type t = Data.state

--- a/src/compiler.mli
+++ b/src/compiler.mli
@@ -12,7 +12,6 @@ type flags = {
 val default_flags : flags
 val compiler_flags : flags State.component
 
-val init_state : flags -> State.t
 
 type program
 type 'a query
@@ -20,10 +19,12 @@ type 'a query
 exception CompileError of Loc.t option * string
 
 type compilation_unit
+val init_state : ?symbols_of:State.t -> flags -> State.t
 
 val program_of_ast : State.t -> header:compilation_unit -> Ast.Program.t -> State.t * program
 val unit_of_ast : State.t -> ?header:compilation_unit -> Ast.Program.t -> compilation_unit
 val assemble_units : header:compilation_unit -> compilation_unit list -> State.t * program
+val extend : State.t * program -> compilation_unit list -> State.t * program
 
 val query_of_ast : State.t -> program -> Ast.Goal.t -> unit query
 val query_of_term :

--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -409,7 +409,7 @@ end = struct (* {{{ *)
  }
 
   let state =
-    Fork.new_local (State.init () |> State.end_goal_compilation StrMap.empty |> State.end_compilation)
+    Fork.new_local (State.init () |> State.begin_goal_compilation |> State.end_goal_compilation StrMap.empty |> State.end_compilation)
   let read_custom_constraint ct =
     State.get ct !state
   let update_custom_constraint ct f =
@@ -3006,7 +3006,7 @@ let try_fire_rule (gid[@trace]) rule (constraints as orig_constraints) =
         (shift_bound_vars ~depth:0 ~to_:max_depth guard);
     assignments = StrMap.empty;
     initial_depth = max_depth;
-    initial_runtime_state = State.(init () |> end_goal_compilation StrMap.empty |> end_compilation);
+    initial_runtime_state = State.(init () |> State.begin_goal_compilation |> end_goal_compilation StrMap.empty |> end_compilation);
     query_arguments = Query.N;
     symbol_table = !C.table;
     builtins = !FFI.builtins;
@@ -3464,11 +3464,11 @@ let execute_loop ?delay_outside_fragment exec ~more ~pp =
  let { search; next_solution; get } = make_runtime ?delay_outside_fragment exec in
  let k = ref noalts in
  let do_with_infos f =
-  let time0 = Unix.gettimeofday() in
-  let o, alts = mk_outcome f (fun () -> get CS.Ugly.delayed, get CS.state |> State.end_execution, exec.query_arguments, { Data.uv_names = ref (get Pp.uv_names); table = get C.table }) exec.assignments in
-  let time1 = Unix.gettimeofday() in
-  k := alts;
-  pp (time1 -. time0) o in
+   let time0 = Unix.gettimeofday() in
+   let o, alts = mk_outcome f (fun () -> get CS.Ugly.delayed, get CS.state |> State.end_execution, exec.query_arguments, { Data.uv_names = ref (get Pp.uv_names); table = get C.table }) exec.assignments in
+   let time1 = Unix.gettimeofday() in
+   k := alts;
+   pp (time1 -. time0) o in
  do_with_infos search;
  while !k != noalts do
    if not(more()) then k := noalts else


### PR DESCRIPTION
After time measuring in Coq-Elpi we found that "assembling + optimizing" a program can even 0.01 of a second, which is not much in the absolute can be 10x the execution time.

The main trick is to expose an API to compile a unit using the same, locked, symbol table of a program. In this way the unit is guaranteed to allocate no new symbols and can hence be assembled without relocating it.