### PR TITLE
Remove .install file hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,6 @@ build:
 	( echo "FLG -ppx './merlinppx.exe --as-ppx --cookie '\''elpi_trace=\"true\"'\'''" >> src/.merlin );\
 	exit $$RC
 
-fix-elpi.install:
-	dune exec ./fix_elpi_install.exe -- elpi.install
-
 install:
 	dune install $(DUNE_OPTS)
 

--- a/elpi.opam
+++ b/elpi.opam
@@ -11,7 +11,6 @@ build: [
   ["dune" "subst"] {pinned}
   [make "build" "DUNE_OPTS=-p %{name}% -j %{jobs}%"]
   [make "tests" "DUNE_OPTS=-p %{name}%" "TIMEOUT=120"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
-  [make "fix-elpi.install"]
 ]
 
 depends: [

--- a/ppxfindcache/dune
+++ b/ppxfindcache/dune
@@ -4,25 +4,21 @@
 
 (executable
   (name ppxfindcache)
-  (public_name ppxfindcache_elpi_trace_deriving_std)
   (modules ppxfindcache)
   (libraries unix re ppxfindcache_aux
     (select ppxfindcache.ml from
       (elpi.trace.ppx ppx_deriving.std -> ppxfindcache.useppx.ml)
       (-> ppxfindcache.cacheonly.ml)))
-  (flags -linkall)
-)
+  (flags -linkall))
 
 (executable
   (name ppxfindcache2)
-  (public_name ppxfindcache_deriving_std)
   (modules ppxfindcache2)
   (libraries unix re ppxfindcache_aux
     (select ppxfindcache2.ml from
       (ppx_deriving.std -> ppxfindcache2.useppx.ml)
       (-> ppxfindcache2.cacheonly.ml)))
-  (flags -linkall)
-)
+  (flags -linkall))
 
 (rule (copy# ppxfindcache.useppx.ml ppxfindcache2.useppx.ml))
 (rule (copy# ppxfindcache.cacheonly.ml ppxfindcache2.cacheonly.ml))

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
   (name elpi)
   (public_name elpi)
   (preprocess (per_module
-    ((action (run ppxfindcache_deriving_std %{input-file}
+    ((action (run %{project_root}/ppxfindcache/ppxfindcache2.exe %{input-file}
                     --cache-file %{dep:.ppcache/API.ml}
                     --cache-file %{dep:.ppcache/API.mli}
                     --cache-file %{dep:.ppcache/util.ml}
@@ -13,13 +13,13 @@
                     --cache-file %{dep:.ppcache/compiler.ml}
                     --cache-file %{dep:.ppcache/compiler.mli}))
               API ast data compiler)
-    ((action (run ppxfindcache_elpi_trace_deriving_std %{input-file}
+    ((action (run %{project_root}/ppxfindcache/ppxfindcache.exe %{input-file}
                     --ppx-opt --cookie
                     --ppx-opt "elpi_trace=\"true\""
                     --cache-file %{dep:.ppcache/runtime_trace_on.ml}
                     --cache-file %{dep:.ppcache/runtime_trace_on.mli}))
               runtime_trace_on)
-    ((action (run ppxfindcache_elpi_trace_deriving_std %{input-file}
+    ((action (run %{project_root}/ppxfindcache/ppxfindcache.exe %{input-file}
                     --ppx-opt --cookie
                     --ppx-opt "elpi_trace=\"false\""
                     --cache-file %{dep:.ppcache/runtime_trace_off.ml}


### PR DESCRIPTION
We make the ppx executables private and refer to them by a qualified
path. This allows us to rmeove a hack to edit the .install file after
dune generates it.