### PR TITLE
Improve behavior and error messages in nth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
     Nathan Guermond for testing this tricky case.
   - Change `Rawdata.Constants.eqc` to a builtin
   - Fix `Rawdata.Constants.cutc` has always been a builtin
+- Library:
+  - Better error messages in `std.nth`
 
 # v1.13.7 (July 2021)
 

--- a/src/builtin.elpi
+++ b/src/builtin.elpi
@@ -669,8 +669,9 @@ omap (some X) F (some Y) :- F X Y.
 
 % [nth N L X] picks in X the N-th element of L (L must be of length > N)
 pred nth i:int, i:list A, o:A.
-nth 0 [X|_] X :- !.
-nth N [_|XS] R :- !, N1 is N - 1, nth N1 XS R.
+nth 0 [X|_ ] R :- !, X = R.
+nth N [_|XS] R :- N > 0, !, N1 is N - 1, nth N1 XS R.
+nth N _ _ :- N < 0, !, fatal-error "nth got a negative index".
 nth _ _ _ :- fatal-error "nth run out of list items".
 
 % [lookup L K V] sees L as a map from K to V

--- a/src/builtin_stdlib.elpi
+++ b/src/builtin_stdlib.elpi
@@ -162,8 +162,9 @@ omap (some X) F (some Y) :- F X Y.
 
 % [nth N L X] picks in X the N-th element of L (L must be of length > N)
 pred nth i:int, i:list A, o:A.
-nth 0 [X|_] X :- !.
-nth N [_|XS] R :- !, N1 is N - 1, nth N1 XS R.
+nth 0 [X|_ ] R :- !, X = R.
+nth N [_|XS] R :- N > 0, !, N1 is N - 1, nth N1 XS R.
+nth N _ _ :- N < 0, !, fatal-error "nth got a negative index".
 nth _ _ _ :- fatal-error "nth run out of list items".
 
 % [lookup L K V] sees L as a map from K to V


### PR DESCRIPTION
Currently, `nth` issues a single error message `nth run out of list items`, for a few situations:
 - when the index is too large;
 - when the index is negative;
 - and when it successfully indexes the collection, but unifying this element with the result fails. (This is due to improper cut placement.)

This change keeps the error message for the first situation, but adds a `nth got a negative index` error message for the second, and makes it fail normally in the third case.