### PR TITLE
camlp5 -> menhir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,17 @@ jobs:
           opam exec -- make build
           opam exec -- cp _build/install/default/bin/elpi elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe
 
+      - name: Strip binary
+        run: opam exec -- strip ${{ env.workspace }}/elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe
+
+# Artifacts 1 ################################################################
+
+      - name: Save binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: elpi-${{ matrix.ocaml-version }}-${{ runner.os }}
+          path: elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe
+
 # Test ######################################################################
 #
 # We run the test suite which also produces data.csf containing benchmarks
@@ -94,17 +105,7 @@ jobs:
           opam exec -- ls -l tests/sources/*.elpi
           opam exec -- make tests PWD=${{ env.workspace }} RUNNERS='dune ${{ env.workspace }}/elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe' TIME=--time=${{ env.cygwin_root }}/bin/time.exe
 
-      - name: Strip binary
-        run: opam exec -- strip ${{ env.workspace }}/elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe
-
-# Artifacts ##################################################################
-
-
-      - name: Save binary
-        uses: actions/upload-artifact@v2
-        with:
-          name: elpi-${{ matrix.ocaml-version }}-${{ runner.os }}
-          path: elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe
+# Artifacts 2 ################################################################
 
       - name: Save benchmarking data
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Install dependencies
         run: |
           opam depext camlp5 || true # no depext on opam 2.1
+          opam install 'camlp5>=8' || true # not a strict dependency
           opam install . --deps-only --with-doc --with-test
 
       - name: Build elpi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           - windows-latest
         ocaml-version:
           - 4.12.0+domains
-          - 4.13.1
+          - 4.14.0
           - 4.07.1
         exclude:
           - os: windows-latest
@@ -69,10 +69,14 @@ jobs:
 #
 # We generate binaries like elpi-4.07.1-Linux.exe in the working directory
 
-      - name: Install dependencies
+      - name: Install optional dependencies on 4.07.1
+        if: matrix.ocaml-version == '4.07.1'
         run: |
           opam depext camlp5 || true # no depext on opam 2.1
           opam install 'camlp5>=8' || true # not a strict dependency
+  
+      - name: Install real dependencies
+        run: |
           opam install . --deps-only --with-doc --with-test
 
       - name: Build elpi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-version:
-          - 4.12.0+domains
-          - 4.14.0
+          - 4.13.1
+          - 4.11.2
+          - 4.09.1
           - 4.07.1
         profile:
           - dev
@@ -26,9 +27,9 @@ jobs:
           - os: ubuntu-latest
             ocaml-version: 4.14.0
             profile: fatalwarnings
-        exclude:
-          - os: windows-latest
+          - os: ubuntu-latest
             ocaml-version: 4.12.0+domains
+            profile: dev
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,13 +23,21 @@ jobs:
           - 4.07.1
         profile:
           - dev
+        parser:
+          - new
         include:
           - os: ubuntu-latest
             ocaml-version: 4.14.0
             profile: fatalwarnings
+            parser: new
           - os: ubuntu-latest
             ocaml-version: 4.12.0+domains
             profile: dev
+            parser: new
+          - os: ubuntu-latest
+            ocaml-version: 4.11.2
+            profile: dev
+            parser: legacy
 
     runs-on: ${{ matrix.os }}
 
@@ -76,11 +84,11 @@ jobs:
 #
 # We generate binaries like elpi-4.07.1-Linux.exe in the working directory
 
-      - name: Install optional dependencies on 4.07.1
-        if: matrix.ocaml-version == '4.07.1'
+      - name: Install optional dependencies for legacy parser
+        if: matrix.parser == 'legacy'
         run: |
           opam depext camlp5 || true # no depext on opam 2.1
-          opam install 'camlp5>=8' || true # not a strict dependency
+          opam install 'camlp5>=8'
   
       - name: Install real dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,20 +24,20 @@ jobs:
         profile:
           - dev
         parser:
-          - new
+          - menhir
         include:
           - os: ubuntu-latest
             ocaml-version: 4.14.0
             profile: fatalwarnings
-            parser: new
+            parser: menhir
           - os: ubuntu-latest
             ocaml-version: 4.12.0+domains
             profile: dev
-            parser: new
+            parser: menhir
           - os: ubuntu-latest
             ocaml-version: 4.11.2
             profile: dev
-            parser: legacy
+            parser: menhir-camlp5
 
     runs-on: ${{ matrix.os }}
 
@@ -84,8 +84,8 @@ jobs:
 #
 # We generate binaries like elpi-4.07.1-Linux.exe in the working directory
 
-      - name: Install optional dependencies for legacy parser
-        if: matrix.parser == 'legacy'
+      - name: Install optional dependencies for menhir-camlp5 parser
+        if: matrix.parser == 'menhir-camlp5'
         run: |
           opam depext camlp5 || true # no depext on opam 2.1
           opam install 'camlp5>=8'
@@ -98,18 +98,18 @@ jobs:
         run: |
           opam exec -- dune subst
           opam exec -- make build DUNE_OPTS='--profile ${{ matrix.profile }}'
-          opam exec -- cp _build/install/default/bin/elpi elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe
+          opam exec -- cp _build/install/default/bin/elpi elpi-${{ matrix.ocaml-version }}-${{ matrix.parser }}-${{ runner.os }}.exe
 
       - name: Strip binary
-        run: opam exec -- strip ${{ env.workspace }}/elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe
+        run: opam exec -- strip ${{ env.workspace }}/elpi-${{ matrix.ocaml-version }}-${{ matrix.parser }}-${{ runner.os }}.exe
 
 # Artifacts 1 ################################################################
 
       - name: Save binary
         uses: actions/upload-artifact@v2
         with:
-          name: elpi-${{ matrix.ocaml-version }}-${{ runner.os }}
-          path: elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe
+          name: elpi-${{ matrix.ocaml-version }}-${{ matrix.parser }}-${{ runner.os }}
+          path: elpi-${{ matrix.ocaml-version }}-${{ matrix.parser }}-${{ runner.os }}.exe
 
 # Test ######################################################################
 #
@@ -117,20 +117,20 @@ jobs:
 
       - name: Test elpi on Unix
         if: runner.os != 'Windows'
-        run: opam exec -- make tests RUNNERS='dune ${{ env.workspace }}/elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe'
+        run: opam exec -- make tests RUNNERS='dune ${{ env.workspace }}/elpi-${{ matrix.ocaml-version }}-${{ matrix.parser }}-${{ runner.os }}.exe'
 
       - name: Test elpi on Windows
         if: runner.os == 'Windows'
         run: |
           opam exec -- ls -l tests/sources/*.elpi
-          opam exec -- make tests PWD=${{ env.workspace }} RUNNERS='dune ${{ env.workspace }}/elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe' TIME=--time=${{ env.cygwin_root }}/bin/time.exe
+          opam exec -- make tests PWD=${{ env.workspace }} RUNNERS='dune ${{ env.workspace }}/elpi-${{ matrix.ocaml-version }}-${{ matrix.parser }}-${{ runner.os }}.exe' TIME=--time=${{ env.cygwin_root }}/bin/time.exe
 
 # Artifacts 2 ################################################################
 
       - name: Save benchmarking data
         uses: actions/upload-artifact@v2
         with:
-          name: .benchmark-${{ matrix.ocaml-version }}-${{ runner.os }}
+          name: .benchmark-${{ matrix.ocaml-version }}-${{ matrix.parser }}-${{ runner.os }}
           path: data.csv
           retention-days: 1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,12 @@ jobs:
           - 4.12.0+domains
           - 4.14.0
           - 4.07.1
+        profile:
+          - dev
+        include:
+          - os: ubuntu-latest
+            ocaml-version: 4.14.0
+            profile: fatalwarnings
         exclude:
           - os: windows-latest
             ocaml-version: 4.12.0+domains
@@ -79,10 +85,10 @@ jobs:
         run: |
           opam install . --deps-only --with-doc --with-test
 
-      - name: Build elpi
+      - name: Build elpi with dune profile ${{ matrix.profile }}
         run: |
           opam exec -- dune subst
-          opam exec -- make build
+          opam exec -- make build DUNE_OPTS='--profile ${{ matrix.profile }}'
           opam exec -- cp _build/install/default/bin/elpi elpi-${{ matrix.ocaml-version }}-${{ runner.os }}.exe
 
       - name: Strip binary

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 
 # UNRELEASED
 
+Requires Menhir 20211230 or above, camlp5 is now optional.
+
 - Parser:
   - New parser based on Menhir
     + The grammar is not extensible anymore
@@ -20,6 +22,7 @@
 - REPL:
   - New `-parse-term`
   - New `-legacy-parser`
+  - New `-legacy-parser-available`
   - Removed `-print-accumulated-files`
 
 # v1.14.3 (March 2022)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,27 @@
+
+# UNRELEASED
+
+- Parser:
+  - New parser based on Menhir
+    + The grammar is not extensible anymore
+    + Token families are used to provide open ended infix symbols, see
+      the [documentation](src/parser/README.md)
+  - Old parser available via `-legacy-parser`
+    + only compiled when `camlp5` is available
+
+- API:
+  - `Parse.goal_from_stream` -> `Parse.goal_from`
+  - `Parse.program_from_stream` -> `Parse.program_from`
+  - `Parse.resolve_file` now takes an `~elpi` argument
+  - `Setup.init` resolver argument takes a `~unit` instead of `~file`
+  - `Setup.init` takes `?legacy_parser`
+  - `Setup.legacy_parser_avaiable`
+
+- REPL:
+  - New `-parse-term`
+  - New `-legacy-parser`
+  - Removed `-print-accumulated-files`
+
 # v1.14.3 (March 2022)
 
 - Tests:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 
 # UNRELEASED
 
-Requires Menhir 20211230 or above, camlp5 is now optional.
+Requires Menhir 20211230 and OCaml 4.07 or above.
+Camlp5 is now optional.
 
 - Parser:
   - New parser based on Menhir

--- a/INCOMPATIBILITIES.md
+++ b/INCOMPATIBILITIES.md
@@ -12,6 +12,7 @@ This file tries to summarise known incompatibilities between Elpi and Teyjus.
 
 # Syntax
 
+- Since Elpi 1.15 the default parser does not support the `infix` directive
 - No syntax for negative numbers: `~ 2` is the unary minus applied to `2`,
   not the number `-2`. If you want to write `-2`, just write `-2` with no
   space in between.

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,23 @@
 help:
-	@echo 'Known targets:'
+	@echo 'Build targets:'
 	@echo
 	@echo '  build            builds elpi'
 	@echo '  install          install elpi'
 	@echo '  clean            remove build artifacts'
 	@echo
+	@echo 'Testing targets:'
+	@echo
 	@echo '  tests            runs the entire test suite'
 	@echo '  tests ONLY=rex   runs only tests matching rex'
 	@echo
 	@echo '  git/treeish      checkout treeish and build elpi.git.treeish'
+	@echo
+	@echo 'Parser maintenance targets:'
+	@echo
+	@echo '  menhir-repl      run menhir in interactive mode'
+	@echo '  menhir-explain-conflicts'
+	@echo '  menhir-complete-errormsgs run when updating the grammar'
+	@echo '  menhir-strip-errormsgs remove comments from error message file'
 	@echo
 
 INSTALL=_build/install/default
@@ -29,11 +38,6 @@ CP5:=$(shell ocamlfind query camlp5)
 
 build:
 	dune build $(DUNE_OPTS) @all
-	# hack: link camlp5.gramlib in the plugin
-	ocamlfind opt -shared -linkall -o _build/install/default/lib/elpi/elpi.cmxs \
-		$(CP5)/gramlib.cmxa \
-		_build/install/default/lib/elpi/elpi.cmxa
-
 
 install:
 	dune install $(DUNE_OPTS)
@@ -44,8 +48,10 @@ doc:
 clean:
 	rm -rf _build
 
+# testing
 tests:
 	$(MAKE) build
+	dune runtest
 	ulimit -s $(STACK); OCAMLRUNPARAM=l=$(STACK) \
 		tests/test.exe \
 		--seed $$RANDOM \
@@ -72,5 +78,31 @@ git/%:
 		mkdir -p _build/install/default/bin/; \
 		ln -s $$PWD/elpi _build/install/default/bin/elpi.git.$*; \
 	  fi
+
+# parser maintenance
+menhir-repl:
+	menhir --interpret src/parser/tokens.mly \
+		src/parser/token_precedence.mly \
+		--base grammar src/parser/grammar.mly 2>/dev/null
+menhir-explain-conflicts:
+	-menhir --explain src/parser/tokens.mly \
+		src/parser/token_precedence.mly \
+		--base grammar src/parser/grammar.mly
+	echo "Plese look at grammar.conflicts"
+menhir-complete-errormsgs:
+	menhir src/parser/tokens.mly \
+		src/parser/token_precedence.mly \
+		--base grammar src/parser/grammar.mly \
+		--list-errors > src/parser/error_messages.auto.messages
+	menhir src/parser/tokens.mly \
+		src/parser/token_precedence.mly \
+		--base grammar src/parser/grammar.mly\
+		--merge-errors src/parser/error_messages.auto.messages \
+		--merge-errors src/parser/error_messages.txt \
+		> src/parser/error_messages.merged
+	mv src/parser/error_messages.merged src/parser/error_messages.txt
+	rm src/parser/error_messages.auto.messages
+menhir-strip-errormsgs:
+	sed -e "/^##/d" -i.bak src/parser/error_messages.txt
 
 .PHONY: tests help install build clean

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,10 @@ RUNNERS=\
   $(shell if type tjsim >/dev/null 2>&1; then type -P tjsim; else echo; fi)
 TIME=--time $(shell if type -P gtime >/dev/null 2>&1; then type -P gtime; else echo /usr/bin/time; fi)
 STACK=1114112
+
 DUNE_OPTS=
 
-CP5:=$(shell ocamlfind query camlp5)
+CP5:=$(shell if ocamlfind query camlp5x 2>/dev/null >&2; then : ; else echo "INFO: Camlp5 not found: legacy parser disabled." >& 2; fi)
 
 build:
 	dune build $(DUNE_OPTS) @all

--- a/dune
+++ b/dune
@@ -7,4 +7,6 @@
 
 (env
   (dev
-    (flags (:standard -w -9 -w -32 -w -27 -w -6 -w -37 -warn-error -A))))
+    (flags (:standard -w -9 -w -32 -w -27 -w -6 -w -37 -warn-error -A)))
+  (fatalwarnings
+    (flags (:standard -w -9 -w -32 -w -27 -w -6 -w -37 -warn-error +A))))

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
 (lang dune 2.0)
 (name elpi)
+(using menhir 2.0)

--- a/elpi.opam
+++ b/elpi.opam
@@ -16,7 +16,6 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0" & < "4.14.0"}
   "stdlib-shims"
-  "camlp5" {> "7.99"}
   "ppxlib" {>= "0.12.0" }
   "menhir" {>= "20211230" }
   "re" {>= "1.7.2"}
@@ -25,6 +24,9 @@ depends: [
   "cmdliner" {with-test}
   "dune" {>= "2.2.0"}
   "conf-time" {with-test}
+]
+depopts: [
+  "camlp5" {> "7.99"}
 ]
 synopsis: "ELPI - Embeddable λProlog Interpreter"
 description: """

--- a/elpi.opam
+++ b/elpi.opam
@@ -18,6 +18,7 @@ depends: [
   "stdlib-shims"
   "camlp5" {> "7.99"}
   "ppxlib" {>= "0.12.0" }
+  "menhir" {>= "20211230" }
   "re" {>= "1.7.2"}
   "ppx_deriving" {>= "4.2"}
   "ANSITerminal" {with-test}

--- a/elpi.opam
+++ b/elpi.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.0" }
+  "ocaml" {>= "4.07.0" }
   "stdlib-shims"
   "ppxlib" {>= "0.12.0" }
   "menhir" {>= "20211230" }

--- a/elpi.opam
+++ b/elpi.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.0" & < "4.14.0"}
+  "ocaml" {>= "4.04.0" }
   "stdlib-shims"
   "ppxlib" {>= "0.12.0" }
   "menhir" {>= "20211230" }

--- a/src/API.ml
+++ b/src/API.ml
@@ -376,7 +376,7 @@ end
 module BuiltInData = struct
 
   let int    = snd @@ RawOpaqueData.conversion_of_cdata ~name:"int"    ~compare:(fun x y -> x - y) ~pp:(fun fmt x -> Util.CData.pp fmt (ED.C.int.Util.CData.cin x)) ED.C.int
-  let float  = snd @@ RawOpaqueData.conversion_of_cdata ~name:"float"  ~compare:Pervasives.compare (*Float.compare*)      ~pp:(fun fmt x -> Util.CData.pp fmt (ED.C.float.Util.CData.cin x)) ED.C.float
+  let float  = snd @@ RawOpaqueData.conversion_of_cdata ~name:"float"  ~compare:Float.compare      ~pp:(fun fmt x -> Util.CData.pp fmt (ED.C.float.Util.CData.cin x)) ED.C.float
   let string = snd @@ RawOpaqueData.conversion_of_cdata ~name:"string" ~compare:String.compare     ~pp:(fun fmt x -> Util.CData.pp fmt (ED.C.string.Util.CData.cin x)) ED.C.string
   let loc    = snd @@ RawOpaqueData.conversion_of_cdata ~name:"loc"    ~compare:Util.Loc.compare   ~pp:(fun fmt x -> Util.CData.pp fmt (ED.C.loc.Util.CData.cin x)) ED.C.loc
   let poly ty =
@@ -661,14 +661,6 @@ module FlexibleData = struct
     val show : t -> string
   end
 
-  module type HostWeak = sig
-    type t
-    val equal : t -> t -> bool
-    val hash : t -> int
-    val pp : Format.formatter -> t -> unit
-    val show : t -> string
-  end
-
     (* Bijective map between elpi UVar and host equivalent *)
   let uvmap_no = ref 0
   module Map = functor(T : Host) -> struct
@@ -763,86 +755,6 @@ module FlexibleData = struct
   end
 
   module type Show = Util.Show
-  module WeakMap = functor(T : HostWeak) -> functor (D : Show) -> struct
-
-    module H2E = Ephemeron.K1.Make(T)
-    module E2H = Ephemeron.K1.Make(Elpi)
-
-    type t = {
-        h2e : (Elpi.t * D.t) H2E.t;
-        e2h : (T.t * D.t) E2H.t;
-    }
-
-    let create n = {
-      h2e = H2E.create n;
-      e2h = E2H.create n;
-    }
-
-    let reset { h2e; e2h } = H2E.reset h2e; E2H.reset e2h
-
-    let add uv v d { h2e; e2h } =
-      H2E.replace h2e v (uv,d);
-      E2H.replace e2h uv (v,d)
-
-    let elpi v { h2e; e2h } =
-      H2E.find h2e v
-
-    let host e { h2e; e2h } =
-      E2H.find e2h e
-
-
-    let remove_both e v { h2e; e2h } = 
-      H2E.remove h2e v;
-      E2H.remove e2h e
-    let remove_elpi k m =
-      let v,_ = host k m in
-      remove_both k v m
-
-    let remove_host v m =
-      let e, _ = elpi v m in
-      remove_both e v m
-
-    let filter f { h2e; e2h } =
-      E2H.filter_map_inplace (fun e (v,d) -> if f v e d then Some(v,d) else None) e2h;
-      H2E.filter_map_inplace (fun v (e,d) -> if f v e d then Some(e,d) else None) h2e
-
-    let fold f { h2e } acc =
-      let module R = (val !r) in let open R in
-      let get_val = function
-        | Elpi.Ref { ED.Term.contents = ub }
-          when ub != ED.dummy ->
-            Some (deref_head ~depth:0 ub)
-        | Elpi.Ref _ -> None
-        | Elpi.Arg _ -> None in
-      H2E.fold (fun k (uk,d) acc -> f k uk (get_val uk) d acc) h2e acc
-
-    let uvn = incr uvmap_no; !uvmap_no
-
-    let pp fmt (m : t) =
-      let pp k uv _ d () =
-           Format.fprintf fmt "@[<h>%a@ <-> %a / %a@]@ " T.pp k Elpi.pp uv D.pp d
-        in
-      Format.fprintf fmt "@[<v>";
-      fold pp m ();
-      Format.fprintf fmt "@]"
-    ;;
-
-    let show m = Format.asprintf "%a" pp m
-
-    let uvmap = ED.State.declare ~name:(Printf.sprintf "elpi:weakuvm:%d" uvn) ~pp
-      ~clause_compilation_is_over:(fun x -> reset x; x)
-      ~goal_compilation_begins:(fun x -> x)
-      ~goal_compilation_is_over:(fun ~args { h2e; e2h } ->
-        let r = create 3 in
-        H2E.iter (fun v (e,d) -> H2E.add r.h2e v (Elpi.compilation_is_over ~args e,d)) h2e;
-        E2H.iter (fun e (v,d) -> E2H.add r.e2h (Elpi.compilation_is_over ~args e) (v,d)) e2h;
-        Some r)
-      ~compilation_is_over:(fun x -> Some x)
-      ~execution_is_over:(fun x -> Some x)
-      ~init:(fun () -> create 3)
-
-  end
-
   let uvar  = {
     Conversion.ty = Conversion.TyName "uvar";
     pp_doc = (fun fmt () -> Format.fprintf fmt "Unification variable, as the uvar keyword");

--- a/src/API.ml
+++ b/src/API.ml
@@ -2,6 +2,9 @@
 (* license: GNU Lesser General Public License Version 2.1 or later           *)
 (* ------------------------------------------------------------------------- *)
 
+open Elpi_util
+open Elpi_parser
+
 module type Runtime = (module type of Runtime_trace_off)
 
 let r = ref (module Runtime_trace_off : Runtime)
@@ -22,17 +25,27 @@ let set_trace argv =
 module Setup = struct
 
 type builtins = Compiler.builtins
-type elpi = Parser.parser_state * Compiler.header
+type elpi = {
+  parser : (module Parse.Parser);
+  resolver : ?cwd:string -> unit:string -> unit -> string;
+  header : Compiler.header
+}
 type flags = Compiler.flags
 
-let init ?(flags=Compiler.default_flags) ~builtins ?file_resolver () =
+let init ?(flags=Compiler.default_flags) ~builtins ?file_resolver ?(legacy_parser=false) () : elpi =
   (* At the moment we can only init the parser once *)
   let file_resolver =
     match file_resolver with
     | Some x -> x
-    | None -> fun ?cwd:_ ~file:_ () ->
+    | None -> fun ?cwd:_ ~unit:_ () ->
         raise (Failure "'accumulate' is disabled since Setup.init was not given a ~file_resolver.") in
-  let parsing_state = Parser.init ~lp_syntax:Parser.lp_gramext ~file_resolver in
+  let parser =
+    if legacy_parser then begin
+      if not Legacy_parser_proxy.valid then
+         Util.error "The legacy parser is not available (disabled at compile time)";
+      (module Legacy_parser_proxy.Make(struct let resolver = file_resolver end) : Parse.Parser)
+    end else
+      (module Parse.Make(struct let resolver = file_resolver end) : Parse.Parser) in
   Data.Global_symbols.lock ();
   let header_src =
     builtins |> List.map (fun (fname,decls) ->
@@ -42,23 +55,22 @@ let init ?(flags=Compiler.default_flags) ~builtins ?file_resolver () =
       Data.BuiltInPredicate.document fmt decls;
       Format.pp_print_flush fmt ();
       let text = Buffer.contents b in
-      let strm = Stream.of_string text in
-      let loc = Util.Loc.initial fname in
+      let lexbuf = Lexing.from_string text in
+      let module P = (val parser) in
       try
-        Parser.parse_program_from_stream parsing_state
-          ~print_accumulated_files:false loc strm
-      with Parser.ParseError(loc,msg) ->
+        P.program_from ~loc:(Util.Loc.initial fname) lexbuf
+      with Parse.ParseError(loc,msg) ->
         List.iteri (fun i s ->
           Printf.eprintf "%4d: %s\n" (i+1) s)
           (Re.Str.(split_delim (regexp_string "\n") text));
         Printf.eprintf "Excerpt of %s:\n%s\n" fname
           (String.sub text loc.Util.Loc.line_starts_at
             Util.Loc.(loc.source_stop - loc.line_starts_at));
-      Util.anomaly ~loc msg) in
+        Util.anomaly ~loc msg) in
   let header =
-    try Compiler.header_of_ast ~flags builtins (List.concat header_src)
+    try Compiler.header_of_ast ~flags ~parser builtins (List.concat header_src)
     with Compiler.CompileError(loc,msg) -> Util.anomaly ?loc msg in
-  (parsing_state, header)
+  { parser; header; resolver = file_resolver }
 
 let trace = set_trace
 
@@ -73,6 +85,7 @@ let set_std_formatter = Util.set_std_formatter
 let set_err_formatter fmt =
   Util.set_err_formatter fmt; Trace_ppx_runtime.Runtime.(set_trace_output TTY fmt)
 
+let legacy_parser_available = Legacy_parser_proxy.valid
 end
 
 module EA = Ast
@@ -81,19 +94,50 @@ module Ast = struct
   type program = Ast.Program.t
   type query = Ast.Goal.t
   module Loc = Util.Loc
+  module Goal = Ast.Goal
 end
 
 module Parse = struct
-  let program ~elpi:(ps,_) ?(print_accumulated_files=false) =
-    Parser.parse_program ps ~print_accumulated_files
-  let program_from_stream ~elpi:(ps,_) ?(print_accumulated_files=false) =
-    Parser.parse_program_from_stream ps ~print_accumulated_files
-  let goal loc s = Parser.parse_goal ~loc s
-  let goal_from_stream loc s = Parser.parse_goal_from_stream ~loc s
-  exception ParseError = Parser.ParseError
 
-  let resolve_file = Parser.resolve
-  let std_resolver = Parser.std_resolver
+  let eq_loc x y =
+    match x, y with
+    | { Util.Loc.source_name = n1; source_start = s1; source_stop = r1; line = l1; line_starts_at = bl1 },
+      { Util.Loc.source_name = n2; source_start = s2; source_stop = r2; line = l2; line_starts_at = bl2 } ->
+        n1 = n2 &&
+        s1 = s2 &&
+        r1 + 1 = r2 &&
+        l1 = l2 
+        (*bl1 - 1 = bl2*)
+
+  let eq x y =
+    match x,y with
+    | EA.Program.Clause { EA.Clause.loc = loc1; attributes = attributes1; body = body1 },
+      EA.Program.Clause { EA.Clause.loc = loc2; attributes = attributes2; body = body2 } ->
+        attributes1 = attributes2 &&
+        body1 = body2 &&
+        eq_loc loc1 loc2
+    | _ -> true
+
+  let program ~elpi:{ Setup.parser } ~files =
+    let module P = (val parser) in
+    List.(concat (map (fun file -> P.program ~file) files))
+
+  let program_from ~elpi:{ Setup.parser } ~loc buf =
+    let module P = (val parser) in
+    P.program_from ~loc buf
+
+  let goal ~elpi:{ Setup.parser } ~loc ~text =
+    let module P = (val parser) in
+    P.goal ~loc ~text
+  let goal_from ~elpi:{ Setup.parser } ~loc buf =
+    let module P = (val parser) in
+    P.goal_from ~loc buf
+
+  exception ParseError = Elpi_parser.Parser_config.ParseError
+
+  let resolve_file ~elpi:{ Setup.resolver } = resolver
+  let std_resolver = Elpi_util.Util.std_resolver
+
 end
 
 module ED = Data
@@ -128,7 +172,7 @@ module Compile = struct
 
   let to_setup_flags x = x
 
-  let program ?(flags=Compiler.default_flags) ~elpi:(_,header) l =
+  let program ?(flags=Compiler.default_flags) ~elpi:{ Setup.header } l =
     Compiler.program_of_ast ~flags ~header (List.flatten l)
 
   let query s_p t =
@@ -147,9 +191,9 @@ module Compile = struct
   }
   let default_flags = Compiler.default_flags
   let optimize = Compiler.optimize_query
-  let unit ?(flags=Compiler.default_flags) ~elpi:(_,header) x = Compiler.unit_of_ast ~flags ~header x
+  let unit ?(flags=Compiler.default_flags) ~elpi:{ Setup.header } x = Compiler.unit_of_ast ~flags ~header x
   let extend ?(flags=Compiler.default_flags) ~base ul = Compiler.append_units ~flags ~base ul
-  let assemble ?(flags=Compiler.default_flags) ~elpi:(_,header) = Compiler.assemble_units ~flags ~header
+  let assemble ?(flags=Compiler.default_flags) ~elpi:{ Setup.header } = Compiler.assemble_units ~flags ~header
 
 end
 
@@ -168,20 +212,21 @@ end
 module Pp = struct
   let term pp_ctx f t = (* XXX query depth *)
     let module R = (val !r) in let open R in
-    R.Pp.uppterm ~pp_ctx 0 [] ~argsdepth:0 [||] f t
+    Pp.uppterm ~pp_ctx 0 [] ~argsdepth:0 [||] f t
 
   let constraints pp_ctx f c =
     let module R = (val !r) in let open R in
-    Util.pplist ~boxed:true R.(pp_stuck_goal ~pp_ctx) "" f c
+    Util.pplist ~boxed:true (pp_stuck_goal ~pp_ctx) "" f c
 
   let state = ED.State.pp
 
   let query f c =
     let module R = (val !r) in let open R in
-    Compiler.pp_query (fun ~pp_ctx ~depth -> R.Pp.uppterm ~pp_ctx depth [] ~argsdepth:0 [||]) f c
+    Compiler.pp_query (fun ~pp_ctx ~depth -> Pp.uppterm ~pp_ctx depth [] ~argsdepth:0 [||]) f c
 
   module Ast = struct
     let program = EA.Program.pp
+    let query = EA.Goal.pp
   end
 end
 
@@ -248,14 +293,13 @@ module RawOpaqueData = struct
     state, cin x, [] in
   let readback ~depth state t =
     let module R = (val !r) in let open R in
-    match R.deref_head ~depth t with
+    match deref_head ~depth t with
     | ED.Term.CData c when isc c -> state, cout c, []
     | ED.Term.Const i as t when i < 0 ->
         begin try state, ED.Constants.Map.find i constants_map, []
         with Not_found -> raise (Conversion.TypeErr(ty,depth,t)) end
     | t -> raise (Conversion.TypeErr(ty,depth,t)) in
   let pp_doc fmt () =
-    let module R = (val !r) in let open R in
     if doc <> "" then begin
       ED.BuiltInPredicate.pp_comment fmt ("% " ^ doc);
       Format.fprintf fmt "@\n";
@@ -269,7 +313,6 @@ module RawOpaqueData = struct
   { Conversion.embed; readback; ty; pp_doc; pp }
 
   let conversion_of_cdata (type a) ~name ?doc ?(constants=[]) ~compare ~pp cd =
-    let module R = (val !r) in let open R in
     let module VM = Map.Make(struct type t = a let compare = compare end) in
     let constants_map, values_map =
       List.fold_right (fun (n,v) (cm,vm) ->
@@ -391,13 +434,13 @@ module BuiltInData = struct
     let ty = Conversion.(TyName ty) in
     let embed ~depth state (x,from) =
       let module R = (val !r) in let open R in
-      state, R.hmove ~from ~to_:depth ?avoid:None x, [] in
+      state, hmove ~from ~to_:depth ?avoid:None x, [] in
     let readback ~depth state t =
       state, fresh_copy t depth, [] in
     { Conversion.embed; readback; ty;
       pp = (fun fmt (t,d) ->
         let module R = (val !r) in let open R in
-        R.Pp.uppterm d [] d ED.empty_env fmt t);
+        Pp.uppterm d [] d ED.empty_env fmt t);
       pp_doc = (fun fmt () -> ()) }
    
   let map_acc f s l =
@@ -455,7 +498,7 @@ module Elpi = struct
         Format.fprintf fmt "%s" str
     | Ref ub ->
         let module R = (val !r) in let open R in
-        R.Pp.uppterm 0 [] 0 [||] fmt (ED.mkUVar ub 0 0)
+        Pp.uppterm 0 [] 0 [||] fmt (ED.mkUVar ub 0 0)
 
   let show m = Format.asprintf "%a" pp m
 
@@ -516,7 +559,6 @@ module RawData = struct
 
   type constant = ED.Term.constant
   type builtin = ED.Term.constant
-  type uvar_body = ED.Term.uvar_body
   type term = ED.Term.term
   type view =
     (* Pure subterms *)
@@ -534,7 +576,7 @@ module RawData = struct
 
   let rec look ~depth t =
     let module R = (val !r) in let open R in
-    match R.deref_head ~depth t with
+    match deref_head ~depth t with
     | ED.Term.Arg _ | ED.Term.AppArg _ -> assert false
     | ED.Term.AppUVar(ub,0,args) -> UnifVar (Ref ub,args)
     | ED.Term.AppUVar(ub,lvl,args) -> look ~depth (R.expand_appuv ub ~depth ~lvl ~args)
@@ -611,11 +653,9 @@ module RawData = struct
     goal : int * term
   }
 
-  type constraints = Data.constraints
-
   let constraints l =
     let module R = (val !r) in let open R in
-    Util.map_filter (fun x -> R.get_suspended_goal x.ED.kind) l
+    Util.map_filter (fun x -> get_suspended_goal x.ED.kind) l
   let no_constraints = []
 
   let mkUnifVar handle ~args state =
@@ -708,7 +748,7 @@ module FlexibleData = struct
       let get_val = function
         | Elpi.Ref { ED.Term.contents = ub }
           when ub != ED.dummy ->
-            Some (R.deref_head ~depth:0 ub)
+            Some (deref_head ~depth:0 ub)
         | Elpi.Ref _ -> None
         | Elpi.Arg _ -> None in
       H2E.fold (fun k uk acc -> f k uk (get_val uk) acc) h2e acc
@@ -743,7 +783,6 @@ module FlexibleData = struct
 
   module type Show = Util.Show
   module WeakMap = functor(T : HostWeak) -> functor (D : Show) -> struct
-    open Util
 
     module H2E = Ephemeron.K1.Make(T)
     module E2H = Ephemeron.K1.Make(Elpi)
@@ -791,7 +830,7 @@ module FlexibleData = struct
       let get_val = function
         | Elpi.Ref { ED.Term.contents = ub }
           when ub != ED.dummy ->
-            Some (R.deref_head ~depth:0 ub)
+            Some (deref_head ~depth:0 ub)
         | Elpi.Ref _ -> None
         | Elpi.Arg _ -> None in
       H2E.fold (fun k (uk,d) acc -> f k uk (get_val uk) d acc) h2e acc
@@ -866,7 +905,7 @@ module BuiltInPredicate = struct
     readback = (fun ~depth hyps csts state t ->
              let module R = (val !r) in let open R in
              let rec aux t =
-               match R.deref_head ~depth t with
+               match deref_head ~depth t with
                | ED.Term.Arg _ | ED.Term.AppArg _ -> assert false
                | ED.Term.UVar _ | ED.Term.AppUVar _
                | ED.Term.Discard -> state, NoData, []
@@ -891,7 +930,7 @@ module BuiltInPredicate = struct
              | NoData -> assert false);
     readback = (fun ~depth hyps csts state t ->
              let module R = (val !r) in let open R in
-             match R.deref_head ~depth t with
+             match deref_head ~depth t with
              | ED.Term.Arg _ | ED.Term.AppArg _ -> assert false
              | ED.Term.Discard -> state, NoData, []
              | _ -> let state, x, gls = a.readback ~depth hyps csts state t in
@@ -1015,10 +1054,10 @@ module Utils = struct
 
   let move ~from ~to_ t =
     let module R = (val !r) in let open R in
-    R.hmove ~from ~to_ ?avoid:None t
+    hmove ~from ~to_ ?avoid:None t
   let beta ~depth t args =
     let module R = (val !r) in let open R in
-    R.deref_appuv ~from:depth ~to_:depth ?avoid:None args t
+    deref_appuv ~from:depth ~to_:depth ?avoid:None args t
 
   let error = Util.error
   let type_error = Util.type_error
@@ -1030,7 +1069,7 @@ module Utils = struct
     let module Data = ED.Term in
     let module R = (val !r) in let open R in
     let rec aux d ctx t =
-      match R.deref_head ~depth:d t with
+      match deref_head ~depth:d t with
       | Data.Const i when i >= 0 && i < depth ->
           error "program_of_term: the term is not closed"
       | Data.Const i when i < 0 ->
@@ -1061,10 +1100,10 @@ module Utils = struct
       | Data.Discard -> Term.mkCon "_"
     in
     let attributes =
-      (match name with Some x -> [Clause.Name x] | None -> []) @
+      (match name with Some x -> [Name x] | None -> []) @
       (match graft with
-        | Some (`After,x) -> [Clause.After x]
-        | Some (`Before,x) -> [Clause.Before x]
+        | Some (`After,x) -> [After x]
+        | Some (`Before,x) -> [Before x]
         | None -> []) in
     [Program.Clause {
       Clause.loc = loc;
@@ -1084,18 +1123,18 @@ end
 module RawPp = struct
   let term depth fmt t =
     let module R = (val !r) in let open R in
-    R.Pp.uppterm depth [] 0 ED.empty_env fmt t
+    Pp.uppterm depth [] 0 ED.empty_env fmt t
 
   let constraints f c = 
     let module R = (val !r) in let open R in
-    Util.pplist ~boxed:true (R.pp_stuck_goal ?pp_ctx:None) "" f c
+    Util.pplist ~boxed:true (pp_stuck_goal ?pp_ctx:None) "" f c
 
   let list = Util.pplist
 
   module Debug = struct
     let term depth fmt t =
       let module R = (val !r) in let open R in
-      R.Pp.ppterm depth [] 0 ED.empty_env fmt t
+       Pp.ppterm depth [] 0 ED.empty_env fmt t
     let show_term = ED.show_term
   end
 end

--- a/src/API.ml
+++ b/src/API.ml
@@ -99,25 +99,6 @@ end
 
 module Parse = struct
 
-  let eq_loc x y =
-    match x, y with
-    | { Util.Loc.source_name = n1; source_start = s1; source_stop = r1; line = l1; line_starts_at = bl1 },
-      { Util.Loc.source_name = n2; source_start = s2; source_stop = r2; line = l2; line_starts_at = bl2 } ->
-        n1 = n2 &&
-        s1 = s2 &&
-        r1 + 1 = r2 &&
-        l1 = l2 
-        (*bl1 - 1 = bl2*)
-
-  let eq x y =
-    match x,y with
-    | EA.Program.Clause { EA.Clause.loc = loc1; attributes = attributes1; body = body1 },
-      EA.Program.Clause { EA.Clause.loc = loc2; attributes = attributes2; body = body2 } ->
-        attributes1 = attributes2 &&
-        body1 = body2 &&
-        eq_loc loc1 loc2
-    | _ -> true
-
   let program ~elpi:{ Setup.parser } ~files =
     let module P = (val parser) in
     List.(concat (map (fun file -> P.program ~file) files))

--- a/src/API.mli
+++ b/src/API.mli
@@ -795,41 +795,8 @@ module FlexibleData : sig
     val show : t -> string
   end
 
-  module type HostWeak = sig
-    type t
-    val equal : t -> t -> bool
-    val hash : t -> int
-    val pp : Format.formatter -> t -> unit
-    val show : t -> string
-  end
-
   module type Show = sig
     type t
-    val pp : Format.formatter -> t -> unit
-    val show : t -> string
-  end
-
-  (* Keys Elpi.t and Host.t are weak, if any goes loose the entry is removed.
-     The reference to D.t is strong (but held by the weak ones) *)
-  module WeakMap : functor(Host : HostWeak) -> functor (D : Show) -> sig
-    type t
-
-    val create : int -> t
-    val add : Elpi.t -> Host.t -> D.t -> t -> unit
-
-    val remove_elpi : Elpi.t -> t -> unit
-    val remove_host : Host.t -> t -> unit
-
-    val filter : (Host.t -> Elpi.t -> D.t -> bool) -> t -> unit
-
-    (* The eventual body at its depth *)
-    val fold : (Host.t -> Elpi.t -> Data.term option -> D.t -> 'a -> 'a) -> t -> 'a -> 'a
-
-    val elpi   : Host.t -> t -> Elpi.t * D.t
-    val host : Elpi.t -> t -> Host.t * D.t
-
-    val uvmap : t State.component
-
     val pp : Format.formatter -> t -> unit
     val show : t -> string
   end

--- a/src/API.mli
+++ b/src/API.mli
@@ -52,7 +52,7 @@ module Setup : sig
       @param file_resolver maps a file name to an absolute path, if not specified the
         options like [-I] or the env variable [TJPATH] serve as resolver. The
         resolver returns the abslute file name
-        (possibly adjusting the file extension). By default it fails.
+        (possibly adjusting the unit extension). By default it fails.
         See also {!val:Parse.std_resolver}.
 
       @return a handle [elpi] to an elpi instance equipped with the given
@@ -61,7 +61,8 @@ module Setup : sig
   val init :
     ?flags:flags ->
     builtins:builtins list ->
-    ?file_resolver:(?cwd:string -> file:string -> unit -> string) ->
+    ?file_resolver:(?cwd:string -> unit:string -> unit -> string) ->
+    ?legacy_parser:bool ->
     unit ->
     elpi
 
@@ -81,32 +82,37 @@ module Setup : sig
   val set_type_error : (?loc:Ast.Loc.t -> string -> 'a) -> unit
   val set_std_formatter : Format.formatter -> unit
   val set_err_formatter : Format.formatter -> unit
+
+  (** The legacy parser is an optional build dependency *)
+  val legacy_parser_available : bool
 end
 
 module Parse : sig
 
   (** [program file_list] parses a list of files,
       Raises Failure if the file does not exist. *)
-  val program : elpi:Setup.elpi -> ?print_accumulated_files:bool ->
-    string list -> Ast.program
-  val program_from_stream : elpi:Setup.elpi -> ?print_accumulated_files:bool ->
-    Ast.Loc.t -> char Stream.t -> Ast.program
+  val program : elpi:Setup.elpi ->
+    files:string list -> Ast.program
+  val program_from : elpi:Setup.elpi ->
+    loc:Ast.Loc.t -> Lexing.lexbuf -> Ast.program
 
   (** [goal file_list] parses the query,
       Raises Failure if the file does not exist.  *)
-  val goal : Ast.Loc.t -> string -> Ast.query
-  val goal_from_stream : Ast.Loc.t -> char Stream.t -> Ast.query
+  val goal : elpi:Setup.elpi ->
+    loc:Ast.Loc.t -> text:string -> Ast.query
+  val goal_from : elpi:Setup.elpi ->
+    loc:Ast.Loc.t -> Lexing.lexbuf -> Ast.query
 
   (** [resolve f] computes the full path of [f] as the parser would do (also)
       for files recursively accumulated. Raises Failure if the file does not
       exist. *)
-  val resolve_file : ?cwd:string -> file:string -> unit -> string
+  val resolve_file : elpi:Setup.elpi -> ?cwd:string -> unit:string -> unit -> string
 
   (** [std_resolver cwd paths ()] returns a resolver function that looks in cwd
       and paths (relative to cwd, or absolute) *)
   val std_resolver :
     ?cwd:string -> paths:string list -> unit ->
-      (?cwd:string -> file:string -> unit -> string)
+      (?cwd:string -> unit:string -> unit -> string)
 
   exception ParseError of Ast.Loc.t * string
 end
@@ -243,6 +249,7 @@ module Pp : sig
 
   module Ast : sig
     val program : Format.formatter -> Ast.program -> unit
+    val query : Format.formatter -> Ast.query -> unit
   end
 
 end
@@ -1087,7 +1094,7 @@ module Quotation : sig
 
   (** To implement the string_to_term built-in (AVOID, makes little sense
    * if depth is non zero, since bound variables have no name!) *)
-  val term_at : depth:int -> State.t -> Ast.query -> State.t * Data.term
+  val term_at : depth:int -> State.t -> string -> State.t * Data.term
 
   (** Like quotations but for identifiers that begin and end with
    * "`" or "'", e.g. `this` and 'that'. Useful if the object language

--- a/src/builtin.elpi
+++ b/src/builtin.elpi
@@ -102,13 +102,13 @@ type (div) int -> int -> int.
 
 type (^) string -> string -> string.
 
-type ~ int -> int.
+type (~) int -> int.
 
-type ~ float -> float.
+type (~) float -> float.
 
-type i~ int -> int.
+type (i~) int -> int.
 
-type r~ float -> float.
+type (r~) float -> float.
 
 type abs int -> int.
 
@@ -327,7 +327,7 @@ external pred lookahead i:in_stream, o:string.
 % [string_to_term S T] parses a term T from S
 external pred string_to_term i:string, o:any.
 
-% [readterm InStream T] reads T from InStream
+% [readterm InStream T] reads T from InStream, ends with \n
 external pred readterm i:in_stream, o:any.
 
 pred printterm i:out_stream, i:A.

--- a/src/builtin.ml
+++ b/src/builtin.ml
@@ -1516,6 +1516,10 @@ let std_builtins =
 
 
 let default_checker () =
-  let elpi = API.Setup.init ~builtins:[std_builtins] () in
-  let ast = API.Parse.program_from ~elpi ~loc:(API.Ast.Loc.initial "(checker)") (Lexing.from_string Builtin_checker.code) in
-  API.Compile.program ~flags:API.Compile.default_flags ~elpi [ast]
+  try
+    let elpi = API.Setup.init ~builtins:[std_builtins] () in
+    let ast = API.Parse.program_from ~elpi ~loc:(API.Ast.Loc.initial "(checker)") (Lexing.from_string Builtin_checker.code) in
+    API.Compile.program ~flags:API.Compile.default_flags ~elpi [ast]
+  with
+  | API.Parse.ParseError(loc,msg) -> API.Utils.anomaly ~loc msg
+  | API.Compile.CompileError(loc,msg) -> API.Utils.anomaly ?loc msg

--- a/src/compiler.mli
+++ b/src/compiler.mli
@@ -2,6 +2,9 @@
 (* license: GNU Lesser General Public License Version 2.1 or later           *)
 (* ------------------------------------------------------------------------- *)
 
+open Elpi_util
+open Elpi_parser
+
 open Util
 open Data
 
@@ -17,7 +20,7 @@ exception CompileError of Loc.t option * string
 type builtins = string * Data.BuiltInPredicate.declaration list
 
 type header
-val header_of_ast : flags:flags -> builtins list -> Ast.Program.t ->  header
+val header_of_ast : flags:flags -> parser:(module Parse.Parser) -> builtins list -> Ast.Program.t ->  header
 
 type program
 val program_of_ast : flags:flags -> header:header -> Ast.Program.t -> program
@@ -36,7 +39,7 @@ val query_of_data :
 
 val optimize_query : 'a query -> 'a executable
 
-val term_of_ast : depth:int -> State.t -> Loc.t * Ast.Term.t -> State.t * term
+val term_of_ast : depth:int -> State.t -> string -> State.t * term
 
 val pp_query : (pp_ctx:pp_ctx -> depth:int -> Format.formatter -> term -> unit) -> Format.formatter -> 'a query -> unit
 

--- a/src/data.ml
+++ b/src/data.ml
@@ -4,6 +4,9 @@
 
 (* Internal term representation *)
 
+open Elpi_util
+open Elpi_parser
+
 module Fmt = Format
 module F = Ast.Func
 open Util

--- a/src/data.ml
+++ b/src/data.ml
@@ -647,10 +647,14 @@ let term_of_extra_goal = function
   | RawGoal x -> x
   | x ->
       Util.anomaly (Printf.sprintf "Unprocessed extra_goal: %s.\nOnly %s and %s can be left unprocessed,\nplease call API.RawData.set_extra_goals_postprocessing.\n"
+        (* ocaml >= 4.08 | (Obj.Extension_constructor.(name (of_val x)))
+        (Obj.Extension_constructor.(name (of_val (Unify(dummy,dummy)))))
+        (Obj.Extension_constructor.(name (of_val (RawGoal dummy))))) *)
         (Obj.(extension_name (extension_constructor x)))
         (Obj.(extension_name (extension_constructor (Unify(dummy,dummy)))))
         (Obj.(extension_name (extension_constructor (RawGoal dummy)))))
-
+        [@ warning "-A"]
+        
 end
 
 module ContextualConversion = struct

--- a/src/dune
+++ b/src/dune
@@ -1,16 +1,26 @@
 (library
-  (name elpi)
   (public_name elpi)
   (preprocess (per_module
-    ((pps ppx_deriving.std) API ast data compiler)
+    ((pps ppx_deriving.std) API data compiler)
     ((pps ppx_deriving.std elpi.trace.ppx -- --cookie "elpi_trace=\"true\"") runtime)
     ((pps ppx_deriving.std elpi.trace.ppx -- --cookie "elpi_trace=\"false\"") runtime_trace_off)
-    ((action (run camlp5o -I . -I +camlp5 pa_extend.cmo pa_lexer.cmo %{input-file})) parser)
     ))
-  (libraries re.str camlp5.gramlib unix stdlib-shims)
-  (flags -linkall)
-  (modules elpi util parser ast compiler data ptmap builtin builtin_checker builtin_stdlib builtin_map builtin_set API runtime_trace_off runtime)
-  (private_modules util parser ast compiler data ptmap builtin_stdlib builtin_map builtin_set runtime runtime_trace_off)
+  (libraries re.str unix stdlib-shims elpi.parser elpi.util
+    (select legacy_parser_proxy.ml from
+      (elpi.legacy_parser -> legacy_parser_proxy.real.ml)
+      (-> legacy_parser_proxy.dummy.ml)))
+  ; (flags -linkall)
+  (modules
+    ; ----- public API ---------------------------------
+    elpi API builtin builtin_checker
+    ; ----- internal stuff -----------------------------
+    compiler data ptmap runtime_trace_off runtime
+    builtin_stdlib builtin_map builtin_set
+    legacy_parser_proxy)
+  (private_modules
+    compiler data ptmap runtime_trace_off runtime
+    builtin_stdlib builtin_map builtin_set
+    legacy_parser_proxy)
 )
 
 (rule (with-stdout-to builtin_stdlib.ml (progn

--- a/src/elpi-checker.elpi
+++ b/src/elpi-checker.elpi
@@ -264,12 +264,12 @@ typecheck-program P Q DeclaredTypes RC :-
 
 % ---------- warnings ------------------------------------------------------
 
-type `-> term -> int -> entry.
+type (->) term -> int -> entry.
 type variable term -> prop.
 
 mode (report-linear i).
 report-linear [].
-report-linear [V `-> 1 + uvar |NS] :- !,
+report-linear [V -> 1 + uvar |NS] :- !,
   pp V VN,
   if (not(rex_match "_" VN), not(rex_match ".*_" VN))
     (checking LOC,
@@ -278,13 +278,13 @@ report-linear [V `-> 1 + uvar |NS] :- !,
      warning LOC MSG)
     true,
   report-linear NS.
-report-linear [V `-> uvar |NS] :-
+report-linear [V -> uvar |NS] :-
   pp V VN,
   if (not(rex_match "_" VN), not(rex_match ".*_" VN))
     (checking LOC, MSG is VN ^" is unused", warning LOC MSG)
     true,
   report-linear NS.
-report-linear [_ `-> _ | NS] :- report-linear NS.
+report-linear [_ -> _ | NS] :- report-linear NS.
 
 type count A -> list B -> prop.
 count (lam F) E :- pi x\ count (F x) E.
@@ -294,7 +294,7 @@ count X E :- variable X, !, incr X E.
 count A _.
 
 mode (incr i i).
-incr X [X `-> K | _] :- add1 K.
+incr X [X -> K | _] :- add1 K.
 incr X [_ | XS] :- incr X XS.
 
 mode (add1 i).
@@ -302,9 +302,9 @@ add1 (uvar as K) :- K = 1 + FRESH_.
 add1 (1 + K) :- add1 K.
 
 check-non-linear [N|NS] (arg C) L :- pi x\
- (pp x N :- !) => (variable x) => check-non-linear NS (C x) [x `-> FRESH_ | L].
+ (pp x N :- !) => (variable x) => check-non-linear NS (C x) [x -> FRESH_ | L].
 check-non-linear [] (arg C) L :- pi x\
- (variable x) => check-non-linear NS (C x) [x `-> FRESH_ | L].
+ (variable x) => check-non-linear NS (C x) [x -> FRESH_ | L].
 check-non-linear _ C L :-
   count C L, report-linear L.
 

--- a/src/elpi-checker.elpi
+++ b/src/elpi-checker.elpi
@@ -263,13 +263,15 @@ typecheck-program P Q DeclaredTypes RC :-
              (typecheck P Q {gettimeofday} {std.length P} RC))).
 
 % ---------- warnings ------------------------------------------------------
+% elpi:skip 1
+infix >>> 141.
 
-type (->) term -> int -> entry.
+type (>>>) term -> int -> entry.
 type variable term -> prop.
 
 mode (report-linear i).
 report-linear [].
-report-linear [V -> 1 + uvar |NS] :- !,
+report-linear [(V >>> 1 + uvar) |NS] :- !,
   pp V VN,
   if (not(rex_match "_" VN), not(rex_match ".*_" VN))
     (checking LOC,
@@ -278,13 +280,13 @@ report-linear [V -> 1 + uvar |NS] :- !,
      warning LOC MSG)
     true,
   report-linear NS.
-report-linear [V -> uvar |NS] :-
+report-linear [(V >>> uvar) |NS] :-
   pp V VN,
   if (not(rex_match "_" VN), not(rex_match ".*_" VN))
     (checking LOC, MSG is VN ^" is unused", warning LOC MSG)
     true,
   report-linear NS.
-report-linear [_ -> _ | NS] :- report-linear NS.
+report-linear [(_ >>> _) | NS] :- report-linear NS.
 
 type count A -> list B -> prop.
 count (lam F) E :- pi x\ count (F x) E.
@@ -294,7 +296,7 @@ count X E :- variable X, !, incr X E.
 count A _.
 
 mode (incr i i).
-incr X [X -> K | _] :- add1 K.
+incr X [(X >>> K) | _] :- add1 K.
 incr X [_ | XS] :- incr X XS.
 
 mode (add1 i).
@@ -302,9 +304,9 @@ add1 (uvar as K) :- K = 1 + FRESH_.
 add1 (1 + K) :- add1 K.
 
 check-non-linear [N|NS] (arg C) L :- pi x\
- (pp x N :- !) => (variable x) => check-non-linear NS (C x) [x -> FRESH_ | L].
+ (pp x N :- !) => (variable x) => check-non-linear NS (C x) [(x >>> FRESH_) | L].
 check-non-linear [] (arg C) L :- pi x\
- (variable x) => check-non-linear NS (C x) [x -> FRESH_ | L].
+ (variable x) => check-non-linear NS (C x) [(x >>> FRESH_) | L].
 check-non-linear _ C L :-
   count C L, report-linear L.
 

--- a/src/legacy_parser/dune
+++ b/src/legacy_parser/dune
@@ -1,0 +1,8 @@
+(library
+  (name elpi_legacy_parser)
+  (public_name elpi.legacy_parser)
+  (optional)
+  (libraries elpi.util elpi.parser camlp5.gramlib)
+  (flags -w -A)
+  (preprocess (per_module ((action (run camlp5o -I . -I +camlp5 pa_extend.cmo pa_lexer.cmo %{input-file})) parser)))
+  (modules parser))

--- a/src/legacy_parser/parser.ml
+++ b/src/legacy_parser/parser.ml
@@ -801,10 +801,10 @@ let run_parser state f x =
   | Ploc.Exc(l,(Token.Error msg | Stream.Error msg)) ->
       let loc = of_ploc l in
       raise(ParseError(loc,msg))
+  | Ploc.Exc(l,NotInProlog(loc,s)) -> raise (ParseError(loc, "NotInProlog: " ^ s))
   | Ploc.Exc(l,e) ->
       let loc = of_ploc l in
       raise(ParseError(loc,"Unexpected exception: " ^ Printexc.to_string e))
-  | NotInProlog(loc,s) -> raise (ParseError(loc, "NotInProlog: " ^ s))
 ;;
 
 let parse_program s ~print_accumulated_files filenames : Program.t =

--- a/src/legacy_parser/parser.mli
+++ b/src/legacy_parser/parser.mli
@@ -2,6 +2,9 @@
 (* license: GNU Lesser General Public License Version 2.1 or later           *)
 (* ------------------------------------------------------------------------- *)
 
+open Elpi_util
+open Elpi_parser
+
 open Util
 open Ast
 
@@ -22,12 +25,8 @@ type parser_state
 (* Loads the basic grammar and sets the paths.
    Camlp5 limitation: the grammar is loaded once and forall. *)
 val init :
-  lp_syntax:gramext list ->
-  file_resolver:(?cwd:string -> file:string -> unit -> string) ->
+  file_resolver:(?cwd:string -> unit:string -> unit -> string) ->
     parser_state
-val std_resolver :
-  ?cwd:string -> paths:string list -> unit ->
-     (?cwd:string -> file:string -> unit -> string)
 
 (* BUG: extending the grammar is imperative, cannot be undone *)
 val parse_program : parser_state -> print_accumulated_files:bool -> string list -> Program.t
@@ -35,9 +34,7 @@ val parse_program_from_stream : parser_state -> print_accumulated_files:bool -> 
 val parse_goal : ?loc:Loc.t -> string -> Goal.t
 val parse_goal_from_stream : ?loc:Loc.t -> char Stream.t -> Goal.t
 
-val resolve : ?cwd:string -> file:string -> unit -> string
-
-exception ParseError of Loc.t * string
+val resolve : ?cwd:string -> unit:string -> unit -> string
 
 val get_literal : string -> string
 

--- a/src/legacy_parser_proxy.dummy.ml
+++ b/src/legacy_parser_proxy.dummy.ml
@@ -1,0 +1,7 @@
+module Make(C:Elpi_parser.Parse.Config) = struct
+  let program ~file:_ = assert false
+  let goal ~loc:_ ~text:_ = assert false
+  let program_from ~loc:_ _ = assert false
+  let goal_from ~loc:_ _ = assert false
+end
+let valid = false

--- a/src/legacy_parser_proxy.mli
+++ b/src/legacy_parser_proxy.mli
@@ -1,0 +1,7 @@
+
+open Elpi_parser
+
+module Make(C:Parse.Config) : Parse.Parser
+
+(** compile time deps were available *)
+val valid : bool

--- a/src/legacy_parser_proxy.real.ml
+++ b/src/legacy_parser_proxy.real.ml
@@ -1,0 +1,14 @@
+open Elpi_legacy_parser
+
+module Make(C:Elpi_parser.Parse.Config) = struct
+
+  let s = ref (Parser.init ~file_resolver:C.resolver)
+
+  let program ~file = Parser.parse_program !s ~print_accumulated_files:false [file]
+  let goal ~loc ~text = Parser.parse_goal ~loc text
+  
+  let program_from ~loc buf = Parser.parse_program_from_stream !s loc ~print_accumulated_files:false (Stream.from (fun i -> try Some (Lexing.lexeme_char buf i) with Invalid_argument _ -> None))
+  let goal_from ~loc buf = Parser.parse_goal_from_stream ~loc (Stream.from (fun i -> try Some (Lexing.lexeme_char buf i) with Invalid_argument _ -> None))
+end
+
+let valid = true

--- a/src/legacy_parser_proxy.real.ml
+++ b/src/legacy_parser_proxy.real.ml
@@ -7,8 +7,16 @@ module Make(C:Elpi_parser.Parse.Config) = struct
   let program ~file = Parser.parse_program !s ~print_accumulated_files:false [file]
   let goal ~loc ~text = Parser.parse_goal ~loc text
   
-  let program_from ~loc buf = Parser.parse_program_from_stream !s loc ~print_accumulated_files:false (Stream.from (fun i -> try Some (Lexing.lexeme_char buf i) with Invalid_argument _ -> None))
-  let goal_from ~loc buf = Parser.parse_goal_from_stream ~loc (Stream.from (fun i -> try Some (Lexing.lexeme_char buf i) with Invalid_argument _ -> None))
+  let program_from ~loc buf =
+    Parser.parse_program_from_stream !s loc ~print_accumulated_files:false (Stream.from (fun i ->
+      if i >= buf.Lexing.lex_buffer_len then buf.Lexing.refill_buff buf;
+      try Some (Lexing.lexeme_char buf i)
+      with Invalid_argument _ -> None))
+  let goal_from ~loc buf =
+    Parser.parse_goal_from_stream ~loc (Stream.from (fun i ->
+      if i >= buf.Lexing.lex_buffer_len then buf.Lexing.refill_buff buf;
+      try Some (Lexing.lexeme_char buf i)
+      with Invalid_argument _ -> None))
 end
 
 let valid = true

--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -1,0 +1,86 @@
+This parser is a standard LR parser based on Menhir.
+
+Tokens, token families and their precedence is described in
+[lexer_config.ml](lexer_config.ml). Out of that we generate:
+- `lexer.mll` filling in a [template](lexer.mll.in) which contains all other
+  lexical convention
+- [token_precedence.mly](token_precedence.mly) which is coalesced by Menhir
+  with [tokens.mly]([tokens.mly) and [grammar.mly](grammar.mly) in order to
+  build the LR parser
+
+The file [parse.ml](parse.ml) ties the recursion knot: `accumulate` calls the
+parser itself on another *file*. The parser needs to be abstracted
+(via an OCaml functor) over a file resolver, this is also done here. Finally
+this file holds a cache of already parsed files to preserve the old semantics.
+It also loads signature files when loading `.mod` files, for backward
+compatibility with Teyjus. The module type `Parser` is defined in
+[parse.mli](parse.mli), and is all that clients should use.
+
+The file [error_messages.txt](error_messages.txt) is maintained by a few
+targets in the root `Makefile` starting with `menhir-`, mainly
+`menhir-complete-errormsgs` and `menhir-strip-errormsgs`.
+
+Unit tests:
+- [test_lexer.ml](test_lexer.ml) tests some lexing rules
+- [test_parser.ml](test_parser.ml) tests some parsing rules
+
+While the grammar is not extensible token families are used to provide
+an open ended set of mixfix symbols. The relative precedence of a mixfix
+is given by their family which is identified by its prefix.
+
+When this parser encounters an mixfix declaration it outputs an error along
+these lines:
+```
+Mixfix directives are not supported by this parser.
+
+The parser is based on token families.
+A family is identified by some starting characters, for example
+a token '+-->' belongs to the family of '+'. There is no need
+to declare it.
+
+All the tokens of a family are parsed with the same precedence and
+associativity, for example 'x +--> y *--> z' is parsed as
+'x +--> (y *--> z)' since the family of '*' has higher precedence
+than the family of '+'.
+
+Here the table of tokens and token families.
+Token families are represented by the start symbols followed by '..'.
+Tokens of families marked with [*] cannot end with the starting symbol,
+eg `foo` is not an infix, while `foo is.
+The listing is ordered by increasing precedence.
+
+fixity                     | tokens / token families
+-------------------------- + -----------------------------------
+Infix   not   associative  | :-  ?-  
+Infix   right associative  | ;  
+Infix   right associative  | ,  
+Infix   right associative  | ->  
+Infix   right associative  | =>  
+Infix   not   associative  | =  ==  =<  r<  i<  s<  r=<  i=<  s=< 
+                             <..  r>  i>  s>  r>=  i>=  s>=  >.. 
+                             is  
+Infix   right associative  | ::  
+Infix   not   associative  | '.. [*]  
+Infix   left  associative  | ^..  r+  i+  s+  +..  -  r-  i-  s-  
+Infix   left  associative  | r*  i*  s*  *..  /  div  mod  
+Infix   right associative  | --..  
+Infix   not   associative  | `.. [*]  
+Infix   right associative  | ==..  
+Infix   right associative  | ||..  
+Infix   right associative  | &&..  
+Infix   left  associative  | #..  
+Prefix  not   associative  | r~  i~  ~..  
+Postfix not   associative  | ?..  
+
+If the token is a valid mixfix, and you want the file to stay compatible
+with Teyjus, you can ask Elpi to skip the directive. Eg:
+
+% elpi:skip 2  // skips the next two lines
+infixr ==> 120.
+infixr || 120.
+
+As a debugging facility one can ask Elpi to print the AST in order to
+verify how the text was parsed. Eg:
+
+echo 'X = a || b ==> c' | elpi -parse-term
+```

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -241,7 +241,7 @@ let cfloat =
   CData.(declare {
     data_name = "float";
     data_pp = (fun f x -> Fmt.fprintf f "%f" x);
-    data_compare = Pervasives.compare (*Float.compare*);
+    data_compare = Float.compare;
     data_hash = Hashtbl.hash;
     data_hconsed = false;
   })

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -100,13 +100,19 @@ let mkSeq l =
 
 exception NotInProlog of Loc.t * string
 
+let rec best_effort_pp = function
+ | Lam (x,t) -> "x\\" ^ best_effort_pp t
+ | CData c -> CData.show c
+ | Quoted _ -> "{{ .. }}"
+ | _ -> ".."
+
 let mkApp loc = function
 (* FG: for convenience, we accept an empty list of arguments *)
   | [(App _ | Const _ | Quoted _) as c] -> c
   | App(c,l1)::l2 -> App(c,l1@l2)
   | (Const _ | Quoted _) as c::l2 -> App(c,l2)
   | [] -> anomaly ~loc "empty application"
-  | x::_ -> raise (NotInProlog(loc,"syntax error: the head of an application must be a constant or a variable"))
+  | x::_ -> raise (NotInProlog(loc,"syntax error: the head of an application must be a constant or a variable, got: " ^ best_effort_pp x))
 
 let mkAppF loc c = function
   | [] -> anomaly ~loc "empty application"

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -2,8 +2,10 @@
 (* license: GNU Lesser General Public License Version 2.1 or later           *)
 (* ------------------------------------------------------------------------- *)
 
+open Elpi_util
 open Util
 
+module Loc = Loc
 module Func = struct
 
   module Self = struct
@@ -17,7 +19,6 @@ module Func = struct
    let rec aux = function
     | "nil" -> aux "[]"
     | "cons" -> aux "::"
-    | "&" -> aux ","
     | x ->
        try Hashtbl.find h x
        with Not_found -> Hashtbl.add h x x ; x
@@ -96,7 +97,6 @@ let mkSeq l =
   | hd::tl -> App(Const Func.consf,[hd;aux tl])
  in
   aux l
-let mkIs x f = App(Const Func.isf,[x;f])
 
 exception NotInProlog of Loc.t * string
 
@@ -105,8 +105,13 @@ let mkApp loc = function
   | [(App _ | Const _ | Quoted _) as c] -> c
   | App(c,l1)::l2 -> App(c,l1@l2)
   | (Const _ | Quoted _) as c::l2 -> App(c,l2)
-  | [] -> raise (NotInProlog(loc,"empty application"))
-  | x::_ -> raise (NotInProlog(loc,"application head: " ^ show x))
+  | [] -> anomaly ~loc "empty application"
+  | x::_ -> raise (NotInProlog(loc,"syntax error: the head of an application must be a constant or a variable"))
+
+let mkAppF loc c = function
+  | [] -> anomaly ~loc "empty application"
+  | args -> App(Const c,args)
+
 
 let fresh_uv_names = ref (-1);;
 let mkFreshUVar () = incr fresh_uv_names; Const (Func.from_string ("_" ^ string_of_int !fresh_uv_names))
@@ -116,15 +121,16 @@ let mkCon c = Const (Func.from_string c)
 
 end
 
+type raw_attribute =
+  | If of string
+  | Name of string
+  | After of string
+  | Before of string
+  | External
+  | Index of int list
+[@@deriving show]
 
 module Clause = struct
-
-  type attribute =
-    | Name of string
-    | After of string
-    | Before of string
-    | If of string
-  [@@deriving show]
   
   type ('term,'attributes) t = {
     loc : Loc.t;
@@ -136,11 +142,6 @@ module Clause = struct
 end
 
 module Chr = struct
-
-  type attribute =
-    | Name of string
-    | If of string
-  [@@deriving show]
   
   type sequent = { eigen : Term.t; context : Term.t; conclusion : Term.t }
   and 'attribute t = {
@@ -151,7 +152,9 @@ module Chr = struct
     attributes : 'attribute;
     loc: Loc.t;
   }
-  [@@deriving show, create]
+  [@@deriving show]
+
+
 
 end
 
@@ -167,12 +170,6 @@ module Macro = struct
 end
 
 module Type = struct
-
-  type attribute =
-    | External
-    | Index of int list (* depth *)
-  [@@deriving show]
-  
 
   type 'attribute t = {
     loc : Loc.t;
@@ -208,23 +205,25 @@ module Program = struct
     | Begin of Loc.t
     | Namespace of Loc.t * Func.t
     | Constraint of Loc.t * Func.t list
-    | Shorten of Loc.t * Func.t * Func.t (* prefix suffix *)
+    | Shorten of Loc.t * (Func.t * Func.t) list (* prefix suffix *)
     | End of Loc.t
 
-    | Accumulated of Loc.t * (Digest.t * decl list)
+    | Accumulated of Loc.t * (Digest.t * decl list) list
 
     (* data *)
-    | Clause of (Term.t, Clause.attribute list) Clause.t
-    | Local of Func.t
+    | Clause of (Term.t, raw_attribute list) Clause.t
+    | Local of Func.t list
     | Mode of Func.t Mode.t list
-    | Chr of Chr.attribute list Chr.t
+    | Chr of raw_attribute list Chr.t
     | Macro of (Func.t, Term.t) Macro.t
-    | Type of Type.attribute list Type.t
+    | Type of raw_attribute list Type.t list
+    | Pred of raw_attribute list Type.t * Func.t Mode.t
     | TypeAbbreviation of Func.t TypeAbbreviation.t
+    | Ignored of Loc.t
   [@@deriving show]
 
 
-let mkLocal x = Local (Func.from_string x)
+let mkLocal x = Local (List.map Func.from_string x)
 
 type t = decl list [@@deriving show]
 
@@ -238,7 +237,7 @@ end
  
 module Fmt = Format
 
-let { CData.cin = in_float; isc = is_float; cout = out_float } as cfloat =
+let cfloat =
   CData.(declare {
     data_name = "float";
     data_pp = (fun f x -> Fmt.fprintf f "%f" x);
@@ -246,7 +245,7 @@ let { CData.cin = in_float; isc = is_float; cout = out_float } as cfloat =
     data_hash = Hashtbl.hash;
     data_hconsed = false;
   })
-let { CData.cin = in_int; isc = is_int; cout = out_int } as cint =
+let cint =
   CData.(declare {
     data_name = "int";
     data_pp = (fun f x -> Fmt.fprintf f "%d" x);
@@ -254,7 +253,7 @@ let { CData.cin = in_int; isc = is_int; cout = out_int } as cint =
     data_hash = Hashtbl.hash;
     data_hconsed = false;
   })
-let { CData.cin = in_string; isc = is_string; cout = out_string } as cstring =
+let cstring =
   CData.(declare {
     data_name = "string";
     data_pp = (fun f x -> Fmt.fprintf f "%s" x);
@@ -262,7 +261,7 @@ let { CData.cin = in_string; isc = is_string; cout = out_string } as cstring =
     data_hash = Hashtbl.hash;
     data_hconsed = true;
   })
-let { CData.cin = in_loc; isc = is_loc; cout = out_loc } as cloc =
+let cloc =
   CData.(declare {
     data_name = "Loc.t";
     data_pp = Util.Loc.pp;
@@ -298,7 +297,7 @@ and cattribute = {
 }
 and tattribute =
   | External
-  | Indexed of int list
+  | Index of int list
 and 'a shorthand = {
   iloc : Loc.t;
   full_name : 'a;

--- a/src/parser/dune
+++ b/src/parser/dune
@@ -1,0 +1,44 @@
+(library
+  (name elpi_parser)
+  (public_name elpi.parser)
+  (preprocess (per_module ((pps ppx_deriving.std) ast)))
+  (libraries unix menhirLib elpi_lexer_config elpi.util stdlib-shims)
+  (modules ast grammar lexer parser_config error_messages parse))
+
+(library
+  (name elpi_lexer_config)
+  (public_name elpi.lexer_config)
+  (libraries elpi.util)
+  (modules tokens lexer_config))
+
+(executable
+  (name gen_token_precedence)
+  (modules gen_token_precedence)
+  (libraries elpi.lexer_config))
+
+(executable
+  (name gen_infix_lexer)
+  (modules gen_infix_lexer)
+  (libraries elpi.lexer_config str))
+
+(menhir (modules tokens) (flags --only-tokens))
+(menhir (modules grammar tokens token_precedence) (flags --external-tokens Elpi_lexer_config.Tokens --exn-carries-state) (merge_into grammar))
+(ocamllex (modules lexer))
+
+(rule
+;  (mode promote)
+  (action (with-stdout-to lexer.mll
+    (run %{project_root}/src/parser/gen_infix_lexer.exe %{dep:lexer.mll.in}))))
+
+(rule
+  (mode promote) ; needed by --list-errors
+  (action (with-stdout-to token_precedence.mly
+    (run %{project_root}/src/parser/gen_token_precedence.exe))))
+
+(rule
+  (action (with-stdout-to error_messages.ml
+    (run menhir %{dep:tokens.mly} %{dep:grammar.mly} %{dep:token_precedence.mly}
+      --base grammar --compile-errors %{dep:error_messages.txt} ))))
+
+(test (name test_lexer) (libraries elpi_parser str) (modules test_lexer) (preprocess (pps ppx_deriving.std)))
+(test (name test_parser) (libraries elpi_parser str menhirLib) (modules test_parser) (preprocess (pps ppx_deriving.std)))

--- a/src/parser/error_messages.txt
+++ b/src/parser/error_messages.txt
@@ -1,0 +1,493 @@
+goal: FAMILY_TILDE VDASH
+program: FAMILY_TILDE VDASH
+goal: LBRACKET FAMILY_TILDE VDASH
+
+This prefix operator expects an argument.
+
+goal: CONSTANT FAMILY_TIMES VDASH
+goal: CONSTANT FAMILY_MINUS VDASH
+goal: CONSTANT FAMILY_LT VDASH
+goal: CONSTANT FAMILY_EXP VDASH
+goal: CONSTANT FAMILY_BTICK VDASH
+goal: CONSTANT FAMILY_GT VDASH
+goal: CONSTANT FAMILY_EQ VDASH
+goal: CONSTANT FAMILY_AND VDASH
+goal: CONSTANT FAMILY_SHARP VDASH
+goal: CONSTANT FAMILY_TICK VDASH
+goal: CONSTANT SLASH VDASH
+goal: CONSTANT IS VDASH
+program: AFTER IS VDASH
+program: AFTER FAMILY_PLUS VDASH
+program: AFTER FAMILY_TIMES VDASH
+goal: LBRACKET AFTER FAMILY_TIMES VDASH
+program: AFTER FAMILY_TICK VDASH
+program: AFTER SLASH VDASH
+program: AFTER FAMILY_SHARP VDASH
+program: AFTER FAMILY_OR VDASH
+program: AFTER FAMILY_MINUS VDASH
+program: AFTER FAMILY_LT VDASH
+program: AFTER FAMILY_GT VDASH
+program: AFTER FAMILY_EXP VDASH
+program: AFTER FAMILY_EQ VDASH
+program: AFTER FAMILY_BTICK VDASH
+program: AFTER FAMILY_AND VDASH
+goal: LBRACKET AFTER FAMILY_EQ VDASH
+goal: LBRACKET AFTER FAMILY_GT VDASH
+goal: LBRACKET AFTER FAMILY_BTICK VDASH
+goal: LBRACKET AFTER FAMILY_LT VDASH
+goal: LBRACKET AFTER FAMILY_EXP VDASH
+goal: LBRACKET AFTER FAMILY_MINUS VDASH
+goal: LBRACKET AFTER FAMILY_OR VDASH
+goal: LBRACKET AFTER FAMILY_PLUS VDASH
+goal: LBRACKET AFTER FAMILY_AND VDASH
+goal: LBRACKET AFTER SLASH VDASH
+goal: LBRACKET AFTER FAMILY_TICK VDASH
+goal: LBRACKET AFTER FAMILY_SHARP VDASH
+goal: AFTER FAMILY_OR VDASH
+goal: AFTER FAMILY_PLUS VDASH
+program: AFTER DARROW VDASH
+program: AFTER QDASH VDASH
+program: AFTER OR VDASH
+program: AFTER MOD VDASH
+program: AFTER EQ VDASH
+program: AFTER DIV VDASH
+program: AFTER CONS VDASH
+program: AFTER CONJ VDASH
+program: AFTER ARROW VDASH
+program: AFTER VDASH VDASH
+goal: LBRACKET AFTER CONS VDASH
+goal: LBRACKET AFTER DIV VDASH
+goal: LBRACKET AFTER MOD VDASH
+goal: AFTER VDASH VDASH
+goal: AFTER MOD VDASH
+goal: AFTER DIV VDASH
+goal: AFTER CONS VDASH
+goal: AFTER OR VDASH
+goal: AFTER EQ VDASH
+goal: AFTER DARROW VDASH
+goal: AFTER CONJ VDASH
+goal: AFTER ARROW VDASH
+goal: AFTER QDASH VDASH
+goal: LBRACKET AFTER VDASH VDASH
+goal: LBRACKET AFTER OR VDASH
+goal: LBRACKET AFTER IS VDASH
+goal: LBRACKET AFTER EQ VDASH
+goal: LBRACKET AFTER DARROW VDASH
+goal: LBRACKET AFTER ARROW VDASH
+goal: LBRACKET AFTER QDASH VDASH
+goal: LPAREN AFTER AS VDASH
+goal: AFTER BIND VDASH
+goal: LBRACKET AFTER CONJ VDASH
+goal: LBRACKET AFTER BIND VDASH
+goal: AFTER MINUSs VDASH
+goal: AFTER MINUSr VDASH
+goal: AFTER MINUSi VDASH
+goal: AFTER MINUS VDASH
+goal: AFTER EQ2 VDASH
+goal: LBRACKET AFTER MINUSs VDASH
+goal: LBRACKET AFTER MINUSr VDASH
+goal: LBRACKET AFTER MINUSi VDASH
+goal: LBRACKET AFTER MINUS VDASH
+goal: LBRACKET AFTER EQ2 VDASH
+program: AFTER MINUSs VDASH
+program: AFTER MINUSr VDASH
+program: AFTER MINUSi VDASH
+program: AFTER MINUS VDASH
+program: AFTER EQ2 VDASH
+
+This infix operator expects a right hand side.
+
+program: VDASH
+program: CONSTANT FULLSTOP VDASH
+
+Unexpected start of program clause or declaration.
+
+program: CONSTANT RPAREN
+
+Unexpected ')'.
+
+goal: AFTER USE_SIG
+program: AFTER FAMILY_QMARK USE_SIG
+program: AFTER VDASH FLOAT USE_SIG
+program: AFTER FAMILY_TIMES FLOAT USE_SIG
+program: AFTER FAMILY_TICK FLOAT USE_SIG
+program: AFTER SLASH FLOAT USE_SIG
+program: AFTER FAMILY_SHARP FLOAT USE_SIG
+program: AFTER FAMILY_PLUS FLOAT USE_SIG
+program: AFTER FAMILY_OR FLOAT USE_SIG
+program: AFTER FAMILY_MINUS FLOAT USE_SIG
+program: AFTER FAMILY_LT FLOAT USE_SIG
+program: AFTER FAMILY_GT FLOAT USE_SIG
+program: AFTER FAMILY_EXP FLOAT USE_SIG
+program: AFTER FAMILY_EQ FLOAT USE_SIG
+program: AFTER FAMILY_BTICK FLOAT USE_SIG
+program: AFTER FAMILY_AND FLOAT USE_SIG
+program: AFTER QDASH FLOAT USE_SIG
+program: AFTER OR FLOAT USE_SIG
+program: AFTER MOD FLOAT USE_SIG
+program: AFTER IS FLOAT USE_SIG
+program: AFTER EQ FLOAT USE_SIG
+program: AFTER DIV FLOAT USE_SIG
+program: AFTER DARROW FLOAT USE_SIG
+program: AFTER CONS FLOAT USE_SIG
+program: AFTER CONJ FLOAT USE_SIG
+program: AFTER ARROW FLOAT USE_SIG
+program: LPAREN USE_SIG
+program: LPAREN FLOAT USE_SIG
+goal: LBRACKET AFTER VDASH FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_TIMES FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_SHARP FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_TICK FLOAT USE_SIG
+goal: LBRACKET AFTER SLASH FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_AND FLOAT USE_SIG
+goal: LBRACKET AFTER MOD FLOAT USE_SIG
+goal: LBRACKET AFTER DIV FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_PLUS FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_OR FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_MINUS FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_EXP FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_LT FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_BTICK FLOAT USE_SIG
+goal: LBRACKET AFTER CONS FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_GT FLOAT USE_SIG
+goal: LBRACKET AFTER FAMILY_EQ FLOAT USE_SIG
+goal: LBRACKET AFTER BIND FLOAT USE_SIG
+goal: LBRACKET AFTER OR FLOAT USE_SIG
+goal: LBRACKET AFTER IS FLOAT USE_SIG
+goal: LBRACKET AFTER EQ FLOAT USE_SIG
+goal: LBRACKET PIPE FLOAT USE_SIG
+goal: LBRACKET FLOAT USE_SIG
+goal: LCURLY FLOAT USE_SIG
+goal: FAMILY_TILDE FLOAT USE_SIG
+goal: LPAREN AFTER AS FLOAT USE_SIG
+goal: FLOAT USE_SIG
+goal: AFTER QDASH FLOAT USE_SIG
+goal: LBRACKET AFTER USE_SIG
+goal: AFTER OR FLOAT USE_SIG
+goal: AFTER IS FLOAT USE_SIG
+goal: AFTER CONS FLOAT USE_SIG
+goal: AFTER FAMILY_GT FLOAT USE_SIG
+goal: AFTER FAMILY_EQ FLOAT USE_SIG
+goal: AFTER DIV FLOAT USE_SIG
+goal: AFTER FAMILY_PLUS FLOAT USE_SIG
+goal: AFTER FAMILY_OR FLOAT USE_SIG
+goal: AFTER FAMILY_MINUS FLOAT USE_SIG
+goal: AFTER FAMILY_EXP FLOAT USE_SIG
+goal: AFTER FAMILY_LT FLOAT USE_SIG
+goal: AFTER FAMILY_BTICK FLOAT USE_SIG
+goal: LBRACKET FAMILY_TILDE FLOAT USE_SIG
+goal: LBRACKET LPAREN AFTER RPAREN USE_SIG
+goal: AFTER VDASH FLOAT USE_SIG
+goal: AFTER FAMILY_TIMES FLOAT USE_SIG
+goal: AFTER FAMILY_SHARP FLOAT USE_SIG
+goal: LPAREN AFTER RPAREN USE_SIG
+goal: AFTER AFTER USE_SIG
+goal: AFTER FAMILY_TICK FLOAT USE_SIG
+goal: AFTER SLASH FLOAT USE_SIG
+goal: AFTER FAMILY_AND FLOAT USE_SIG
+goal: AFTER BIND FLOAT USE_SIG
+goal: AFTER MOD FLOAT USE_SIG
+goal: AFTER EQ FLOAT USE_SIG
+goal: AFTER DARROW FLOAT USE_SIG
+goal: AFTER CONJ FLOAT USE_SIG
+goal: AFTER ARROW FLOAT USE_SIG
+goal: LBRACKET AFTER DARROW FLOAT USE_SIG
+goal: LBRACKET AFTER ARROW FLOAT USE_SIG
+goal: LBRACKET AFTER QDASH FLOAT USE_SIG
+goal: LBRACKET AFTER PIPE FLOAT USE_SIG
+program: FAMILY_TILDE FLOAT USE_SIG
+goal: LPAREN LBRACKET RBRACKET USE_SIG
+program: LPAREN AFTER RPAREN USE_SIG
+goal: AFTER MINUSs FLOAT USE_SIG
+goal: AFTER MINUSr FLOAT USE_SIG
+goal: AFTER MINUSi FLOAT USE_SIG
+goal: AFTER MINUS FLOAT USE_SIG
+goal: AFTER EQ2 FLOAT USE_SIG
+goal: LBRACKET AFTER MINUSs FLOAT USE_SIG
+goal: LBRACKET AFTER MINUSr FLOAT USE_SIG
+goal: LBRACKET AFTER MINUSi FLOAT USE_SIG
+goal: LBRACKET AFTER MINUS FLOAT USE_SIG
+goal: LBRACKET AFTER EQ2 FLOAT USE_SIG
+program: AFTER MINUSs FLOAT USE_SIG
+program: AFTER MINUSr FLOAT USE_SIG
+program: AFTER MINUSi FLOAT USE_SIG
+program: AFTER MINUS FLOAT USE_SIG
+program: AFTER EQ2 FLOAT USE_SIG
+
+Term expected, got keyword.
+
+goal: LPAREN USE_SIG
+goal: LPAREN FAMILY_TILDE VDASH
+
+Mixfix symbol or term expected.
+
+goal: LPAREN AS VDASH
+
+Malformed as binding. Examples:
+(f X as Y)
+([_,_|_] as Y)
+
+goal: VDASH
+goal: LCURLY VDASH
+goal: LBRACKET VDASH
+
+Term expected.
+
+goal: LPAREN ARROW VDASH
+
+Right parenthesis ')' expected.
+
+infix_SYMB: USE_SIG
+
+Infix symbol expected.
+
+postfix_SYMB: VDASH
+
+Postifx symbol expected.
+
+prefix_SYMB: VDASH
+
+Prefix symbol expected.
+
+program: MODE VDASH
+program: MODE LPAREN VDASH
+program: MODE LPAREN AFTER VDASH
+program: MODE LPAREN AFTER IO VDASH
+program: MODE LPAREN AFTER IO RPAREN VDASH
+
+Malformed mode declaration. Example:
+mode (foo i i o).
+
+program: MACRO VDASH
+program: MACRO FLOAT USE_SIG
+program: MACRO AFTER VDASH VDASH
+program: MACRO AFTER VDASH FLOAT USE_SIG
+
+Malformed macro declaration. Example:
+macro @foo X Y :- p X => q Y.
+
+program: COLON VDASH
+
+Attribute expected. Examples:
+:name "some name"
+:index (_ 1 1)
+
+program: COLON NAME VDASH
+
+Malformed 'name' attribute. Example:
+:name "name of the clause"
+
+program: COLON INDEX VDASH
+program: COLON INDEX LPAREN VDASH
+program: COLON INDEX LPAREN FRESHUV VDASH
+
+Malformed 'index' attribute. Example:
+:index(1 _ 1)
+
+program: COLON IF VDASH
+
+Malformed 'if' attribute. Example:
+:if "VARIABLE"
+
+program: COLON BEFORE VDASH
+program: COLON AFTER VDASH
+
+Malformed grafting attribute. Example:
+:before "some name"
+:after "some other name"
+
+program: COLON EXTERNAL VDASH
+program: COLON EXTERNAL COLON VDASH
+
+Malformed 'external' attribute. Example:
+:external pred
+
+program: TYPE VDASH
+program: TYPE AFTER TYPE
+program: TYPE AFTER AFTER RPAREN
+
+Malformed type declaration. Examples:
+type app tm -> tm -> tm.
+type lam (tm -> tm) -> tm.
+type (++) list A -> list A -> list A.
+
+program: RULE LPAREN USE_SIG
+program: RULE LPAREN AFTER USE_SIG
+program: RULE VDASH
+program: RULE IFF AFTER VDASH
+program: RULE LPAREN AFTER COLON VDASH
+program: RULE LPAREN AFTER COLON FLOAT USE_SIG
+program: RULE AFTER VDASH
+program: RULE BIND VDASH
+program: RULE BIND AFTER VDASH
+program: RULE PIPE VDASH
+program: RULE PIPE FLOAT USE_SIG
+program: RULE IFF VDASH
+
+Malformed CHR rule declaration. Examples:
+rule (match this).
+rule (match this) \ (remove that).
+rule (match this) \ (remove that) | (only when).
+rule (match this) \ (remove that) | (only when) <=> (add this).
+
+program: ACCUMULATE VDASH
+program: ACCUMULATE AFTER CONJ VDASH
+program: ACCUMULATE LPAREN USE_SIG
+program: ACCUMULATE AFTER VDASH
+
+Malformed accumulate. Examples:
+accumulate foo.
+accumulate foo, bar.
+accumulate "foo/bar".
+
+goal: LBRACKET AFTER AFTER RPAREN
+
+Closing '[' with ')'.
+
+goal: LBRACKET PIPE VDASH
+goal: LBRACKET AFTER PIPE VDASH
+
+List expected. Examples:
+[ this , that | More ].
+[ Head | Tail ].
+
+program: TYPEABBREV VDASH
+program: TYPEABBREV LPAREN USE_SIG
+program: TYPEABBREV LPAREN AFTER AFTER VDASH
+program: TYPEABBREV AFTER VDASH
+program: TYPEABBREV AFTER AFTER RPAREN
+program: TYPEABBREV LPAREN AFTER VDASH
+
+Type abbreviation expected. Examples:
+typeabbrev context (list term).
+typeabbrev (two A) (pair A A).
+
+program: SHORTEN VDASH
+program: SHORTEN AFTER FULLSTOP LCURLY AFTER RCURLY VDASH
+program: SHORTEN AFTER VDASH
+program: SHORTEN AFTER FULLSTOP VDASH
+program: SHORTEN AFTER FULLSTOP LCURLY VDASH
+program: SHORTEN AFTER FULLSTOP LCURLY AFTER FULLSTOP LCURLY AFTER RCURLY VDASH
+program: SHORTEN AFTER FULLSTOP LCURLY AFTER CONJ VDASH
+program: SHORTEN AFTER FULLSTOP LCURLY AFTER VDASH
+program: SHORTEN AFTER FULLSTOP LCURLY AFTER FULLSTOP VDASH
+program: SHORTEN AFTER FULLSTOP LCURLY AFTER FULLSTOP LCURLY VDASH
+
+Shortening directive expected. Examples:
+shorten foo.{ bar }.
+shorten foo.{ bar , baz }.
+shorten foo.{ bar , baz. { qux , dim } }.
+
+program: NAMESPACE VDASH
+program: NAMESPACE AFTER VDASH
+
+Namespace header expected. Examples:
+namespace foo {
+
+program: LOCAL VDASH
+program: LOCAL AFTER TYPE
+program: LOCAL AFTER AFTER RPAREN
+
+Local symbol declaration expected. Examples:
+local foo.
+local foo, bar.
+local foo (term -> term).
+
+program: KIND VDASH
+program: KIND AFTER SIGMA
+program: KIND AFTER TYPE VDASH
+program: KIND AFTER TYPE ARROW VDASH
+
+Kind declaration expected. Examples:
+kind term  type.
+kind list  type -> type.
+
+program: CONSTRAINT VDASH
+program: CONSTRAINT AFTER VDASH
+
+Constraint Handling Rule header expected. Examples:
+constraint foo {
+constraint foo bar {
+
+program: EXTERNAL VDASH
+
+External declaration expected. Examples:
+external type foo term -> prop.
+external pred foo i:term.
+
+program: AFTER AFTER RPAREN
+
+Unexpected ')'.
+
+program: PRED VDASH
+program: PRED AFTER VDASH
+program: PRED AFTER IO COLON AFTER CONJ VDASH
+program: PRED AFTER IO VDASH
+program: PRED AFTER IO COLON VDASH
+program: PRED AFTER IO COLON AFTER RPAREN
+
+Predicate declaration expected. Examples:
+pred append i:list A, i:list A, o:list A.
+pred map i:list A, i:(A -> B -> prop), o:list B.
+
+program: EXPORTDEF AFTER LPAREN USE_SIG
+program: EXPORTDEF AFTER LPAREN AFTER FULLSTOP
+program: EXPORTDEF AFTER AFTER ARROW VDASH
+program: EXPORTDEF AFTER AFTER ARROW LPAREN AFTER RPAREN VDASH
+program: EXPORTDEF AFTER AFTER VDASH
+program: EXPORTDEF AFTER AFTER LPAREN USE_SIG
+program: EXPORTDEF AFTER AFTER LPAREN AFTER FULLSTOP
+program: EXPORTDEF AFTER AFTER AFTER VDASH
+program: EXPORTDEF VDASH
+program: EXPORTDEF AFTER TYPE
+program: EXPORTDEF AFTER AFTER RPAREN
+
+Definition export directive expected (Teyjus compatibility, ignored by Elpi).
+Examples:
+exportdef foo, bar.
+exportdef foo  (term -> term).
+
+program: SIG VDASH
+program: MODULE VDASH
+program: MODULE AFTER VDASH
+
+Module/Signature header expected (Teyjus compatibility, ignored by Elpi).
+Examples:
+module foo.
+sig bar.
+
+program: LOCALKIND VDASH
+
+Local kind declaration expected (Teyjus compatibility, ignored by Elpi).
+Examples:
+localkind foo.
+localkind foo, bar.
+
+program: CLOSED AFTER VDASH
+program: CLOSED AFTER CONJ VDASH
+program: CLOSED VDASH
+
+Closed directive expected (Teyjus compatibility, ignored by Elpi).
+Examples:
+closed foo.
+closed foo, bar.
+
+program: USEONLY VDASH
+program: USEONLY AFTER TYPE
+program: USEONLY AFTER AFTER RPAREN
+
+Useonly directive expected (Teyjus compatibility, ignored by Elpi).
+Examples:
+useonly foo.
+useonly foo, bar.
+
+program: FIXITY AFTER INTEGER VDASH
+program: FIXITY USE_SIG
+program: FIXITY FAMILY_TILDE VDASH
+program: FIXITY AFTER VDASH
+
+Mixfix declaration expected (Teyjus compatibility, ignored by Elpi).
+Examples:
+infixl and 30.
+infixr ++ 45.
+prefix - 12.

--- a/src/parser/gen_infix_lexer.ml
+++ b/src/parser/gen_infix_lexer.ml
@@ -1,0 +1,35 @@
+
+open Elpi_lexer_config.Lexer_config
+open Re
+
+let pp_fixed fmt l =
+  l |> List.iter (fun x -> Format.fprintf fmt "| %S " x)
+
+let pp_tokens fmt l =
+  l |> List.iter (function
+    | Fixed { token; the_token; _ } ->
+        Format.fprintf fmt "  | %S { %s }@;" the_token token
+    | Extensible { start; token; fixed; at_least_one_char; _ } ->
+        let next = if at_least_one_char then "symbcharplus" else "symbcharstar" in
+        Format.fprintf fmt "  | ( %S %s %a) as x { %s x }@;" start next pp_fixed fixed token)
+
+let lexing_rules =
+  let open Format in
+  let b = Buffer.create 100 in
+  let fmt = formatter_of_buffer b in
+  fprintf fmt "@[<v>(* generated *)@;";
+  mixfix_symbols |> List.iter (fun { tokens; _ } ->
+    fprintf fmt "%a" pp_tokens tokens);
+  fprintf fmt "@;(* /generated *)@;@]";
+  pp_print_flush fmt ();
+  Buffer.contents b
+
+let () =
+  let template = Sys.argv.(1) in
+  let ic = open_in template in
+  try while true do
+    let l = input_line ic in
+    let l = Str.global_replace (Str.regexp_string "@@MIXFIX@@") lexing_rules l in
+    Printf.printf "%s\n" l;
+  done;
+  with End_of_file -> () 

--- a/src/parser/gen_token_precedence.ml
+++ b/src/parser/gen_token_precedence.ml
@@ -1,0 +1,17 @@
+open Elpi_lexer_config.Lexer_config
+
+let pp_mehir_fixity fmt = function
+  | Infix | Postfix | Prefix -> Format.fprintf fmt "nonassoc"
+  | Infixl -> Format.fprintf fmt "left"
+  | Infixr -> Format.fprintf fmt "right"
+
+let pp_token_names fmt l =
+  l |> List.iter (function
+    | Fixed { token; _ } -> Format.fprintf fmt "%s " token
+    | Extensible { token; _ } -> Format.fprintf fmt "%s " token)
+
+let () =
+  Format.printf "%%right BIND\n";
+  mixfix_symbols |> List.iter (fun { fixity; tokens; _ } ->
+    Format.printf "%%%a %a\n" pp_mehir_fixity fixity pp_token_names tokens);
+  Format.printf "%%%%\n"

--- a/src/parser/grammar.mly
+++ b/src/parser/grammar.mly
@@ -1,0 +1,483 @@
+(* elpi: embedded lambda prolog interpreter                                  *)
+(* license: GNU Lesser General Public License Version 2.1 or later           *)
+(* ------------------------------------------------------------------------- *)
+
+%parameter < C : Parser_config.ParseFile >
+
+%{
+open Elpi_util
+open Elpi_lexer_config
+
+open Lexer_config
+open Parser_config
+open Ast
+open Term
+
+
+let loc (startpos, endpos) = {
+  Util.Loc.source_name = startpos.Lexing.pos_fname;
+  source_start = startpos.Lexing.pos_cnum;
+  source_stop = endpos.Lexing.pos_cnum;
+  line = endpos.Lexing.pos_lnum;
+  line_starts_at = endpos.Lexing.pos_bol;
+}
+
+let desugar_multi_binder loc = function
+  | App(Const hd as binder,args)
+    when Func.equal hd Func.pif || Func.equal hd Func.sigmaf && List.length args > 1 ->
+      let last, rev_rest = let l = List.rev args in List.hd l, List.tl l in
+      let names = List.map (function
+        | Const x -> Func.show x
+        | (App _ | Lam _ | CData _ | Quoted _) ->
+            raise (ParseError(loc,"Only names are allowed after 'pi' or 'sigma'"))) rev_rest in
+      let body = mkApp loc [binder;last] in
+      List.fold_left (fun bo name -> mkApp loc [binder;mkLam name bo]) body names
+  | (App _ | Const _ | Lam _ | CData _ | Quoted _) as t -> t
+;;
+
+let desugar_macro loc lhs rhs =
+  match lhs, rhs with
+  | Const name, body ->
+      if ((Func.show name).[0] != '@') then
+        raise (ParseError(loc,"Macro name must begin with '@'"));
+      name, body
+  | App(Const name,args), body ->
+      if ((Func.show name).[0] != '@') then
+        raise (ParseError(loc,"Macro name must begin with '@'"));
+      let names = List.map (function
+        | Const x -> Func.show x
+        | (App _ | Lam _ | CData _ | Quoted _) ->
+              raise (ParseError(loc,"Macro parameters must be names"))) args in
+      name, List.fold_right mkLam names body
+  | _ ->
+        raise (ParseError(loc,"Illformed macro left hand side"))
+;;
+
+let mkApp loc = function
+  | Const c :: a :: App (Const c1, args) :: [] when Func.(equal c andf && equal c1 andf) ->
+      mkAppF loc c (a :: args)
+  | l -> mkApp loc l
+
+let binder l = function
+  | None -> l
+  | Some (loc,b) ->
+      match List.rev l with
+      | Const name :: rest ->
+          List.rev rest @ [mkLam (Func.show name) b]
+      | _ -> raise (ParseError(loc,"bind '\\' operator must follow a name"))
+;;
+
+let underscore () = Const Func.dummyname
+
+let decode_sequent t =
+  match t with
+  | App(Const c,[hyps;bo]) when c == Func.sequentf -> hyps, bo
+  | _ -> underscore (), t
+
+let prop = Func.from_string "prop"
+
+let fix_church x = if Func.show x = "o" then prop else x
+%}
+
+%on_error_reduce term
+
+(* non terminals *)
+%type < Program.t > program
+%type < Goal.t > goal
+%type < (Term.t, raw_attribute list) Clause.t > clause
+%type < Term.t > term
+%type < Program.decl > decl
+%type < Func.t > infix_SYMB
+%type < Func.t > prefix_SYMB
+%type < Func.t > postfix_SYMB
+%type < Func.t > constant
+
+(* entry points *)
+%start program
+%start goal
+
+(* for testing *)
+%start infix_SYMB
+%start prefix_SYMB
+%start postfix_SYMB
+
+(* token precedence are in token_precedence.mly *)
+
+%%
+program:
+| EOF { [] }
+| d = decl; p = program { d :: p }
+
+decl:
+| c = clause; FULLSTOP { Program.Clause c }
+| r = chr_rule; FULLSTOP { Program.Chr r }
+| p = pred; FULLSTOP { Program.Pred (snd p, fst p) }
+| t = type_; FULLSTOP { Program.Type t }
+| t = kind; FULLSTOP { Program.Type t }
+| m = mode; FULLSTOP { Program.Mode [m] }
+| m = macro; FULLSTOP { Program.Macro m }
+| CONSTRAINT; cl = list(constant); LCURLY { Program.Constraint(loc $sloc, cl) }
+| NAMESPACE; c = constant; LCURLY { Program.Namespace(loc $sloc, c )}
+| SHORTEN; s = shorten; FULLSTOP { Program.Shorten(loc $sloc, s) }
+| a = typeabbrev; FULLSTOP { Program.TypeAbbreviation a }
+| LCURLY { Program.Begin (loc $sloc) }
+| RCURLY { Program.End (loc $sloc) }
+| ext = accumulate; l = separated_nonempty_list(CONJ,filename); FULLSTOP {
+    Program.Accumulated(loc $sloc,List.(concat (map (fun x ->
+      let cwd = Filename.dirname (loc $sloc).source_name in
+      C.parse_file ~cwd (x ^ ext)) l)))
+  }
+| LOCAL; l = separated_nonempty_list(CONJ,constant); option(type_term); FULLSTOP {
+    Program.Local l
+  }
+| ignored; FULLSTOP { Program.Ignored (loc $sloc) }
+| f = fixity; FULLSTOP { error_mixfix (loc $loc) }
+
+accumulate:
+| ACCUMULATE { ".elpi" }
+| IMPORT { ".mod" }
+| ACCUM_SIG { ".sig" }
+| USE_SIG { ".sig" }
+
+filename:
+| c = constant { Func.show c }
+| s = STRING { s }
+
+chr_rule:
+| attributes = attributes; RULE;
+  to_match = list(sequent);
+  to_remove = preceded(BIND,nonempty_list(sequent))?;
+  guard = preceded(PIPE,term)?;
+  new_goal = preceded(IFF,sequent)? {
+    { Chr.to_match; to_remove = Util.option_default [] to_remove; guard; new_goal; attributes; loc=(loc $sloc) }
+  }
+
+pred:
+| attributes = attributes; PRED;
+  c = constant; args = separated_list(CONJ,pred_item) { 
+   let name = c in
+   { Mode.loc=loc $sloc; name; args = List.map fst args },
+   { Type.loc=loc $sloc; attributes; name;
+     ty = List.fold_right (fun (_,t) ty ->
+       mkApp (loc $loc(c)) [mkCon "->";t;ty]) args (mkCon "prop") }
+ }
+pred_item:
+| io = i_o; COLON; ty = type_term { (io,ty) }
+i_o:
+| io = IO { 
+    if io = 'i' then true
+    else if io = 'o' then false
+    else assert false
+}
+
+kind:
+| KIND; names = separated_nonempty_list(CONJ,constant); k = kind_term {
+    names |> List.map (fun n->
+     { Type.loc=loc $sloc; attributes=[]; name =  n; ty = k })
+  }
+type_:
+| attributes = attributes;
+  TYPE; names = separated_nonempty_list(CONJ,constant); t = type_term {
+    names |> List.map (fun n->
+     { Type.loc=loc $sloc; attributes; name = n; ty = t })
+  }
+
+atype_term:
+| c = STRING { mkC (cstring.Util.CData.cin c) }
+| c = constant { Const (fix_church c) }
+| LPAREN; t = type_term; RPAREN { t }
+type_term:
+| c = constant { Const (fix_church c) }
+| hd = constant; args = nonempty_list(atype_term) { mkAppF (loc $loc(hd)) hd args }
+| hd = type_term; ARROW; t = type_term { mkApp (loc $loc(hd)) [mkCon "->"; hd; t] }
+| LPAREN; t = type_term; RPAREN { t }
+
+kind_term:
+| TYPE { mkCon "type" }
+| hd = TYPE; ARROW; t = kind_term { mkApp (loc $loc(hd)) [mkCon "->"; mkCon "type"; t] }
+
+mode:
+| MODE; LPAREN; c = constant; l = nonempty_list(i_o); RPAREN {
+    { Mode.name = c; args = l; loc = loc $sloc } 
+}
+
+macro:
+| MACRO; m = term; VDASH; b = term {
+  let name, body = desugar_macro (loc $sloc) m b in
+  { Macro.loc = loc $sloc; name; body }
+}
+
+typeabbrev:
+| TYPEABBREV; a = abbrevform; t = type_term {
+    let name, args = a in
+    let args = List.map Func.show args in
+    let nparams = List.length args in
+    let value = List.fold_right mkLam args t in
+    { TypeAbbreviation.name = name;
+      nparams = nparams;
+      value = value;
+      loc = loc $sloc }
+  }
+
+abbrevform:
+| c = constant { c, [] }
+| LPAREN; hd = constant; args = nonempty_list(constant); RPAREN { hd, args  }
+
+
+ignored:
+| MODULE; constant
+| SIG; constant
+| EXPORTDEF; separated_nonempty_list(CONJ,constant)
+| EXPORTDEF; separated_nonempty_list(CONJ,constant); type_term
+| LOCALKIND; separated_nonempty_list(CONJ,constant)
+| USEONLY; separated_nonempty_list(CONJ,constant)
+| USEONLY; separated_nonempty_list(CONJ,constant); type_term
+| CLOSED; separated_nonempty_list(CONJ,constant)
+  { Program.Ignored (loc $sloc) }
+
+fixity:
+| f = FIXITY; c = constant; i = INTEGER { (fixity_of_string f,c,i,loc $loc(c)) }
+| f = FIXITY; c = mixfix_SYMB; i = INTEGER { (fixity_of_string f,c,i,loc $loc(c)) }
+
+shorten:
+| l = trie {
+     List.map Func.(fun (x,y) -> from_string x, from_string y) l
+  }
+
+trie:
+| c = constant; FULLSTOP; LCURLY; l = separated_nonempty_list(CONJ,subtrie); RCURLY {
+    List.map (fun (p,x) -> Func.show c ^ "." ^ p, x) (List.flatten l)
+}
+subtrie:
+| name = constant { [Func.show name, Func.show name] }
+| prefix = constant; FULLSTOP; LCURLY; l = separated_nonempty_list(CONJ,subtrie); RCURLY {
+    List.map (fun (p,x) -> Func.show prefix ^ "." ^ p, x) (List.flatten l)
+}
+
+sequent:
+| t = closed_term {
+    let context, conclusion = decode_sequent t in
+    { Chr.eigen = underscore (); context; conclusion }
+  }
+| LPAREN; c = constant; COLON; t = term; RPAREN {
+    let context, conclusion = decode_sequent t in
+    { Chr.eigen = Const c; context; conclusion }
+  }
+
+goal:
+| g = term; EOF { ( loc $sloc , g ) }
+| g = term; FULLSTOP { ( loc $sloc , g ) }
+
+clause:
+| attributes = attributes; body = clause_hd_term; {
+    { Clause.loc = loc $sloc;
+      attributes;
+      body;
+    }
+  }
+| attributes = attributes; l = clause_hd_term; VDASH; r = term { 
+    { Clause.loc = loc $sloc;
+      attributes;
+      body = App(Const Func.rimplf,[l;r])
+    }
+}
+
+attributes:
+| { [] }
+| EXTERNAL { [ External ] }
+| COLON; l = separated_nonempty_list(COLON, attribute) { l }
+
+attribute:
+| IF; s = STRING { If s }
+| NAME; s = STRING  { Name s }
+| AFTER; s = STRING { After s }
+| BEFORE; s = STRING { Before s }
+| EXTERNAL { External }
+| INDEX; LPAREN; l = nonempty_list(indexing) ; RPAREN { Index l }
+
+indexing:
+| FRESHUV { 0 }
+| i = INTEGER { i }
+
+term:
+| t = open_term { t }
+| t = binder_term { t }
+| t = closed_term { t }
+
+term_noconj:
+| t = open_term_noconj { t }
+| t = binder_term_noconj { t }
+| t = closed_term { t }
+
+closed_term:
+| x = INTEGER { mkC (cint.Util.CData.cin x)}
+| x = FLOAT { mkC (cfloat.Util.CData.cin x)}
+| x = STRING { mkC (cstring.Util.CData.cin x)}
+| x = QUOTED { mkQuoted (loc $loc) x }
+| LPAREN; t = term; AS; c = term; RPAREN { App(mkCon "as",[t;c]) }
+| LBRACKET; l = list_items { mkSeq l }
+| LBRACKET; l = list_items_tail;  {  mkSeq l }
+| LCURLY; t = term; RCURLY { App (Const Func.spillf,[t]) }
+| t = head_term { t }
+
+head_term:
+| t = constant { Const t }
+| LPAREN; t = term; RPAREN { t }
+
+list_items:
+| RBRACKET { [mkNil] }
+| x = term_noconj; RBRACKET { [x;mkNil] }
+| x = term_noconj; CONJ; xs = list_items { x :: xs }
+
+list_items_tail:
+| PIPE; x = term_noconj; RBRACKET { [x] }
+| x = term_noconj; PIPE; xs = term_noconj; RBRACKET { [x;xs] }
+| x = term_noconj; CONJ; xs = list_items_tail { x :: xs }
+
+binder_term:
+| t = constant; b = binder_body { mkLam (Func.show t) (snd b) }
+
+binder_body:
+| bind = BIND; b = term { (loc $loc(bind), b) }
+
+binder_term_noconj:
+| t = constant; BIND; b = term { mkLam (Func.show t) b }
+
+open_term:
+| hd = head_term; args = nonempty_list(closed_term); b = option(binder_body) {
+    let args = binder args b in
+    let t = mkApp (loc $loc(hd)) (hd :: args) in
+    desugar_multi_binder (loc $loc(hd)) t
+} (*%prec OR*)
+| l = term; s = infix;  r = term { mkApp (loc $loc) [Const s;l;r] }
+| s = prefix; r = term { App(Const s,[r]) }
+| l = term; s = postfix; { App(Const s,[l]) }
+
+open_term_noconj:
+| hd = head_term; args = nonempty_list(closed_term); b = option(binder_body) {
+    let args = binder args b in
+    let t = mkApp (loc $loc(hd)) (hd :: args) in
+    desugar_multi_binder (loc $loc(hd)) t
+} (*%prec OR*)
+| l = term_noconj; s = infix_noconj;  r = term_noconj { mkApp (loc $loc) [Const s;l;r] }
+| s = prefix; r = term_noconj { App(Const s,[r]) }
+| l = term_noconj; s = postfix; { App(Const s,[l]) }
+
+(* avoids the conflict between `{` (Program.Begin) and `{spilled}` (Program.Clause) *)
+clause_hd_term:
+| t = clause_hd_open_term { t }
+| t = clause_hd_closed_term { t }
+
+clause_hd_closed_term:
+| t = constant { Const t }
+| LPAREN; t = term; RPAREN { t }
+
+clause_hd_open_term:
+| hd = head_term; args = nonempty_list(closed_term); b = option(binder_body) {
+    let args = binder args b in
+    let t = mkApp (loc $loc(hd)) (hd :: args) in
+    desugar_multi_binder (loc $loc(hd)) t
+} (*%prec OR*)
+| l = clause_hd_term; s = infix_novdash; r = term { mkApp (loc $loc) [Const s;l;r] }
+| s = prefix; r = term { App(Const s,[r]) }
+| l = clause_hd_term; s = postfix; { App(Const s,[l]) }
+
+constant:
+| c = CONSTANT {
+    if c = "nil" then Func.nilf
+    else if c = "cons" then Func.consf
+    else Func.from_string c }
+| IF { Func.from_string "if" }
+| NAME { Func.from_string "name" }
+| BEFORE { Func.from_string "before" }
+| AFTER { Func.from_string "after" }
+| INDEX { Func.from_string "index" }
+| c = IO { Func.from_string @@ String.make 1 c }
+| CUT { Func.cutf }
+| PI { Func.pif }
+| SIGMA { Func.sigmaf }
+| FRESHUV { Func.dummyname }
+| LPAREN; s = mixfix_SYMB; RPAREN { s }
+| LPAREN; AS; RPAREN  { Func.from_string "as" }
+| NIL { Func.nilf }
+
+mixfix_SYMB:
+| x = infix { x }
+| x = prefix { x }
+| x = postfix { x }
+
+infix_SYMB:
+| x = infix { x }
+
+prefix_SYMB:
+| x = prefix { x }
+
+postfix_SYMB:
+| x = postfix { x }
+
+%inline prefix:
+| x = extensible_prefix { x }
+
+%inline postfix:
+| x = extensible_postfix { x }
+
+%inline infix:
+| x = extensible_infix { x }
+| x = non_extensible_infix { x }
+
+%inline infix_noconj:
+| x = extensible_infix { x }
+| x = non_extensible_infix_noconj { x }
+
+%inline infix_novdash:
+| x = extensible_infix { x }
+| x = non_extensible_infix_novdash { x }
+
+%inline extensible_infix:
+| s = FAMILY_PLUS  { Func.from_string s }
+| s = FAMILY_TIMES { Func.from_string s }
+| s = FAMILY_MINUS { Func.from_string s }
+| s = FAMILY_EXP   { Func.from_string s }
+| s = FAMILY_LT    { Func.from_string s }
+| s = FAMILY_GT    { Func.from_string s }
+| s = FAMILY_EQ    { Func.from_string s }
+| s = FAMILY_AND   { Func.from_string s }
+| s = FAMILY_OR   { Func.from_string s }
+| s = FAMILY_SHARP { Func.from_string s }
+| s = FAMILY_BTICK { Func.from_string s }
+| s = FAMILY_TICK  { Func.from_string s }
+
+%inline non_extensible_infix_novdash_noconj:
+| CONS   { Func.consf }
+| EQ     { Func.eqf }
+| MINUS  { Func.from_string "-" }
+| MINUSr { Func.from_string "r-" }
+| MINUSi { Func.from_string "i-" }
+| MINUSs { Func.from_string "s-" }
+| EQ2    { Func.from_string "==" }
+| OR     { Func.orf }
+| IS     { Func.isf }
+| MOD    { Func.from_string "mod" }
+| DIV    { Func.from_string "div" }
+| ARROW  { Func.arrowf }
+| DARROW { Func.implf }
+| QDASH  { Func.sequentf }
+| SLASH  { Func.from_string "/" }
+
+%inline non_extensible_infix_novdash:
+| x = non_extensible_infix_novdash_noconj { x }
+| CONJ   { Func.andf }
+
+%inline non_extensible_infix_noconj:
+| x = non_extensible_infix_novdash_noconj { x }
+| VDASH  { Func.rimplf }
+
+%inline non_extensible_infix:
+| x = non_extensible_infix_novdash { x }
+| VDASH  { Func.rimplf }
+
+%inline extensible_prefix:
+| s = FAMILY_TILDE { Func.from_string s }
+
+%inline extensible_postfix:
+| s = FAMILY_QMARK { Func.from_string s }

--- a/src/parser/lexer.mll.in
+++ b/src/parser/lexer.mll.in
@@ -1,0 +1,167 @@
+{
+(* elpi: embedded lambda prolog interpreter                                  *)
+(* license: GNU Lesser General Public License Version 2.1 or later           *)
+(* ------------------------------------------------------------------------- *)
+    open Elpi_lexer_config.Tokens
+    exception Error of string
+
+    let new_line b =
+      Lexing.new_line b
+
+    let skip b n =
+      let open Lexing in
+      b.lex_curr_p <- { b.lex_curr_p with pos_cnum = b.lex_curr_p.pos_cnum + n }
+
+}
+
+let digit = [ '0' - '9' ]
+
+let pnum = (digit +)
+
+let num = '-' ? pnum
+
+let ucase = [ 'A' - 'Z' ]
+let lcase = [ 'a' - 'z' ]
+let schar2 = '+'  | '*' | '/' | '^' | '<' | '>' | '`' | '\'' | '?' | '@' | '#' | '~' | '=' | '&' | '!'
+let schar = schar2 | '-' | '$' | '_'
+let idchar = lcase | ucase | digit | schar
+let idcharstar = idchar *
+let idcharstarns = (idchar | "." ( ucase | lcase )) *
+let symbchar = lcase | ucase | digit | schar | ':'
+let symbcharstar = symbchar *
+let symbcharplus = symbchar +
+
+rule linecomment = parse
+| '\n' { new_line lexbuf; token lexbuf }
+| eof { token lexbuf }
+| _ { skip lexbuf 1; linecomment lexbuf }
+
+and multilinecomment nest = parse
+| '\n' { new_line lexbuf; multilinecomment nest lexbuf }
+| "*/" { if nest = 0 then token lexbuf else multilinecomment (nest - 1) lexbuf }
+| "/*" { multilinecomment (nest+1) lexbuf }
+| _ { skip lexbuf 1; multilinecomment nest lexbuf }
+
+and string b = parse
+| '\n'     { Buffer.add_char b '\n'; new_line lexbuf; string b lexbuf }
+| '\\' 'n' { Buffer.add_char b '\n'; skip lexbuf 2; string b lexbuf }
+| '\\' 'b' { Buffer.add_char b '\b'; skip lexbuf 2; string b lexbuf }
+| '\\' 't' { Buffer.add_char b '\t'; skip lexbuf 2; string b lexbuf }
+| '\\' 'r' { Buffer.add_char b '\r'; skip lexbuf 2; string b lexbuf }
+| '\\' '\\' { Buffer.add_char b '\\'; skip lexbuf 2; string b lexbuf }
+| '\\' '"' { Buffer.add_char b '"';  skip lexbuf 2; string b lexbuf }
+| '"' '"'  { Buffer.add_char b '"';  skip lexbuf 2; string b lexbuf }
+| '"' { STRING (Buffer.contents b) }
+| _ # '"' as c { Buffer.add_char b c; skip lexbuf 1; string b lexbuf }
+
+and quoted n = parse
+| '{' { skip lexbuf 1; quoted (n+1) lexbuf }
+| '\n' { let b = Buffer.create 80 in Buffer.add_char b '\n'; skip lexbuf 1; new_line lexbuf; quoted_inner b n 0 lexbuf }
+| _ as c { let b = Buffer.create 80 in Buffer.add_char b c; skip lexbuf 1; quoted_inner b n 0 lexbuf }
+
+and quoted_inner b n l = parse
+| '}' {
+    Buffer.add_char b '}'; skip lexbuf 1; 
+    try lookahead_close b (n-1) lexbuf;
+      if l = 0 then begin
+        lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_cnum = lexbuf.lex_curr_p.pos_cnum - 1};
+        QUOTED (Buffer.sub b 0 (Buffer.length b -n))
+      end
+      else quoted_inner b n (l-1) lexbuf
+    with Failure _ -> quoted_inner b n l lexbuf
+  }
+| '{' {
+    Buffer.add_char b '{'; skip lexbuf 1; 
+    try lookahead_open b (n-1) lexbuf; quoted_inner b n (l+1) lexbuf
+    with Failure _ -> quoted_inner b n l lexbuf
+  }
+| '\n' { Buffer.add_char b '\n'; new_line lexbuf; quoted_inner b n l lexbuf }
+| _ as c { Buffer.add_char b c; quoted_inner b n l lexbuf }
+
+and lookahead_close b n = parse
+| '}' {
+    Buffer.add_char b '}'; skip lexbuf 1; 
+    if n = 1 then () else lookahead_close b (n-1) lexbuf
+  }
+
+and lookahead_open b n = parse
+| '{' {
+    Buffer.add_char b '{'; skip lexbuf 1; 
+    if n = 1 then () else lookahead_open b (n-1) lexbuf
+  }
+
+and token = parse
+| ("#line" " "+ (num as n) " "+ '"' ([^'"']+ as f) '"' " "* '\n' as x) {
+    let open Lexing in
+    lexbuf.lex_curr_p <- {
+      pos_fname = f;
+      pos_lnum = int_of_string n;
+      pos_cnum = 0;
+      pos_bol = lexbuf.lex_curr_p.pos_bol;
+    };
+    lexbuf.lex_abs_pos <- - (String.length x) - lexbuf.lex_start_p.pos_cnum;
+    lexbuf.lex_start_p <- lexbuf.lex_curr_p;
+    token lexbuf }
+| ( ' ' | '\t' | '\r' ) { skip lexbuf 1; token lexbuf }
+| '\n' { new_line lexbuf; token lexbuf }
+| '%' { linecomment lexbuf }
+| "/*" { multilinecomment 0 lexbuf }
+| "." { FULLSTOP }
+| "_" idchar + as c { CONSTANT c }
+| "_" { FRESHUV }
+| num as i { INTEGER (int_of_string i) }
+| num "." pnum as f { FLOAT (float_of_string f) }
+| "." pnum as f { FLOAT (float_of_string f) }
+| '"' { string (Buffer.create 80) lexbuf }
+| ":" { COLON }
+| "\\" { BIND }
+| "(" { LPAREN }
+| ")" { RPAREN }
+| "([])" { NIL }
+| "[" { LBRACKET }
+| "]" { RBRACKET }
+| "{" { LCURLY }
+| "}" { RCURLY }
+| "|" { PIPE }
+| "{{" { skip lexbuf 2; quoted 2 lexbuf }
+| ("i" | "o") as s { IO s }
+| "shorten" { SHORTEN }
+| "accumulate" { ACCUMULATE }
+| "local" { LOCAL }
+| "pred" { PRED }
+| "mode" { MODE }
+| "macro" { MACRO }
+| "rule" { RULE }
+| "namespace" { NAMESPACE }
+| "constraint" { CONSTRAINT }
+| "kind" { KIND }
+| "type" { TYPE }
+| "typeabbrev" { TYPEABBREV }
+| "external" { EXTERNAL }
+| "module" { MODULE }
+| "sig" { SIG }
+| "import" { IMPORT }
+| "accum_sig" { ACCUM_SIG }
+| "use_sig" { USE_SIG }
+| "localkind" { LOCALKIND }
+| "useonly" { USEONLY }
+| "exportdef" { EXPORTDEF }
+| "closed" { CLOSED }
+| "as" { AS }
+| "<=>" { IFF }
+| ("infix" | "infixl" | "infixr" | "prefix" | "prefixr" | "postfix" | "postfixl" ) as x { FIXITY x }
+| '\'' symbcharstar '\'' as s { CONSTANT s }
+| '`' symbcharstar '`' as s { CONSTANT s }
+| "!" { CUT }
+| "pi" { PI }
+| "sigma" { SIGMA }
+| "after" { AFTER }
+| "before" { BEFORE }
+| "name" { NAME }
+| "if" { IF }
+| "index" { INDEX }
+@@MIXFIX@@
+| ucase idcharstar as c { CONSTANT c }
+| lcase idcharstarns as c { CONSTANT c }
+| '@' idcharstar as c { CONSTANT c }
+| eof { EOF }

--- a/src/parser/lexer.mll.in
+++ b/src/parser/lexer.mll.in
@@ -31,10 +31,16 @@ let symbchar = lcase | ucase | digit | schar | ':'
 let symbcharstar = symbchar *
 let symbcharplus = symbchar +
 
-rule linecomment = parse
-| '\n' { new_line lexbuf; token lexbuf }
+rule linecomment skipno = parse
+| '\n' { new_line lexbuf; if skipno > 0 then skip_lines skipno lexbuf else token lexbuf }
 | eof { token lexbuf }
-| _ { skip lexbuf 1; linecomment lexbuf }
+| "elpi:skip " (pnum as n) { skip lexbuf 10; skip lexbuf (String.length n); linecomment (int_of_string n) lexbuf }
+| _ { skip lexbuf 1; linecomment skipno lexbuf }
+
+and skip_lines skipno = parse
+| '\n' { new_line lexbuf; let skipno = skipno - 1 in if skipno > 0 then skip_lines skipno lexbuf else token lexbuf }
+| eof { token lexbuf }
+| _ { skip lexbuf 1; skip_lines skipno lexbuf }
 
 and multilinecomment nest = parse
 | '\n' { new_line lexbuf; multilinecomment nest lexbuf }
@@ -104,7 +110,7 @@ and token = parse
     token lexbuf }
 | ( ' ' | '\t' | '\r' ) { skip lexbuf 1; token lexbuf }
 | '\n' { new_line lexbuf; token lexbuf }
-| '%' { linecomment lexbuf }
+| '%' { linecomment 0 lexbuf }
 | "/*" { multilinecomment 0 lexbuf }
 | "." { FULLSTOP }
 | "_" idchar + as c { CONSTANT c }

--- a/src/parser/lexer_config.ml
+++ b/src/parser/lexer_config.ml
@@ -1,0 +1,108 @@
+(* elpi: embedded lambda prolog interpreter                                  *)
+(* license: GNU Lesser General Public License Version 2.1 or later           *)
+(* ------------------------------------------------------------------------- *)
+
+(* extensible syntax *)
+type fixity = Infixl | Infixr | Infix | Prefix | Postfix
+
+let pp_fixity fmt = function
+ | Infixl  -> Format.fprintf fmt "Infix   left  associative"
+ | Infixr  -> Format.fprintf fmt "Infix   right associative"
+ | Infix   -> Format.fprintf fmt "Infix   not   associative"
+ | Prefix  -> Format.fprintf fmt "Prefix  not   associative"
+ | Postfix -> Format.fprintf fmt "Postfix not   associative"
+
+let fixity_of_string = function
+ | "infixl" -> Infixl 
+ | "infixr" -> Infixr 
+ | "infix" -> Infix 
+ | "prefix" -> Prefix 
+ | "prefixr" -> Prefix
+ | "postfix" -> Postfix 
+ | "postfixl" -> Postfix
+ | _ -> assert false
+
+(* family of tokens *)
+
+type extensible = {
+  start : string;
+  mk_token : string -> Tokens.token;
+  token : string;
+  non_enclosed : bool;
+  at_least_one_char : bool;
+  fixed : string list;
+}
+
+type fixed = {
+  token : string;
+  the_token : string;
+  mk_token : Tokens.token;
+}
+
+type mixfix_kind = Fixed of fixed | Extensible of extensible
+
+type mixfix = {
+  tokens : mixfix_kind list;
+  fixity : fixity;
+  legacy_level : int;
+}
+
+let mkFix token the_token mk_token = Fixed { token; the_token; mk_token }
+
+let mkExt token start ?(non_enclosed=false) ?(at_least_one_char=false) ?(fixed=[]) mk_token =
+  Extensible { start; mk_token; token; non_enclosed; at_least_one_char; fixed }
+
+let mixfix_symbols : mixfix list = [
+  { tokens = [ mkFix "VDASH" ":-" VDASH;
+               mkFix "QDASH" "?-" QDASH];
+    fixity = Infix; legacy_level = 1  };
+  { tokens = [ mkFix "OR" ";" OR];
+    fixity = Infixr; legacy_level = 100  };
+  { tokens = [ mkFix "CONJ" "," CONJ];
+    fixity = Infixr; legacy_level = 110  };
+  { tokens = [ mkFix "ARROW" "->" ARROW];
+    fixity = Infixr; legacy_level = 116  };
+  { tokens = [ mkFix "DARROW" "=>" DARROW];
+    fixity = Infixr; legacy_level = 129  };
+  { tokens = [ mkFix "EQ" "=" EQ;
+               mkFix "EQ2" "==" EQ2;
+               mkExt "FAMILY_LT" "<" ~fixed:["=<"; "r<"; "i<"; "s<"; "r=<"; "i=<"; "s=<"] (fun x -> FAMILY_LT x);
+               mkExt "FAMILY_GT" ">" ~fixed:["r>"; "i>"; "s>"; "r>="; "i>="; "s>="] (fun x -> FAMILY_GT x);
+               mkFix "IS" "is" IS;
+               ];
+    fixity = Infix; legacy_level = 130 };
+  { tokens = [ mkFix "CONS" "::" CONS];
+    fixity = Infixr; legacy_level = 140 };
+  { tokens = [ mkExt "FAMILY_TICK" "'" ~non_enclosed:true (fun x -> FAMILY_TICK x) ];
+    fixity = Infix; legacy_level = 0 };
+  { tokens = [ mkExt "FAMILY_EXP" "^" (fun x -> FAMILY_EXP x);
+               mkExt "FAMILY_PLUS" "+" ~fixed:["r+";"i+";"s+"] (fun x -> FAMILY_PLUS x);
+               mkFix "MINUS" "-" MINUS;
+               mkFix "MINUSr" "r-" MINUSr;
+               mkFix "MINUSi" "i-" MINUSi;
+               mkFix "MINUSs" "s-" MINUSs; ];
+    fixity = Infixl; legacy_level = 150 };
+  { tokens = [ mkExt "FAMILY_TIMES" "*" ~fixed:["r*";"i*";"s*"] (fun x -> FAMILY_TIMES x);
+              mkFix "SLASH" "/" SLASH;
+              mkFix "DIV" "div" DIV;
+              mkFix "MOD" "mod" MOD; ];
+    fixity = Infixl; legacy_level = 160 };
+  { tokens = [ mkExt "FAMILY_MINUS" "--" (fun x -> FAMILY_MINUS x) ];
+    fixity = Infixr; legacy_level = 0 };
+  { tokens = [ mkExt "FAMILY_BTICK" "`" ~non_enclosed:true (fun x -> FAMILY_BTICK x) ];
+    fixity = Infix; legacy_level = 141 };
+  { tokens = [ mkExt "FAMILY_EQ" "==" ~at_least_one_char:true (fun x -> FAMILY_EQ x) ];
+    fixity = Infixr; legacy_level = 0 };
+  { tokens = [ mkExt "FAMILY_OR" "||" (fun x -> FAMILY_OR x) ];
+    fixity = Infixr; legacy_level = 0 };
+  { tokens = [ mkExt "FAMILY_AND" "&&" (fun x -> FAMILY_AND x) ];
+    fixity = Infixr; legacy_level = 128 };
+  { tokens = [ mkExt "FAMILY_SHARP" "#" (fun x -> FAMILY_SHARP x) ];
+    fixity = Infixl; legacy_level = 200 };
+  { tokens = [ mkExt "FAMILY_TILDE" "~" ~fixed:["r~"; "i~"] (fun x -> FAMILY_TILDE x) ];
+    fixity = Prefix; legacy_level = 256 };
+  { tokens = [ mkExt "FAMILY_QMARK" "?" (fun x -> FAMILY_QMARK x) ];
+    fixity = Postfix; legacy_level = 300 };
+]
+;;
+

--- a/src/parser/parse.ml
+++ b/src/parser/parse.ml
@@ -1,0 +1,120 @@
+(* elpi: embedded lambda prolog interpreter                                  *)
+(* license: GNU Lesser General Public License Version 2.1 or later           *)
+(* ------------------------------------------------------------------------- *)
+
+open Elpi_util
+open Elpi_lexer_config
+
+exception ParseError = Parser_config.ParseError
+
+module type Parser = sig
+  val program : file:string -> Ast.Program.decl list
+  val goal : loc:Util.Loc.t -> text:string -> Ast.Goal.t
+  
+  val goal_from : loc:Util.Loc.t -> Lexing.lexbuf -> Ast.Goal.t
+  val program_from : loc:Util.Loc.t -> Lexing.lexbuf -> Ast.Program.t
+end
+
+module type Parser_w_Internals = sig
+  include Parser
+
+  module Internal : sig
+    val infix_SYMB : (Lexing.lexbuf -> Tokens.token) -> Lexing.lexbuf -> Ast.Func.t
+    val prefix_SYMB : (Lexing.lexbuf -> Tokens.token) -> Lexing.lexbuf -> Ast.Func.t
+    val postfix_SYMB : (Lexing.lexbuf -> Tokens.token) -> Lexing.lexbuf -> Ast.Func.t
+  end
+end
+
+module type Config = sig
+  val resolver : ?cwd:string -> unit:string -> unit -> string
+
+end
+
+module Make(C : Config) = struct
+  
+let parse_ref : (?cwd:string -> string -> (Digest.t * Ast.Program.decl list) list) ref =
+  ref (fun ?cwd:_ _ -> assert false)
+  
+module Grammar = Grammar.Make(struct
+  let parse_file ?cwd file = !parse_ref ?cwd file
+end)
+let message_of_state s = try Error_messages.message s with Not_found -> "syntax error"
+let chunk s (p1,p2) =
+  String.sub s p1.Lexing.pos_cnum (p2.Lexing.pos_cnum - p1.Lexing.pos_cnum)
+
+let parse grammar digest lexbuf =
+  let buffer, lexer = MenhirLib.ErrorReports.wrap Lexer.token in
+  try
+    let p = grammar lexer lexbuf in
+    digest, p
+  with
+  | Ast.Term.NotInProlog(loc,message) ->
+      raise (Parser_config.ParseError(loc,message^"\n"))
+  | Grammar.Error stateid ->
+    let message = message_of_state stateid in
+    let loc = lexbuf.Lexing.lex_curr_p in
+    let loc = {
+      Util.Loc.source_name = loc.Lexing.pos_fname;
+      line = loc.Lexing.pos_lnum;
+      line_starts_at = loc.Lexing.pos_bol;
+      source_start = loc.Lexing.pos_cnum;
+      source_stop = loc.Lexing.pos_cnum;
+    } in
+    raise (Parser_config.ParseError(loc,message))
+
+let already_parsed = Hashtbl.create 11
+
+let () =
+  parse_ref := (fun ?cwd filename ->
+  let filename = C.resolver ?cwd ~unit:filename () in
+  let digest = Digest.file filename in
+  let to_parse =
+    if Filename.extension filename = ".mod" then
+      let sigf = Filename.chop_extension filename ^ ".sig" in
+      if Sys.file_exists sigf then [sigf,Digest.file sigf;filename,digest]
+      else [filename,digest]
+    else [filename,digest] in
+  to_parse |> List.map (fun (filename,digest) ->
+    if Hashtbl.mem already_parsed digest then
+      digest, []
+    else
+      let ic = open_in filename in
+      let lexbuf = Lexing.from_channel ic in
+      lexbuf.Lexing.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = filename };
+      Hashtbl.add already_parsed digest true;
+      let ast = parse Grammar.program digest lexbuf in
+      close_in ic;
+      ast))
+
+let to_lexing_loc { Util.Loc.source_name; line; line_starts_at; source_start; _ } =
+  { Lexing.pos_fname = source_name;
+    pos_lnum = line;
+    pos_bol = line_starts_at;
+    pos_cnum = source_start; }
+  
+let goal_from ~loc lexbuf =
+  let lexbuf =  { lexbuf with Lexing.lex_start_p = to_lexing_loc loc } in
+  let lexbuf =  { lexbuf with Lexing.lex_curr_p = to_lexing_loc loc } in
+  snd @@ parse Grammar.goal "" lexbuf
+      
+let goal ~loc ~text =
+  let lexbuf = Lexing.from_string text in
+  goal_from ~loc lexbuf
+
+let program_from ~loc lexbuf =
+  Hashtbl.clear already_parsed;
+  let lexbuf =  { lexbuf with Lexing.lex_start_p = to_lexing_loc loc } in
+  let lexbuf =  { lexbuf with Lexing.lex_curr_p = to_lexing_loc loc } in
+  snd @@ parse Grammar.program "" lexbuf
+
+let program ~file =
+  Hashtbl.clear already_parsed;
+  List.(concat (map snd @@ !parse_ref file))
+
+module Internal = struct
+let infix_SYMB = Grammar.infix_SYMB
+let prefix_SYMB = Grammar.prefix_SYMB
+let postfix_SYMB = Grammar.postfix_SYMB
+end
+
+end

--- a/src/parser/parse.mli
+++ b/src/parser/parse.mli
@@ -1,0 +1,33 @@
+
+(* elpi: embedded lambda prolog interpreter                                  *)
+(* license: GNU Lesser General Public License Version 2.1 or later           *)
+(* ------------------------------------------------------------------------- *)
+
+open Elpi_util
+open Elpi_lexer_config
+
+exception ParseError of Util.Loc.t * string
+
+module type Parser = sig
+  val program : file:string -> Ast.Program.decl list
+  val goal : loc:Util.Loc.t -> text:string -> Ast.Goal.t
+  
+  val goal_from : loc:Util.Loc.t -> Lexing.lexbuf -> Ast.Goal.t
+  val program_from : loc:Util.Loc.t -> Lexing.lexbuf -> Ast.Program.t
+end
+
+module type Parser_w_Internals = sig
+  include Parser
+
+  module Internal : sig
+    val infix_SYMB : (Lexing.lexbuf -> Tokens.token) -> Lexing.lexbuf -> Ast.Func.t
+    val prefix_SYMB : (Lexing.lexbuf -> Tokens.token) -> Lexing.lexbuf -> Ast.Func.t
+    val postfix_SYMB : (Lexing.lexbuf -> Tokens.token) -> Lexing.lexbuf -> Ast.Func.t
+  end
+end
+
+module type Config = sig
+  val resolver : ?cwd:string -> unit:string -> unit -> string
+end
+
+module Make(C : Config) : Parser_w_Internals

--- a/src/parser/parser_config.ml
+++ b/src/parser/parser_config.ml
@@ -1,0 +1,139 @@
+(* elpi: embedded lambda prolog interpreter                                  *)
+(* license: GNU Lesser General Public License Version 2.1 or later           *)
+(* ------------------------------------------------------------------------- *)
+
+open Elpi_util
+open Elpi_lexer_config.Lexer_config
+
+exception ParseError of Util.Loc.t * string
+
+(* this is the input of the parser functor in grammar.mly, it ties the knot:
+   accumulate requires to call the same parser on another file, but file/module
+   resolution is not a parser business *)
+
+module type ParseFile = sig
+  val parse_file : ?cwd:string -> string -> (Digest.t * Ast.Program.decl list) list
+end
+
+let rec substrings i len_s s =
+  if len_s - i >= 0 then
+    String.sub s 0 i :: substrings (i+1) len_s s
+  else []
+let substrings s = substrings 1 (String.length s) s
+
+let find_sub tab s =
+  let rec aux = function
+    | [] -> raise Not_found
+    | x :: xs ->
+        try Hashtbl.find tab x
+        with Not_found -> aux xs
+  in
+    aux (substrings s)
+
+let precedence_of, umax_precedence, appl_precedence, inf_precedence =
+  let tab = Hashtbl.create 21 in
+  List.iteri (fun legacy_level { tokens; fixity } ->
+    List.iter (function
+      | Extensible { start; _ } -> Hashtbl.add tab start (fixity,legacy_level)
+      | Fixed { the_token; _ } -> Hashtbl.add tab the_token (fixity,legacy_level)
+      ) tokens;
+    ) mixfix_symbols;
+  let umax_precedence = List.length mixfix_symbols in
+  let appl_precedence = umax_precedence + 1 in
+  let inf_precedence = appl_precedence + 1 in (* greater than any used precedence*)
+  (fun s ->
+    try find_sub tab s
+    with Not_found -> Prefix,appl_precedence),
+  umax_precedence, appl_precedence, inf_precedence
+
+let comma_precedence = 1 + (snd @@ precedence_of ",")
+let min_precedence = -1  (* minimal precedence in use *)
+let lam_precedence = -1  (* precedence of lambda abstraction *)
+let umin_precedence = 0   (* minimal user defined precedence *)
+
+let pp_fixed fmt l =
+  l |> List.iter (fun x -> Format.fprintf fmt "%s @ " x)
+
+let pp_non_enclosed fmt = function
+  | false -> ()
+  | true -> Format.fprintf fmt " [*]"
+
+let pp_tok_list fmt l =
+  List.iter (function
+    | Extensible { start; fixed; non_enclosed; _ } -> Format.fprintf fmt "%a%s..%a @ " pp_fixed fixed start pp_non_enclosed non_enclosed
+    | Fixed { the_token; _ } -> Format.fprintf fmt "%s @ " the_token)
+    l
+
+let legacy_parser_compat_error =
+  let open Format in
+  let b = Buffer.create 80 in
+  let fmt = formatter_of_buffer b in
+  fprintf fmt "@[<v>";
+  fprintf fmt "%s@;" "Mixfix directives are not supported by this parser.";
+  fprintf fmt "%s@;" "";
+  fprintf fmt "%s@;" "The parser is based on token families.";
+  fprintf fmt "%s@;" "A family is identified by some starting characters, for example";
+  fprintf fmt "%s@;" "a token '+-->' belongs to the family of '+'. There is no need";
+  fprintf fmt "%s@;" "to declare it.";
+  fprintf fmt "%s@;" "";
+  fprintf fmt "%s@;" "All the tokens of a family are parsed with the same precedence and";
+  fprintf fmt "%s@;" "associativity, for example 'x +--> y *--> z' is parsed as";
+  fprintf fmt "%s@;" "'x +--> (y *--> z)' since the family of '*' has higher precedence";
+  fprintf fmt "%s@;" "than the family of '+'.";
+  fprintf fmt "%s@;" "";
+  fprintf fmt "%s@;" "Here the table of tokens and token families.";
+  fprintf fmt "%s@;" "Token families are represented by the start symbols followed by '..'.";
+  fprintf fmt "%s@;" "Tokens of families marked with [*] cannot end with the starting symbol,";
+  fprintf fmt "%s@;" "eg `foo` is not an infix, while `foo is.";
+  fprintf fmt "%s@;" "The listing is ordered by increasing precedence.";
+  fprintf fmt "%s@;" "";
+  pp_open_tbox fmt ();
+  pp_set_tab fmt ();
+  fprintf fmt "%-25s  " "fixity";
+  pp_set_tab fmt ();
+  fprintf fmt "| %s" "tokens / token families";
+  pp_print_tab fmt ();
+  let col1 = "--------------------------" in
+  fprintf fmt "%s" col1;
+  pp_print_tab fmt ();
+  fprintf fmt "+ -----------------------------------";
+  pp_print_tab fmt ();
+  List.iter (fun { tokens; fixity; _ } ->
+    fprintf fmt "%a" pp_fixity fixity;
+    pp_print_tab fmt ();
+    let s =
+      let b = Buffer.create 80 in
+      let fmt = formatter_of_buffer b in
+      pp_set_margin fmt 40;
+      fprintf fmt "| ";
+      pp_open_hovbox fmt 1;
+      fprintf fmt "%a" pp_tok_list tokens;
+      pp_close_box fmt ();
+      pp_print_flush fmt ();
+      let s = Buffer.contents b in
+      let pad = "\n" ^ String.(make (length col1) ' ') in
+      Re.Str.(global_replace (regexp_string "\n") pad s)
+    in
+    fprintf fmt "%s" s;
+    pp_print_tab fmt ();
+    ) mixfix_symbols;
+  pp_close_tbox fmt ();
+  fprintf fmt "%s@;" "";
+  fprintf fmt "%s@;" "If the token is a valid mixfix, and you want the file to stay compatible";
+  fprintf fmt "%s@;" "with Teyjus, you can ask Elpi to skip the directive. Eg:";
+  fprintf fmt "%s@;" "";
+  fprintf fmt "%s@;" "% elpi:skip 2  // skips the next two lines";
+  fprintf fmt "%s@;" "infixr ==> 120.";
+  fprintf fmt "%s@;" "infixr || 120.";
+  fprintf fmt "%s@;" "";
+  fprintf fmt "%s@;" "As a debugging facility one can ask Elpi to print the AST in order to";
+  fprintf fmt "%s@;" "verify how the text was parsed. Eg:";
+  fprintf fmt "%s@;" "";
+  fprintf fmt "%s@;" "echo 'X = a || b ==> c' | elpi -parse-term";
+  fprintf fmt "@]";
+  pp_print_flush fmt ();
+  Buffer.contents b
+;;
+
+let error_mixfix loc =
+  raise (ParseError(loc,legacy_parser_compat_error))

--- a/src/parser/test_lexer.ml
+++ b/src/parser/test_lexer.ml
@@ -1,0 +1,191 @@
+open Elpi_lexer_config
+open Elpi_parser
+
+type t = Tokens.token =
+  | VDASH
+  | USE_SIG
+  | USEONLY
+  | TYPEABBREV
+  | TYPE
+  | STRING of ( string )
+  | SLASH
+  | SIGMA
+  | SIG
+  | SHORTEN
+  | RULE
+  | RPAREN
+  | RCURLY
+  | RBRACKET
+  | QUOTED of ( string )
+  | QDASH
+  | PRED
+  | PIPE
+  | PI
+  | OR
+  | NIL
+  | NAMESPACE
+  | NAME
+  | MODULE
+  | MODE
+  | MOD
+  | MINUSs
+  | MINUSr
+  | MINUSi
+  | MINUS
+  | MACRO
+  | LPAREN
+  | LOCALKIND
+  | LOCAL
+  | LCURLY
+  | LBRACKET
+  | KIND
+  | IS
+  | IO of (char)
+  | INTEGER of ( int )
+  | INDEX
+  | IMPORT
+  | IFF
+  | IF
+  | FULLSTOP
+  | FRESHUV
+  | FLOAT of ( float )
+  | FIXITY of (string)
+  | FAMILY_TIMES of (string)
+  | FAMILY_TILDE of (string)
+  | FAMILY_TICK of (string)
+  | FAMILY_SHARP of (string)
+  | FAMILY_QMARK of (string)
+  | FAMILY_PLUS of (string)
+  | FAMILY_OR of (string)
+  | FAMILY_MINUS of (string)
+  | FAMILY_LT of (string)
+  | FAMILY_GT of (string)
+  | FAMILY_EXP of (string)
+  | FAMILY_EQ of (string)
+  | FAMILY_BTICK of (string)
+  | FAMILY_AND of (string)
+  | EXTERNAL
+  | EXPORTDEF
+  | EQ2
+  | EQ
+  | EOF
+  | DIV
+  | DARROW
+  | CUT
+  | CONSTRAINT
+  | CONSTANT of ( string )
+  | CONS
+  | CONJ
+  | COLON
+  | CLOSED
+  | BIND
+  | BEFORE
+  | AS
+  | ARROW
+  | AFTER
+  | ACCUM_SIG
+  | ACCUMULATE
+[@@deriving show]
+
+let error s n msg =
+  Printf.eprintf "lexing '%s' at char %d: %s\n" s n msg;
+  exit 1
+
+let validate s (tok1,lnum1,bol1,cnum1) (tok2,lnum2, bol2, cnum2) =
+  if tok1 <> tok2 then error s cnum2   (Printf.sprintf "wrong token: got %s instead of %s" (show tok2) (show tok1));
+  if lnum1 <> lnum2 then error s cnum2 (Printf.sprintf "wrong line number: got %d instead of %d" lnum2 lnum1);
+  if bol1 <> bol2 then error s cnum2   (Printf.sprintf "wrong begin of line: got %d instead of %d" bol2 bol1);
+  if cnum1 <> cnum2 then error s cnum2 (Printf.sprintf "wrong char count: got %d instead of %d" cnum2 cnum1)
+
+type exp = T of t * int * int * int | E
+
+let rec expect s b = function
+  | [] -> ()
+  | sp :: spec ->
+      begin try
+      let tok2 = Lexer.token b in
+      let open Lexing in
+      let p = b.lex_curr_p in
+      let lnum2, bol2, cnum2 = p.pos_lnum, p.pos_bol, p.pos_cnum in
+      match sp with
+        | T (tok1,lnum1,bol1,cnum1) -> validate s (tok1,lnum1,bol1,cnum1) (tok2,lnum2, bol2, cnum2)
+        | E -> error s cnum2 (Printf.sprintf "wrong lexing: got %s instead of error" (show tok2))
+      with Failure _ ->
+        match sp with
+        | E -> ()
+        | T (tok1,_,_,cnum1) -> error s cnum1 (Printf.sprintf "wrong lexing: got error instead of %s" (show tok1))
+      end;
+      expect s b spec
+
+let test s spec =
+  let s = Str.global_replace (Str.regexp_string "\r") "" s in
+  let b = Lexing.from_string s in
+  expect s b spec
+
+let () =
+  (*    01234567890123456789012345 *)
+  test  "3.4"                        [T(FLOAT 3.4, 1, 0, 3)];
+  test  " 3.4"                       [T(FLOAT 3.4, 1, 0, 4)];
+  test  "\n3.4"                      [T(FLOAT 3.4, 2, 1, 4)];
+  test  "3.4 .5"                     [T(FLOAT 3.4, 1, 0, 3); T(FLOAT 0.5, 1, 0, 6)];
+  test  "3.4\n .5"                   [T(FLOAT 3.4, 1, 0, 3); T(FLOAT 0.5, 2, 4, 7)];
+  (*    01234567890123456789012345 *)
+  test  "3 .4"                       [T(INTEGER 3, 1, 0, 1); T(FLOAT 0.4, 1, 0, 4)];
+  test  "3..4"                       [T(INTEGER 3, 1, 0, 1); T(FULLSTOP, 1, 0, 2); T(FLOAT 0.4, 1, 0, 4)];
+  test  "3."                         [T(INTEGER 3, 1, 0, 1); T(FULLSTOP, 1, 0, 2)];
+  test  "-3."                        [T(INTEGER (-3), 1, 0, 2); T(FULLSTOP, 1, 0, 3)];
+  (*    01234567890123456789012345 *)
+  test  "3%...\n3"                   [T(INTEGER 3, 1, 0, 1); T(INTEGER 3, 2, 6, 7)];
+  test  "3/*..*/3"                   [T(INTEGER 3, 1, 0, 1); T(INTEGER 3, 1, 0, 8)];
+  test  "3/** T **/3"                [T(INTEGER 3, 1, 0, 1); T(INTEGER 3, 1, 0, 11)];
+  test  "3/*\n.*/3"                  [T(INTEGER 3, 1, 0, 1); T(INTEGER 3, 2, 4, 8)];
+  test  "3/*\n/*\n*/*/3"             [T(INTEGER 3, 1, 0, 1); T(INTEGER 3, 3, 7, 12)];
+  test  "3/*"                        [T(INTEGER 3, 1, 0, 1); E];
+  (*    01234567890123456789012345 *)
+  test {|"a"|}                        [T(STRING "a", 1, 0, 3)];
+  test {|"a""b"|}                     [T(STRING "a\"b", 1, 0, 6)];
+  test {|"a\nb"|}                     [T(STRING "a\nb", 1, 0, 6)];
+  test {|"a
+b"|}                                  [T(STRING "a\nb", 2, 3, 5)];
+  (*    01234567890123456789012345 *)
+  test  "x"                           [T(CONSTANT "x", 1, 0, 1)];
+  test  "x-y"                         [T(CONSTANT "x-y", 1, 0, 3)];
+  test  "-y"                          [T(MINUS, 1, 0, 1); T(CONSTANT "y",1,0,2)];
+  test  "_y"                          [T(CONSTANT "_y", 1, 0, 2)];
+  test  "_X"                          [T(CONSTANT "_X", 1, 0, 2)];
+  test  "X_"                          [T(CONSTANT "X_", 1, 0, 2)];
+  test  "x?"                          [T(CONSTANT "x?", 1, 0, 2)];
+  test  "X"                           [T(CONSTANT "X", 1, 0, 1)];
+  test  "X1>@!"                       [T(CONSTANT "X1>@!", 1, 0, 5)];
+  test  "a.B.c"                       [T(CONSTANT "a.B.c", 1, 0, 5)];
+  test  "a.B."                        [T(CONSTANT "a.B", 1, 0, 3); T(FULLSTOP, 1, 0, 4)];
+  test  "a.>"                         [T(CONSTANT "a", 1, 0, 1); T(FULLSTOP, 1, 0, 2); T(FAMILY_GT ">", 1, 0, 3)];
+  (*    01234567890123456789012345 *)
+  test  "-->"                         [T(FAMILY_MINUS "-->", 1, 0, 3)];
+  test  "x.y->z"                      [T(CONSTANT "x.y->z", 1, 0, 6)];
+  (*    01234567890123456789012345 *)
+  test  "{{{ }} }}}"                  [T(QUOTED " }} ", 1, 0, 10)];
+  test  "{{ {{ } }} }}"               [T(QUOTED " {{ } }} ", 1, 0, 13)];
+  test  "{{ x }}3"                    [T(QUOTED " x ", 1, 0, 7); T(INTEGER 3, 1, 0, 8)];
+  test  "{{{ x }}}3"                  [T(QUOTED " x ", 1, 0, 9); T(INTEGER 3, 1, 0, 10)];
+  test  "{{\n x }}3"                  [T(QUOTED "\n x ", 2, 4, 8); T(INTEGER 3, 2, 4, 9)];
+  (*    01234567890123456789012345 *)
+  test  "foo :- bar."                 [T(CONSTANT "foo", 1, 0, 3); T(VDASH, 1, 0, 6); T(CONSTANT "bar", 1, 0, 10); T(FULLSTOP, 1, 0, 11)];
+  test  "foo ?- bar."                 [T(CONSTANT "foo", 1, 0, 3); T(QDASH, 1, 0, 6); T(CONSTANT "bar", 1, 0, 10); T(FULLSTOP, 1, 0, 11)];
+  test  "foo :- x \\ bar."            [T(CONSTANT "foo", 1, 0, 3); T(VDASH, 1, 0, 6); T(CONSTANT "x", 1, 0, 8); T(BIND, 1, 0, 10); T(CONSTANT "bar", 1, 0, 14); T(FULLSTOP, 1, 0, 15)];
+  test  "foo, bar"                    [T(CONSTANT "foo", 1, 0, 3); T(CONJ, 1, 0, 4); T(CONSTANT "bar", 1, 0, 8) ];
+  test  "[]"                          [T(LBRACKET, 1, 0, 1); T(RBRACKET, 1, 0, 2)];
+  (*    01234567890123456789012345 *)
+  test  "X"                           [T(CONSTANT "X", 1, 0, 1) ];
+  test  "is"                          [T(IS, 1, 0, 2) ];
+  test  "#line 3 \"xx\"\na"           [T(CONSTANT "a", 3, 0, 1) ];
+  test  "b\n#line 3 \"xx\"\na"        [T(CONSTANT "b", 1, 0, 1);T(CONSTANT "a", 3, 2, 1) ];
+  test  {|
+b
+c
+#line 7 "xx"
+a|}                                   [T(CONSTANT "b", 2, 1, 2);T(CONSTANT "c", 3, 3, 4);T(CONSTANT "a", 7, 5, 1) ];
+  (*    01234567890123456789012345 *)
+  test  ":name"                       [T(COLON,1,0,1); T(NAME,1,0,5)];
+  test  "@foo"                        [T(CONSTANT "@foo",1,0,4)];
+  test  "a && b"                       [T(CONSTANT "a",1,0,1);T(FAMILY_AND "&&",1,0,4);T(CONSTANT "b",1,0,6)];

--- a/src/parser/test_parser.ml
+++ b/src/parser/test_parser.ml
@@ -1,0 +1,182 @@
+open Elpi_parser
+open Ast
+open Ast.Program
+open Ast.Term
+
+let error s a1 a2 =
+  Printf.eprintf "error parsing '%s':\n%!" s;
+  let f1 = Filename.temp_file "parser_out" "txt" in
+  let f2 = Filename.temp_file "parser_out" "txt" in
+  let oc1 = open_out f1 in
+  let oc2 = open_out f2 in
+  output_string oc1 "new:\n";
+  output_string oc1 (Program.show a1);
+  output_string oc2 "reference:\n";
+  output_string oc2 (Program.show a2);
+  flush_all ();
+  close_out oc1;
+  close_out oc2;
+  let _ = Sys.command (Printf.sprintf "cat %s; cat %s;wdiff -t %s %s" f1 f2 f1 f2) in
+  exit 1
+
+let underscore () = Const (Func.dummyname)
+
+let mkClause loc attributes body =
+  let open Clause in
+  Clause { loc; attributes; body }
+
+let mkLoc x y w z =
+  { Loc.source_name = "(input)"; source_start = x; source_stop = y; line = w; line_starts_at = z}
+  
+
+let chunk s (p1,p2) =
+  String.sub s p1.Lexing.pos_cnum (p2.Lexing.pos_cnum - p1.Lexing.pos_cnum)
+
+let message_of_state s = try Error_messages.message s with Not_found -> "syntax error"
+
+module Parser = Parse.Make(struct let resolver = Elpi_util.Util.std_resolver ~paths:[] () end)
+let test s x y w z att b =
+  let exp = [mkClause (mkLoc x y w z) att b] in
+  let lexbuf = Lexing.from_string s in
+  let loc = Loc.initial "(input)" in
+  try
+    let p = Parser.program_from ~loc lexbuf in
+    if p <> exp then
+      error s p exp
+    with Parse.ParseError(loc,message) ->
+      Printf.eprintf "error parsing '%s' at %s\n%s%!" s (Loc.show loc) message;
+      exit 1
+
+let testR s x y w z attributes to_match to_remove guard new_goal =
+  let exp = [Program.(Chr { Chr.to_match; to_remove; guard; new_goal; loc=(mkLoc x y w z); attributes })] in
+  let lexbuf = Lexing.from_string s in
+  let loc = Loc.initial "(input)" in
+  try
+    let p = Parser.program_from ~loc lexbuf in
+    if p <> exp then
+      error s p exp
+    with Parse.ParseError(loc,message) ->
+      Printf.eprintf "error parsing '%s' at %s\n%s%!" s (Loc.show loc) message;
+      exit 1
+     
+let testF s i msg =
+  let lexbuf = Lexing.from_string s in
+  let loc = Loc.initial "(input)" in
+  try
+    let _ = Parser.program_from ~loc lexbuf in
+    Printf.eprintf "error, '%s' should not parse\n%!" s;
+    exit 1
+  with Parse.ParseError(loc,message) ->
+    if not @@ Str.string_match (Str.regexp_case_fold msg) message 0 then begin
+      Printf.eprintf "error, '%s' fails with message '%s'\nwhich does not match '%s'\n%!" s message msg;   
+      exit 1;
+    end;
+    if loc.Loc.source_start <> i then begin
+      Printf.eprintf "error, '%s' fails at %d instead of %d\n%!" s loc.Loc.source_start i;
+      exit 1;
+    end
+
+
+let (|-) a b = App (mkCon ":-",[a;b])
+let (@) a b = App (mkCon a,b)
+
+let (-->) x b = mkLam x b
+
+let c s = mkCon s
+let str s = mkC (cstring.Elpi_util.Util.CData.cin s)
+
+let ss t = { Chr.eigen = underscore (); context = underscore (); conclusion = t }
+let s e g t = { Chr.eigen = e; context = g; conclusion = t }
+
+let _ =
+  (*    01234567890123456789012345 *)
+  test  "p :- q."           0 6  1 0 [] (c"p" |- c"q");
+  test  "p :- q r."         0 8  1 0 [] (c"p" |- "q" @ [c"r"]);
+  test  "p :- !, q."        0 9  1 0 [] (c"p" |- "," @ [c"!"; c"q"]);
+  test  "p :- q r s."       0 10 1 0 [] (c"p" |- "q" @ [c"r";c"s"]);
+  test  "p :- x \\ q r."    0 12 1 0 [] (c"p" |- "x" --> ("q" @ [c"r"]));
+  test  "p :- _ \\ q r."    0 12 1 0 [] (c"p" |- "%dummy" --> ("q" @ [c"r"]));
+  test  "(A ; B) :- A."     0 12 1 0 [] (";" @ [c"A";c"B"] |- c"A");
+  (*    01234567890123456789012345 *)
+  test  "p :- pi x \\ q."   0 13 1 0 [] (c"p" |- "pi" @ ["x" --> (c"q")]);
+  test  "p :- q, r."        0 9  1 0 [] (c"p" |- "," @ [c"q";c"r"]);
+  test  "p :- f q, r."      0 11 1 0 [] (c"p" |- "," @ ["f" @ [c"q"];c"r"]);
+  test  "p :- q, r, s."     0 12 1 0 [] (c"p" |- "," @ [c"q"; c"r"; c"s"]);
+  (*    01234567890123456789012345 *)
+  test  "p :- q + r * s."   0 14 1 0 [] (c"p" |- "+" @ [c"q"; "*" @ [c"r";c"s"]]);
+  test  "p :- q + r , s."   0 14 1 0 [] (c"p" |- "," @ ["+" @ [c"q"; c"r" ]; c"s"]);
+  test  "p :- q && r = s."  0 15 1 0 [] (c"p" |- "=" @ ["&&" @ [c"q"; c"r"]; c"s"]);
+  test  "q && r x || s."    0 13 1 0 [] ("||" @ ["&&" @ [c"q";"r"@[c"x"]]; c"s"]);
+  test  "f x ==> y."        0 9 1 0 []  ("==>" @ ["f" @ [c"x"]; c"y"]);
+  test  "p :- !, (s X) = X, q." 0 20 1 0 [] (c"p" |- "," @ [c"!";"=" @ ["s" @ [c"X"]; c"X"]; c"q"]);
+  test  "p :- []."          0 7  1 0 [] (c"p" |- mkNil);
+  test  "name."             0 4  1 0 [] (c "name");
+  test  "p :- a => b => c." 0 16 1 0 [] (":-" @ [c"p";"=>" @ [c"a";"=>"@[c"b";c"c"]]]); 
+  (*    01234567890123456789012345 *)
+  test  "p :- [a,b]."       0 10  1 0 [] (c"p" |- mkSeq [c"a";c"b";mkNil]);
+  test  "p :- [a,{b}]."     0 12  1 0 [] (c"p" |- mkSeq [c"a";"%spill"@[c"b"];mkNil]);
+  test  "p :- [(a + b)]."   0 14  1 0 [] (c"p" |- mkSeq ["+" @ [c"a";c"b"];mkNil]);
+  test  "p :- [a + b]."     0 12  1 0 [] (c"p" |- mkSeq ["+" @ [c"a";c"b"];mkNil]);
+  test  "p :- [f a,b]."     0 12  1 0 [] (c"p" |- mkSeq ["f" @ [c"a"];c"b";mkNil]);
+  test  "p :- [(a,b)]."     0 12  1 0 [] (c"p" |- mkSeq ["," @ [c"a";c"b"];mkNil]);
+  test  "p :- [a,b|c]."     0 12  1 0 [] (c"p" |- mkSeq [c"a";c"b";c"c"]);
+  test  "p :- [a,b\\@f, x\\b]." 0 18  1 0 [] (c"p" |- mkSeq [c"a";"b" --> ("," @ [c"@f"; "x" --> c"b"]);mkNil]);
+  test  "X is a."           0 6  1 0 [] ("is" @ [c"X";c"a"]);
+  testF "p :- f use_sig."   14 ".*term expected";
+  testF "X is ."            6 ".*expects a right hand side";
+  testF "X + ."             5 ".*expects a right hand side";
+  testF "X * ."             5 ".*expects a right hand side";
+  test  "p :- X is a, Y is b."   0 19 1 0 [] (":-" @ [c"p";"," @ ["is" @ [c"X";c"a"];"is" @ [c"Y";c"b"]]]);
+  test  "p (f x\\ _ as y)." 0 15 1 0 [] ("p" @ ["as" @ ["f"@["x" --> c"%dummy"];c"y"]]);
+  (*    01234567890123456789012345 *)
+  testF ":-"                2 "unexpected start";
+  testF "type ( -> :-"      12 ".*parenthesis.*expected";
+  testF "+"                 1 "unexpected start";
+  testF "x. x)"             5 "unexpected ')'";
+  testF "x. +"              4 "unexpected start";
+  test  ":name \"x\" x."     0 11 1 0 [Name "x"] (c"x");
+  testF "p :- g (f x) \\ y." 14 ".*bind.*must follow.*name.*";
+  (*    01234567890123456789012345 *)
+  testF ":nam \"x\" x."     4 "attribute expected";
+  testR "rule p (q r)."     0 12 1 0 [] [ss (c"p");ss ("q" @ [c"r"])] [] None None;
+  testR "rule (E : G ?- r)."0 17 1 0 [] [s (c "E") (c"G") (c"r")] [] None None;
+  test  "p :- f \".*\\\\.aux\"." 0 17 1 0 [] (":-" @ [c"p";"f"@ [str ".*\\.aux"]]);
+;;
+
+(* test that all families of tokens are parsed as such *)
+let sanity_check : unit =
+  let open Elpi_lexer_config in
+  let open Lexer_config in
+  let open Tokens in
+  let open Elpi_util in
+  let extensible_SYMB =
+    mixfix_symbols |> List.map (fun { tokens; fixity; _ } ->
+      Util.map_filter (fun x ->
+        let start, mk_token, enclose, x =
+          match x with
+          | Fixed { the_token; mk_token; _ } ->
+              the_token, (fun _ -> mk_token), None, None
+          | Extensible ({ start; mk_token; non_enclosed ; at_least_one_char; _ } as e)->
+              let start = if at_least_one_char then start ^ "x" else start in
+              start, mk_token, (if non_enclosed then Some (fun x -> start ^ x ^ start) else None), Some e in
+    let tok = Lexer.token (Lexing.from_string start) in
+    let token = mk_token start in
+    assert(tok = token);
+    begin try match fixity with
+    | Infix | Infixl | Infixr ->
+        ignore(Parser.Internal.infix_SYMB Lexer.token (Lexing.from_string start))
+    | Postfix ->
+        ignore(Parser.Internal.postfix_SYMB Lexer.token (Lexing.from_string start))
+    | Prefix ->
+        ignore(Parser.Internal.prefix_SYMB Lexer.token (Lexing.from_string start))
+    with _ -> Printf.eprintf "error parsing %s\n" start; exit 1
+    end;
+    begin match enclose with
+    | None -> ()
+    | Some f ->
+      let v = f "xx" in
+      assert(CONSTANT v = Lexer.token (Lexing.from_string v));
+    end;
+    x) tokens) |> List.concat |> List.length in
+  assert(extensible_SYMB = 14)
+

--- a/src/parser/token_precedence.mly
+++ b/src/parser/token_precedence.mly
@@ -1,0 +1,20 @@
+%right BIND
+%nonassoc VDASH QDASH 
+%right OR 
+%right CONJ 
+%right ARROW 
+%right DARROW 
+%nonassoc EQ EQ2 FAMILY_LT FAMILY_GT IS 
+%right CONS 
+%nonassoc FAMILY_TICK 
+%left FAMILY_EXP FAMILY_PLUS MINUS MINUSr MINUSi MINUSs 
+%left FAMILY_TIMES SLASH DIV MOD 
+%right FAMILY_MINUS 
+%nonassoc FAMILY_BTICK 
+%right FAMILY_EQ 
+%right FAMILY_OR 
+%right FAMILY_AND 
+%left FAMILY_SHARP 
+%nonassoc FAMILY_TILDE 
+%nonassoc FAMILY_QMARK 
+%%

--- a/src/parser/tokens.mly
+++ b/src/parser/tokens.mly
@@ -1,0 +1,86 @@
+%token FULLSTOP
+%token < string > CONSTANT
+%token VDASH
+%token QDASH
+%token < int > INTEGER
+%token < float > FLOAT
+%token < string > STRING
+%token FRESHUV
+%token CUT
+%token COLON
+%token BIND
+%token LPAREN
+%token RPAREN
+%token LBRACKET
+%token RBRACKET
+%token LCURLY
+%token RCURLY
+%token PIPE
+%token AS
+%token IS
+%token <char> IO
+%token ARROW
+%token DARROW
+%token DIV
+%token MOD
+%token < string > QUOTED
+%token SHORTEN
+%token ACCUMULATE
+%token LOCAL
+%token PRED
+%token MINUS
+%token MINUSr
+%token MINUSi
+%token MINUSs
+%token MODE
+%token MACRO
+%token RULE
+%token NAMESPACE
+%token CONSTRAINT
+%token KIND
+%token TYPE
+%token TYPEABBREV
+%token EXTERNAL
+%token MODULE
+%token SIG
+%token IMPORT
+%token ACCUM_SIG
+%token USE_SIG
+%token LOCALKIND
+%token USEONLY
+%token EXPORTDEF
+%token CLOSED
+%token <string> FIXITY
+%token PI
+%token SIGMA
+%token IF
+%token BEFORE
+%token AFTER
+%token NAME 
+%token INDEX 
+%token CONS
+%token CONJ
+%token OR
+%token EQ
+%token EQ2
+%token IFF
+%token NIL
+%token EOF
+
+%token <string> FAMILY_PLUS
+%token <string> FAMILY_TIMES
+%token <string> FAMILY_MINUS
+%token <string> FAMILY_EXP
+%token <string> FAMILY_LT
+%token <string> FAMILY_GT
+%token <string> FAMILY_EQ
+%token <string> FAMILY_QMARK
+%token <string> FAMILY_BTICK
+%token <string> FAMILY_TICK
+%token <string> FAMILY_SHARP
+%token <string> FAMILY_TILDE
+%token <string> FAMILY_AND
+%token <string> FAMILY_OR
+%token SLASH
+
+%%

--- a/src/ptmap.ml
+++ b/src/ptmap.ml
@@ -225,7 +225,7 @@ let to_list s =
 
 let pp f fmt m =
   let l = to_list m in
-  Util.(pplist (pp_pair Int.pp f) " " fmt l)
+  Elpi_util.Util.(pplist (pp_pair Int.pp f) " " fmt l)
 
 let show f m =
   let b = Buffer.create 20 in

--- a/src/runtime.mli
+++ b/src/runtime.mli
@@ -2,6 +2,8 @@
 (* license: GNU Lesser General Public License Version 2.1 or later           *)
 (* ------------------------------------------------------------------------- *)
 
+open Elpi_util
+
 open Util
 open Data
 

--- a/src/utils/dune
+++ b/src/utils/dune
@@ -1,0 +1,5 @@
+(library
+  (name elpi_util)
+  (public_name elpi.util)
+  (libraries re.str)
+  (modules util))

--- a/src/utils/util.mli
+++ b/src/utils/util.mli
@@ -117,7 +117,6 @@ val map_acc : ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
 val map_acc2 : ('acc -> 'a -> 'b -> 'acc * 'c) -> 'acc -> 'a list -> 'b list -> 'acc * 'c list
 val map_acc3 : ('acc -> 'a -> 'b -> 'd -> 'acc * 'c) -> 'acc -> 'a list -> 'b list -> 'd list -> 'acc * 'c list
 val partition_i : (int -> 'a -> bool) -> 'a list -> 'a list * 'a list
-val partition_i : (int -> 'a -> bool) -> 'a list -> 'a list * 'a list
 val fold_left2i :
   (int -> 'acc -> 'x -> 'y -> 'acc) -> 'acc -> 'x list -> 'y list -> 'acc
 val uniq : 'a list -> 'a list
@@ -131,6 +130,7 @@ val pp_option :
 val option_mapacc :
   ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a option -> 'acc * 'b option
 val option_iter : ('a -> unit) -> 'a option -> unit
+val option_default : 'a -> 'a option -> 'a
 
 (***************** Unique ID ****************)
 
@@ -162,9 +162,10 @@ val pp_pair :
   (Format.formatter -> 'a -> unit) ->
   (Format.formatter -> 'b -> unit) ->
     Format.formatter -> 'a * 'b -> unit
-val pp_option :
-  (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a option -> unit
-
+val show_pair :
+  (Format.formatter -> 'a -> unit) ->
+  (Format.formatter -> 'b -> unit) ->
+    ('a * 'b) -> string
 
 (* for open types *)
 type 'a spaghetti_printer
@@ -264,3 +265,7 @@ module CData : sig
   val map : 'a cdata -> 'b cdata -> ('a -> 'b) -> t -> t
 end
 
+(* file access *)
+val std_resolver :
+  ?cwd:string -> paths:string list -> unit ->
+     (?cwd:string -> unit:string -> unit -> string)

--- a/tests/dune
+++ b/tests/dune
@@ -8,7 +8,6 @@
        (test_suite ANSITerminal cmdliner str unix -> test.real.ml)
        (-> test.dummy.ml)))
 )
-
 (env
   (dev
     (flags (:standard -w -9 -w -32 -w -27 -w -6 -w -37 -warn-error -A))))

--- a/tests/dune
+++ b/tests/dune
@@ -10,4 +10,6 @@
 )
 (env
   (dev
-    (flags (:standard -w -9 -w -32 -w -27 -w -6 -w -37 -warn-error -A))))
+    (flags (:standard -w -9 -w -32 -w -27 -w -6 -w -37 -warn-error -A)))
+  (fatalwarnings
+    (flags (:standard -w -9 -w -32 -w -27 -w -6 -w -37 -warn-error +A))))

--- a/tests/sources/hollight.elpi
+++ b/tests/sources/hollight.elpi
@@ -1,15 +1,3 @@
-% vim: set ft=lprolog:
-
-infixr --> 126. % type arrow
-infixl '   255. % infix application
-infixl ''  255. % infix System-F application
-infixl &&  128. % and
-infixl `or  127. % or
-infixr ==> 126. % implication
-infixr <=> 125. % iff
-infix  #in 135. % membership
-infix  <<= 130. % subseteq
-
 /* Untrusted predicates called from the kernel:
  * next_object            next object to check
  * callback_proved        proof completed
@@ -70,45 +58,45 @@ typ T :- !. % this line temporarily drops checking of well-formedness for types
 typ T :- var T, !, declare_constraint (typ T) [ T ].
 typ T :- typ' T.
 typ' prop.
-typ' (univ '' A '' B) :- typ A, typ B.
+typ' (univ ## A ## B) :- typ A, typ B.
 typ' (A --> B) :- typ A, typ B.
-typ' (disj_union '' A '' B) :- typ A, typ B.
+typ' (disj_union ## A ## B) :- typ A, typ B.
 
 mode (term i o).
 term (lam A F) (A --> B) :- typ A, pi x\ term x A => term (F x) B.
-term (F ' T) B :- term F (A --> B), term T A.
-term (eq '' A) (A --> A --> prop) :- typ A.
+term (F # T) B :- term F (A --> B), term T A.
+term (eq ## A) (A --> A --> prop) :- typ A.
 term (uvar as T) TY :- declare_constraint (term T TY) T.
 
 /* like term, but on terms that are already known to be well-typed */
 mode (reterm i o).
 reterm (lam A F) (A --> B) :- pi x\ reterm x A => reterm (F x) B.
-reterm (F ' T) B :- reterm F (A --> B).
-reterm (eq '' A) (A --> A --> prop).
+reterm (F # T) B :- reterm F (A --> B).
+reterm (eq ## A) (A --> A --> prop).
 reterm (uvar as T) TY :- declare_constraint (reterm T TY) T.
 
 constraint term reterm { /* No propagation rules for now */}
 
 % thm : bounded tactic -> bounded sequent -> list (bounded sequent) -> o
-thm C (seq Gamma G) _ :- debug, $print Gamma "|- " G " := " C, fail.
+thm C (seq Gamma G) _ :- debug, print Gamma "|- " G " := " C, fail.
 
 /* << HACKS FOR DEBUGGING */
 thm daemon (seq Gamma F) [].
 /* >> HACKS FOR DEBUGGING */
 
-thm r (seq Gamma (eq '' _ ' X ' X)) [].
-thm (t Y) (seq Gamma (eq '' A ' X ' Z))
- [ seq Gamma (eq '' A ' X ' Y), seq Gamma (eq '' A ' Y ' Z) ] :- term Y A.
-thm (m P) (seq Gamma Q) [ seq Gamma (eq '' prop ' P ' Q), seq Gamma P ] :- term P prop.
-thm b (seq Gamma (eq '' _ ' ((lam _ F) ' X) ' (F X))) [].
-thm c (seq Gamma (eq '' B ' (F ' X) ' (G ' Y)))
- [ seq Gamma (eq '' (A --> B) ' F ' G) , seq Gamma (eq '' A ' X ' Y) ] :- reterm X A, reterm Y A.
-thm k (seq Gamma (eq '' (A --> B) ' (lam A S) ' (lam A T)))
- [ bind A x \ seq Gamma (eq '' B ' (S x) ' (T x)) ].
-thm s (seq Gamma (eq '' prop ' P ' Q)) [ seq (P :: Gamma) Q, seq (Q :: Gamma) P ].
+thm r (seq Gamma (eq ## _ # X # X)) [].
+thm (t Y) (seq Gamma (eq ## A # X # Z))
+ [ seq Gamma (eq ## A # X # Y), seq Gamma (eq ## A # Y # Z) ] :- term Y A.
+thm (m P) (seq Gamma Q) [ seq Gamma (eq ## prop # P # Q), seq Gamma P ] :- term P prop.
+thm b (seq Gamma (eq ## _ # ((lam _ F) # X) # (F X))) [].
+thm c (seq Gamma (eq ## B # (F # X) # (G # Y)))
+ [ seq Gamma (eq ## (A --> B) # F # G) , seq Gamma (eq ## A # X # Y) ] :- reterm X A, reterm Y A.
+thm k (seq Gamma (eq ## (A --> B) # (lam A S) # (lam A T)))
+ [ bind A x \ seq Gamma (eq ## B # (S x) # (T x)) ].
+thm s (seq Gamma (eq ## prop # P # Q)) [ seq (P :: Gamma) Q, seq (Q :: Gamma) P ].
 thm (h IGN) (seq Gamma P) [] :- append' IGN [ P | Gamma2 ] Gamma.
 
-thm d (seq Gamma (eq '' _ ' C ' A)) [] :- def0 C A.
+thm d (seq Gamma (eq ## _ # C # A)) [] :- def0 C A.
 thm (th NAME) (seq _ G) [] :- provable NAME G.
 
 thm (thenll TAC1 TACN) SEQ SEQS :-
@@ -118,7 +106,7 @@ thm (thenll TAC1 TACN) SEQ SEQS :-
 
 /*debprint _ (then _ _) :- !.
 debprint _ (thenl _ _) :- !.
-debprint O T :- $print O T.*/
+debprint O T :- print O T.*/
 
 thm TAC SEQ SEQS :-
  deftac TAC SEQ XTAC,
@@ -142,10 +130,10 @@ thm (bind A TAC) (bind A SEQ) NEWL :-
 thm ww (bind A x \ SEQ) [ SEQ ].
 
 /* debuggin only, remove it */
-%thm A B C :- $print "FAILED " (thm A B C), fail.
+%thm A B C :- print "FAILED " (thm A B C), fail.
 
 % loop : list (bounded sequent) -> certificate -> o
-%loop SEQS TACS :- $print "LOOP" (loop SEQS TACS), fail.
+%loop SEQS TACS :- print "LOOP" (loop SEQS TACS), fail.
 loop [] CERTIFICATE :- end_of_proof CERTIFICATE.
 loop [ SEQ | OLD ] CERTIFICATE :-
  next_tactic [ SEQ | OLD ] CERTIFICATE ITAC,
@@ -155,22 +143,22 @@ loop [ SEQ | OLD ] CERTIFICATE :-
  loop SEQS NEW_CERTIFICATE.
 
 prove G TACS :-
- (term G prop, ! ; ppterm PG G, $print "Bad statement:" PG, fail),
+ (term G prop, ! ; ppterm PG G, print "Bad statement:" PG, fail),
 % (TACS = (false,_), ! ;
  loop [ seq [] G ] TACS
 . % ).
 
 not_defined P NAME :-
- not (P NAME _) ; $print "Error:" NAME already defined, fail.
+ not (P NAME _) ; print "Error:" NAME already defined, fail.
 
 check_hyps HS (typ' TYPE) :-
- (not (typ' TYPE) ; $print "Error:" TYPE already defined, fail), $print HS new TYPE.
-check_hyps HS (def0 NAME DEF) :- ppterm PDEF DEF, $print HS NAME "=" PDEF.
+ (not (typ' TYPE) ; print "Error:" TYPE already defined, fail), print HS new TYPE.
+check_hyps HS (def0 NAME DEF) :- ppterm PDEF DEF, print HS NAME "=" PDEF.
 check_hyps HS (term NAME TYPE) :-
- not_defined term NAME, ppterm PTYPE TYPE, $print HS NAME ":" PTYPE.
+ not_defined term NAME, ppterm PTYPE TYPE, print HS NAME ":" PTYPE.
 check_hyps HS (reterm _ _).
 check_hyps HS (provable NAME TYPE) :-
- not_defined provable NAME, ppterm PTYPE TYPE, $print HS NAME ":" PTYPE.
+ not_defined provable NAME, ppterm PTYPE TYPE, print HS NAME ":" PTYPE.
 check_hyps HS (H1,H2) :- check_hyps HS H1, check_hyps HS H2.
 check_hyps HS (pi H) :- pi x \ typ' x => check_hyps [x | HS] (H x).
 check_hyps HS (_ => H2) :- check_hyps HS H2.
@@ -185,13 +173,13 @@ check1 (def NAME TYPDEF) HYPS :- check1def NAME TYPDEF true HYPS, !.
 check1 (decl NAME TYP) HYPS :- check1decl NAME TYP true HYPS, !.
 
 check1def NAME (pi I) HYPSUCHTHAT (pi HYPS) :-
- pi x \ typ' x => check1def (NAME '' x) (I x) (HYPSUCHTHAT, typ x) (HYPS x).
+ pi x \ typ' x => check1def (NAME ## x) (I x) (HYPSUCHTHAT, typ x) (HYPS x).
 check1def NAME (TYP,DEF) HYPSUCHTHAT HYPS :-
  typ TYP, term DEF TYP,
  HYPS = ((HYPSUCHTHAT => term NAME TYP), reterm NAME TYP, def0 NAME DEF).
 
 check1decl NAME (pi I) HYPSUCHTHAT (pi HYPS) :-
- pi x \ typ' x => check1decl (NAME '' x) (I x) (HYPSUCHTHAT, typ x) (HYPS x).
+ pi x \ typ' x => check1decl (NAME ## x) (I x) (HYPSUCHTHAT, typ x) (HYPS x).
 check1decl NAME TYP HYPSUCHTHAT HYPS :-
  typ TYP, HYPS = ((HYPSUCHTHAT => term NAME TYP), reterm NAME TYP).
 
@@ -204,19 +192,19 @@ check1thm NAME (GOAL,TACTICS) (provable NAME GOAL) :-
 check1axm NAME (pi I) (pi HYPS) :- !,
  pi x \ typ' x => check1axm NAME (I x) (HYPS x).
 check1axm NAME GOAL (provable NAME GOAL) :-
- term GOAL prop, ! ; ppterm PGOAL GOAL, $print "Bad statement:" PGOAL, fail.
+ term GOAL prop, ! ; ppterm PGOAL GOAL, print "Bad statement:" PGOAL, fail.
 
 check1nbt TYPE REP ABS REPABS ABSREP PREPH (pi P_TACTICS) HYPSUCHTHAT (pi HYPS) :-
- pi x \ typ' x => check1nbt (TYPE '' x) (REP '' x) (ABS '' x) REPABS ABSREP PREPH (P_TACTICS x) (HYPSUCHTHAT, typ x) (HYPS x).
+ pi x \ typ' x => check1nbt (TYPE ## x) (REP ## x) (ABS ## x) REPABS ABSREP PREPH (P_TACTICS x) (HYPSUCHTHAT, typ x) (HYPS x).
 check1nbt TYPE REP ABS REPABS ABSREP PREPH (P,TACTICS) HYPSUCHTHAT HYPS :-
   term P (X --> prop),
-  prove (exists '' _ ' P ) TACTICS,
-  callback_proved existence_condition (exists '' _ ' P) TACTICS,
+  prove (exists ## _ # P ) TACTICS,
+  callback_proved existence_condition (exists ## _ # P) TACTICS,
   REPTYP = (TYPE --> X),
   ABSTYP = (X --> TYPE),
-  ABSREPTYP = (forall '' TYPE ' lam TYPE x \ eq '' TYPE ' (ABS ' (REP ' x)) ' x),
-  REPABSTYP = (forall '' X ' lam X x \ impl ' (P ' x) ' (eq '' X ' (REP ' (ABS ' x)) ' x)),
-  PREPHTYP = (forall '' TYPE ' lam TYPE x \ (P ' (REP ' x))),
+  ABSREPTYP = (forall ## TYPE # lam TYPE x \ eq ## TYPE # (ABS # (REP # x)) # x),
+  REPABSTYP = (forall ## X # lam X x \ impl # (P # x) # (eq ## X # (REP # (ABS # x)) # x)),
+  PREPHTYP = (forall ## TYPE # lam TYPE x \ (P # (REP # x))),
   !,
   HYPS =
    ( (HYPSUCHTHAT => typ' TYPE)
@@ -227,7 +215,7 @@ check1nbt TYPE REP ABS REPABS ABSREP PREPH (P,TACTICS) HYPSUCHTHAT HYPS :-
 
 check WHAT :-
  next_object WHAT C CONT,
- (C = stop, !, K = true ; check1 C H , check_hyps [] H, $print_constraints, K = (H => check CONT)),
+ (C = stop, !, K = true ; check1 C H , check_hyps [] H, print_constraints, K = (H => check CONT)),
  !, K.
 
 }
@@ -236,25 +224,25 @@ check WHAT :-
 % ppterm/parseterm
 %ppterm X Y :- ppp X Y. parseterm X Y :- ppp X Y.
 %ppp X Y :- var X, var Y, !, X = Y.
-%ppp X (F ' G) :- var X, (var F ; var G), !, X = (F ' G).
-%ppp X (F ' G ' H) :- var X, (var F ; var G ; var H), !,
-% X = (F ' G ' H).
+%ppp X (F # G) :- var X, (var F ; var G), !, X = (F # G).
+%ppp X (F # G # H) :- var X, (var F ; var G ; var H), !,
+% X = (F # G # H).
 
 mode (ppp o i) xas ppterm, (ppp i o) xas parseterm.
 
-ppp (! F2) (forall '' _ ' lam _ F1) :- !, pi x \ ppp (F2 x) (F1 x).
-ppp (! TY F2) (forall '' TY ' lam TY F1) :- !, pi x \ ppp (F2 x) (F1 x).
-ppp (? F2) (exists '' _ ' lam _ F1) :- !, pi x \ ppp (F2 x) (F1 x).
-ppp (? TY F2) (exists '' TY ' lam TY F1) :- !, pi x \ ppp (F2 x) (F1 x).
-ppp (F2 <=> G2) (eq '' prop ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
-ppp (F2 = G2) (eq '' _ ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
-ppp (F2 && G2) (and ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
-ppp (F2 `or G2) (or ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
-ppp (F2 ==> G2) (impl ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
-ppp (X2 #in S2) (in '' _ ' X1 ' S1) :- !, ppp X2 X1, ppp S2 S1.
-ppp (U2 <<= V2) (subseteq '' _ ' U1 ' V1) :- !, ppp U2 U1, ppp V2 V1.
-ppp (F2 + G2) (plus ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
-ppp (F2 ' G2) (F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (! F2) (forall ## _ # lam _ F1) :- !, pi x \ ppp (F2 x) (F1 x).
+ppp (! TY F2) (forall ## TY # lam TY F1) :- !, pi x \ ppp (F2 x) (F1 x).
+ppp (? F2) (exists ## _ # lam _ F1) :- !, pi x \ ppp (F2 x) (F1 x).
+ppp (? TY F2) (exists ## TY # lam TY F1) :- !, pi x \ ppp (F2 x) (F1 x).
+ppp (F2 <=> G2) (eq ## prop # F1 # G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (F2 = G2) (eq ## _ # F1 # G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (F2 && G2) (and # F1 # G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (F2 || G2) (or # F1 # G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (F2 ==> G2) (impl # F1 # G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (X2 #in S2) (in ## _ # X1 # S1) :- !, ppp X2 X1, ppp S2 S1.
+ppp (U2 <<= V2) (subseteq ## _ # U1 # V1) :- !, ppp U2 U1, ppp V2 V1.
+ppp (F2 + G2) (plus # F1 # G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (F2 # G2) (F1 # G1) :- !, ppp F2 F1, ppp G2 G1.
 ppp (lam A F2) (lam A F1) :- !, pi x \ ppp (F2 x) (F1 x).
 ppp A A.
 
@@ -313,7 +301,7 @@ parse_axiom PST ST :- parseterm PST ST.
 parse_thm NAME (pi I) (pi O) :- pi x \ parse_thm NAME (I x) (O x).
 parse_thm _ (PST,TAC) (ST,(false,TAC)) :- !, parseterm PST ST.
 parse_thm NAME PST (ST,(true,[_])) :-
- (not (proves NAME _) ; $print "Error:" NAME already defined, fail),
+ (not (proves NAME _) ; print "Error:" NAME already defined, fail),
  parseterm PST ST.
 
 parse_nbt (pi I) (pi O) :- !, pi x \ parse_nbt (I x) (O x).
@@ -323,12 +311,12 @@ parse_nbt PP (P,(true,[_])) :- parseterm PP P.
 next_object [ C | NEXT ] CT CONTNEXT :-
   parse_obj C [ CT | CONT ], append CONT NEXT CONTNEXT.
 next_object [] C CONT :- 
- $print "Welcome to HOL extra-light",
+ print "Welcome to HOL extra-light",
  toplevel_loop [ C | CONT ].
 next_object toplevel C CONT :- toplevel_loop [ C | CONT ].
 
 read_cmd H :-
- $print "Enter a command or \"stop.\"",
+ print "Enter a command or \"stop.\"",
  flush std_out, $readterm std_in H,
  !.
 read_cmd H :- read_cmd H.
@@ -336,26 +324,26 @@ read_cmd H :- read_cmd H.
 toplevel_loop G :-
  read_cmd H,
  ( H = stop, !, G = [stop]
- ; parse_obj H PH, !, (append PH toplevel G ; $print "error", toplevel_loop G)
- ; $print "bad command", toplevel_loop G ).
+ ; parse_obj H PH, !, (append PH toplevel G ; print "error", toplevel_loop G)
+ ; print "bad command", toplevel_loop G ).
 
 callback_proved _ _ (false,_).
 callback_proved NAME G (true, [ TAC ]) :-
  canonical TAC CANONICALTAC,
  pptac PCANONICALTAC CANONICALTAC,
  ppterm PG G,
- $print (theorem NAME (PG , [ PCANONICALTAC ] )).
+ print (theorem NAME (PG , [ PCANONICALTAC ] )).
 
-end_of_proof (true, []) :- $print "proof completed".
+end_of_proof (true, []) :- print "proof completed".
 end_of_proof (false, []).
 
 next_tactic0 [ SEQ | OLD ] (true, [ _ | _ ]) ITAC :-
- $print,
+ print,
  list_iter_rev [ SEQ | OLD ] print_sequent,
  read_in_context SEQ ITAC BACKTRACK,
  BACKTRACK.
 next_tactic0 SEQS (true, CERT) ITAC :-
- $print "error",
+ print "error",
  next_tactic SEQS (true, CERT) ITAC.
 next_tactic0 SEQS (true_then_false, (_,INT_TACS,_)) ITAC :-
  next_tactic0 SEQS (true, INT_TACS) ITAC.
@@ -363,7 +351,7 @@ next_tactic0 SEQS (false, [ interactive | _ ]) ITAC :-
  next_tactic0 SEQS (true, [ _ ]) ITAC.
 next_tactic0 [ SEQ | OLD ] (false, [ TAC | _ ]) TAC.
 next_tactic0 _ (false, _) ITAC :-
- $print "aborted",
+ print "aborted",
  halt.
 
 next_tactic SEQS CERT TAC :- next_tactic0 SEQS CERT PTAC, parsetac PTAC TAC.
@@ -380,10 +368,10 @@ update_certificate (true_then_false, (SCRIPT,[ TAC | OTHER_TACS ],NON_INTERACTIV
    CERTIFICATE =
     (true_then_false, (SCRIPT,INTERACTIVE_TACS,NON_INTERACTIVE_TACS))
  ; CERTIFICATE = (false, NON_INTERACTIVE_TACS),
-   $print "INTERACTIVE SUBPROOF COMPLETED",
+   print "INTERACTIVE SUBPROOF COMPLETED",
    canonical SCRIPT CSCRIPT,
    pptac PSCRIPT CSCRIPT,
-   $print PSCRIPT).
+   print PSCRIPT).
 update_certificate (false, [ _ | OTHER_TACS ]) _ _ (false, OTHER_TACS).
 
 mk_script (bind A T) NEW NEW_TACS (bind A T2) :- !,
@@ -395,16 +383,16 @@ mk_script ITAC NEW NEW_TACS (thenl ITAC NEW_TACS) :-
  mk_list_of_bounded_fresh NEW NEW_TACS.
 
 read_in_context (bind A K) (bind A TAC) BACKTRACK :-
- pi x \ /* term x A => reterm ' x A => */ read_in_context (K x) (TAC x) BACKTRACK.
+ pi x \ /* term x A => reterm # x A => */ read_in_context (K x) (TAC x) BACKTRACK.
 read_in_context (seq A B) TAC BACKTRACK :-
  flush std_out, $readterm std_in TAC,
  (TAC = backtrack, !, BACKTRACK = (!, fail) ; BACKTRACK = true).
 
 print_sequent (seq Gamma G) :-
- $print,
- list_iter_rev Gamma (x \ sigma PX \ ppterm PX x, $print PX),
- $print "|------------------",
- ppterm PG G, $print PG.
+ print,
+ list_iter_rev Gamma (x \ sigma PX \ ppterm PX x, print PX),
+ print "|------------------",
+ ppterm PG G, print PG.
 print_sequent (bind A F) :- pi x \ print_sequent (F x).
 
 /* turns thenl into then */
@@ -436,38 +424,38 @@ build_quantified_predicate L (_, lam _ p \ lam _ x \ P p x) :-
 
 build_predicate [ (_,K) ] P X R :- !,
  process_constructor K P X R.
-build_predicate [ (_,K) | REST ] P X (or ' Q ' R) :-
+build_predicate [ (_,K) | REST ] P X (or # Q # R) :-
  process_constructor K P X Q,
  build_predicate REST P X R.
 
-process_constructor (forall '' TY ' lam TY Q) P X (exists '' TY ' lam TY R) :-
+process_constructor (forall ## TY # lam TY Q) P X (exists ## TY # lam TY R) :-
  pi y \ process_constructor (Q y) P X (R y).
-process_constructor (impl ' H ' K) P X (and ' H ' R) :-
+process_constructor (impl # H # K) P X (and # H # R) :-
  process_constructor K P X R.
-process_constructor (P ' T) P X (eq '' _ ' X ' T).
+process_constructor (P # T) P X (eq ## _ # X # T).
 
 prove_monotonicity_thm (pi F) PREDF APREDF (pi THM) :- !,
- pi A \ prove_monotonicity_thm (F A) PREDF (APREDF '' A) (THM A).
-prove_monotonicity_thm (param TY F) PREDF APREDF (forall '' TY ' lam TY STM, PROOF) :- !,
- pi x \ prove_monotonicity_thm (F x) PREDF (APREDF ' x) (STM x, PROOF).
+ pi A \ prove_monotonicity_thm (F A) PREDF (APREDF ## A) (THM A).
+prove_monotonicity_thm (param TY F) PREDF APREDF (forall ## TY # lam TY STM, PROOF) :- !,
+ pi x \ prove_monotonicity_thm (F x) PREDF (APREDF # x) (STM x, PROOF).
 prove_monotonicity_thm _ PREDF APREDF THM :-
  THM =
-  (monotone '' _ ' APREDF,
+  (monotone ## _ # APREDF,
    [ then inv (bind* (then (conv (depth_tac (dd [PREDF]))) auto_monotone)) ]).
 
 state_fixpoint_def (pi F) PREDF (pi DEF) :- !,
- pi A \ state_fixpoint_def (F A) (PREDF '' A) (DEF A).
+ pi A \ state_fixpoint_def (F A) (PREDF ## A) (DEF A).
 state_fixpoint_def (param TY F) PREDF (_, lam TY BO) :- !,
- pi x \ state_fixpoint_def (F x) (PREDF ' x) (_, BO x).
-state_fixpoint_def _ PREDF (_, fixpoint '' _ ' PREDF).
+ pi x \ state_fixpoint_def (F x) (PREDF # x) (_, BO x).
+state_fixpoint_def _ PREDF (_, fixpoint ## _ # PREDF).
 
 prove_fix_intro_thm (pi F) PREDF PRED PREDF_MONOTONE (pi THM) :- !,
- pi A \ prove_fix_intro_thm (F A) (PREDF '' A) (PRED '' A) PREDF_MONOTONE (THM A).
-prove_fix_intro_thm (param TY F) PREDF PRED PREDF_MONOTONE (forall '' TY ' lam TY STM, [ then forall_i (bind _ PROOF) ]) :- !,
- pi x \ prove_fix_intro_thm (F x) (PREDF ' x) (PRED ' x) PREDF_MONOTONE (STM x, [ PROOF x ]).
+ pi A \ prove_fix_intro_thm (F A) (PREDF ## A) (PRED ## A) PREDF_MONOTONE (THM A).
+prove_fix_intro_thm (param TY F) PREDF PRED PREDF_MONOTONE (forall ## TY # lam TY STM, [ then forall_i (bind _ PROOF) ]) :- !,
+ pi x \ prove_fix_intro_thm (F x) (PREDF # x) (PRED # x) PREDF_MONOTONE (STM x, [ PROOF x ]).
 prove_fix_intro_thm _ PREDF PRED PREDF_MONOTONE THM :-
  THM =
-  ((! x \ PREDF ' PRED ' x ==> PRED ' x),
+  ((! x \ PREDF # PRED # x ==> PRED # x),
    [then forall_i
      (bind _ x13 \
        then (conv (rand_tac (rator_tac dd)))
@@ -478,22 +466,22 @@ prove_fix_intro_thm _ PREDF PRED PREDF_MONOTONE THM :-
                 (thenl lapply [applyth PREDF_MONOTONE,
                   then
                    (g
-                     (subseteq '' _ '
-                       (PREDF ' (fixpoint '' _ ' PREDF)) '
-                       (fixpoint '' _ ' PREDF)))
+                     (subseteq ## _ '
+                       (PREDF # (fixpoint ## _ # PREDF)) '
+                       (fixpoint ## _ # PREDF)))
                    (then (conv (depth_tac (dd [subseteq])))
                      (then (conv (depth_tac (dd [in])))
                        (then (conv (depth_tac (dd [in])))(itaut 4))))]))))))]).
 
 prove_fix_elim_thm (pi F) PREDF PRED OPRED (pi THM) :- !,
- pi A \ prove_fix_elim_thm (F A) (PREDF '' A) (PRED '' A) OPRED (THM A).
-prove_fix_elim_thm (param TY F) PREDF PRED OPRED (forall '' TY ' lam TY STM, [ then forall_i (bind _ PROOF) ]) :- !,
- pi x \ prove_fix_elim_thm (F x) (PREDF ' x) (PRED ' x) OPRED (STM x, [ PROOF x ]).
+ pi A \ prove_fix_elim_thm (F A) (PREDF ## A) (PRED ## A) OPRED (THM A).
+prove_fix_elim_thm (param TY F) PREDF PRED OPRED (forall ## TY # lam TY STM, [ then forall_i (bind _ PROOF) ]) :- !,
+ pi x \ prove_fix_elim_thm (F x) (PREDF # x) (PRED # x) OPRED (STM x, [ PROOF x ]).
 prove_fix_elim_thm _ PREDF PRED OPRED THM :-
  THM =
   ((! x13 \
-     (! x14 \ PREDF ' x13 ' x14 ==> x13 ' x14) ==>
-      (! x14 \ PRED ' x14 ==> x13 ' x14)) ,
+     (! x14 \ PREDF # x13 # x14 ==> x13 # x14) ==>
+      (! x14 \ PRED # x14 ==> x13 # x14)) ,
     [then forall_i
       (bind _ x23 \
         then (cutth fixpoint_subseteq_any_prefixpoint)
@@ -504,8 +492,8 @@ prove_fix_elim_thm _ PREDF PRED OPRED THM :-
                  (bind _ x24 \
                    then
                     (g
-                      (impl ' (subseteq '' _ ' (PREDF ' x23) ' x23) '
-                        (subseteq '' _ ' (fixpoint '' _ ' PREDF) ' x23)))
+                      (impl # (subseteq ## _ # (PREDF # x23) # x23) '
+                        (subseteq ## _ # (fixpoint ## _ # PREDF) # x23)))
                     (then (conv (depth_tac (dd [subseteq])))
                       (then (conv (depth_tac (dd [subseteq])))
                         (then (conv (depth_tac (dd [in])))
@@ -515,9 +503,9 @@ prove_fix_elim_thm _ PREDF PRED OPRED THM :-
                                 (then
                                   (w
                                     (impl '
-                                      (subseteq '' _ ' (PREDF ' x23) ' x23) '
-                                      (subseteq '' _ '
-                                        (fixpoint '' _ ' PREDF) ' x23)))
+                                      (subseteq ## _ # (PREDF # x23) # x23) '
+                                      (subseteq ## _ '
+                                        (fixpoint ## _ # PREDF) # x23)))
                                   (then inv
                                     (thenl lapply_last [h,
                                       then (lforall_last x24)
@@ -525,17 +513,17 @@ prove_fix_elim_thm _ PREDF PRED OPRED THM :-
 
 prove_intro_thms (pi F) PRED PRED_I INTROTHMS :- !,
  pi A \
-  prove_intro_thms (F A) (PRED '' A) PRED_I (OUT A),
+  prove_intro_thms (F A) (PRED ## A) PRED_I (OUT A),
   list_map (OUT A)
    (i \ o \ sigma Y \ i = (theorem NAME (P A)), o = theorem NAME (pi P))
    INTROTHMS.
 prove_intro_thms (param TY F) PRED PRED_I INTROTHMS :- !,
  pi x \
-  prove_intro_thms (F x) (PRED ' x) PRED_I (OUT x),
+  prove_intro_thms (F x) (PRED # x) PRED_I (OUT x),
   list_map (OUT x)
    (i \ o \ sigma Y \
      i = (theorem NAME (STM x, [ PROOF x ])),
-     o = theorem NAME (forall '' TY ' lam TY STM, [ then forall_i (bind TY PROOF) ]))
+     o = theorem NAME (forall ## TY # lam TY STM, [ then forall_i (bind TY PROOF) ]))
    INTROTHMS.
 prove_intro_thms L PRED PRED_I INTROTHMS :-
  list_map (L PRED) (mk_intro_thm PRED_I) INTROTHMS.
@@ -633,7 +621,7 @@ deftac (repeat! TAC) SEQ (orelse! (then! TAC (repeat! (bind* TAC))) id).
 
 ppptac (pptac TAC) (pptac PTAC) :- ppptac TAC PTAC.
 deftac (pptac TAC) SEQ TAC :-
- $print "SEQ" SEQ ":=" TAC.
+ print "SEQ" SEQ ":=" TAC.
 
 ppptac (time TAC) (time PTAC) :- ppptac TAC PTAC.
 deftac (time TAC) SEQ XTAC :-
@@ -645,7 +633,7 @@ deftacl (time_after TAC B) SEQS TACL :-
  $gettimeofday A,
  D is A - B,
  mk_constant_list SEQS id TACL,
- $print "TIME SPENT " D "FOR" TAC.
+ print "TIME SPENT " D "FOR" TAC.
 
 /* For debugging only (?) For capturing metavariables */
 ppptac (inspect (seq Gamma F) TAC) (inspect (seq PGamma PF) PTAC) :-
@@ -664,11 +652,11 @@ deftac h SEQ (h L).
 /*** eq ***/
 
 ppptac sym sym.
-deftac sym (seq Gamma (eq '' T ' L ' R)) TAC :-
- TAC = thenl (m (eq '' T ' R ' R)) [ thenl c [ thenl c [ r , id ] , r ] , r ].
+deftac sym (seq Gamma (eq ## T # L # R)) TAC :-
+ TAC = thenl (m (eq ## T # R # R)) [ thenl c [ thenl c [ r , id ] , r ] , r ].
 
 ppptac eq_true_intro eq_true_intro.
-deftac eq_true_intro (seq Gamma (eq '' prop ' P ' tt)) TAC :-
+deftac eq_true_intro (seq Gamma (eq ## prop # P # tt)) TAC :-
  TAC = thenl s [ th tt_intro, wl [] ].
 
 /*** true ***/
@@ -676,7 +664,7 @@ deftac eq_true_intro (seq Gamma (eq '' prop ' P ' tt)) TAC :-
 /*** and ***/
 
 ppptac conj conj.
-deftac conj (seq Gamma (and ' P ' Q)) TAC :-
+deftac conj (seq Gamma (and # P # Q)) TAC :-
  TAC =
   then
    (then (conv dd)
@@ -686,80 +674,80 @@ deftac conj (seq Gamma (and ' P ' Q)) TAC :-
           eq_true_intro ])))
    ww.
 
-/* Gamma  "|-"  q    --->   Gamma "|-" and ' p ' q*/
+/* Gamma  "|-"  q    --->   Gamma "|-" and # p # q*/
 ppptac (andr P) (andr PP) :- ppp P PP.
 deftac (andr P) (seq Gamma Q) TAC :-
  TAC =
-  (thenl (m ((lam _ f \ f ' P ' Q) ' (lam _ x \ lam _ y \ y)))
+  (thenl (m ((lam _ f \ f # P # Q) # (lam _ x \ lam _ y \ y)))
     [ then
        %(repeat (conv (depth_tac b))) ROBUS VERSION LINE BELOW
        (then (conv (land_tac b)) (then (conv (land_tac (rator_tac b))) (conv (land_tac b))))
       r
     , thenl (conv (rator_tac id))
-       [ then (thenl (t (lam _ f \ f ' tt ' tt)) [ id, r ])
-          (thenl (m (and ' P ' Q)) [ dd , id ])
+       [ then (thenl (t (lam _ f \ f # tt # tt)) [ id, r ])
+          (thenl (m (and # P # Q)) [ dd , id ])
        , then (repeat (conv (depth_tac b))) (th tt_intro) ]]).
 
-/* (and ' p ' q) :: nil  "|-"  q */
+/* (and # p # q) :: nil  "|-"  q */
 ppptac andr andr.
 deftac andr (seq Gamma Q) TAC :-
- mem Gamma (and ' P ' Q),
+ mem Gamma (and # P # Q),
  TAC = then (andr P) h.
 
-/* Gamma  "|-"  p    --->   Gamma "|-" and ' p ' q*/
+/* Gamma  "|-"  p    --->   Gamma "|-" and # p # q*/
 ppptac (andl P) (andl PP) :- ppp P PP.
 deftac (andl Q) (seq Gamma P) TAC :-
  TAC =
-  (thenl (m ((lam _ f \ f ' P ' Q) ' (lam _ x \ lam _ y \ x)))
+  (thenl (m ((lam _ f \ f # P # Q) # (lam _ x \ lam _ y \ x)))
     [ then
        %(repeat (conv (depth_tac b))) ROBUS VERSION LINE BELOW
        (then (conv (land_tac b)) (then (conv (land_tac (rator_tac b))) (conv (land_tac b))))
       r
     , thenl (conv (rator_tac id))
-       [ then (thenl (t (lam _ f \ f ' tt ' tt)) [ id, r ])
-          (thenl (m (and ' P ' Q)) [ dd , id ])
+       [ then (thenl (t (lam _ f \ f # tt # tt)) [ id, r ])
+          (thenl (m (and # P # Q)) [ dd , id ])
        , then (repeat (conv (depth_tac b))) (th tt_intro) ]]).
 
-/* (and ' p ' q) :: nil  "|-"  p */
+/* (and # p # q) :: nil  "|-"  p */
 ppptac andl andl.
 deftac andl (seq Gamma P) TAC :-
- mem Gamma (and ' P ' Q),
+ mem Gamma (and # P # Q),
  TAC = then (andl Q) h.
 
 
 /*** forall ***/
 
-/* |- forall ' F  -->   |- F ' x */
+/* |- forall # F  -->   |- F # x */
 ppptac forall_i forall_i.
-deftac forall_i (seq Gamma (forall '' _ ' lam _ G)) TAC :-
+deftac forall_i (seq Gamma (forall ## _ # lam _ G)) TAC :-
  TAC = then (conv dd) (then k (bind _ x \ eq_true_intro)).
 
-/* forall ' F |- F ' T */
+/* forall # F |- F # T */
 ppptac forall_e forall_e.
 deftac forall_e (seq Gamma GX) TAC :-
- mem Gamma (forall '' _ ' (lam _ G)), GX = G X,
- TAC = thenl (m ((lam _ G) ' X)) [ b, thenl (m ((lam _ z \ tt) ' X))
-  [ thenl c [ then sym (thenl (m (forall '' _ ' lam _ G)) [dd,h ]), r ]
+ mem Gamma (forall ## _ # (lam _ G)), GX = G X,
+ TAC = thenl (m ((lam _ G) # X)) [ b, thenl (m ((lam _ z \ tt) # X))
+  [ thenl c [ then sym (thenl (m (forall ## _ # lam _ G)) [dd,h ]), r ]
   , then (conv b) (th tt_intro) ] ].
 
-/* forall ' F |- f  -->  F ' a, forall ' F |- f */
+/* forall # F |- f  -->  F # a, forall # F |- f */
 ppptac (lforall F A) (lforall PF PA) :- ppp F PF, ppp A PA.
 deftac (lforall F A) (seq Gamma G) TAC :-
- TAC = thenl (m (impl ' (F A) ' G))
-  [ thenl s [ then mp forall_e, then i h ] , then (w (forall '' _ ' lam _ F)) i ].
+ TAC = thenl (m (impl # (F A) # G))
+  [ thenl s [ then mp forall_e, then i h ] , then (w (forall ## _ # lam _ F)) i ].
 
-/* forall ' F |- f  -->  F ' a, forall ' F |- f */
+/* forall # F |- f  -->  F # a, forall # F |- f */
 ppptac (lforall A) (lforall PA) :- ppp A PA.
 deftac (lforall A) (seq Gamma G) (lforall F A) :-
- mem Gamma (forall '' _ ' lam _ F).
+ mem Gamma (forall ## _ # lam _ F).
 
-/* forall ' F |- f  -->  F ' a, forall ' F |- f */
+/* forall # F |- f  -->  F # a, forall # F |- f */
 ppptac lforall lforall.
 deftac lforall (seq Gamma G) (lforall A).
 
-/* forall ' F |- f  -->  F ' a, forall ' F |- f */
+/* forall # F |- f  -->  F # a, forall # F |- f */
 ppptac (lforall_last A) (lforall_last PA) :- ppp A PA.
-deftac (lforall_last A) (seq ((forall '' _ ' lam _ F)::Gamma) G) (lforall F A).
+deftac (lforall_last A) (seq ((forall ## _ # lam _ F)::Gamma) G) (lforall F A).
 
 /*** false ***/
               
@@ -767,23 +755,23 @@ deftac (lforall_last A) (seq ((forall '' _ ' lam _ F)::Gamma) G) (lforall F A).
 
 /* |- p=>q  -->  p |- q */
 ppptac i i.
-deftac i (seq Gamma (impl ' P ' Q)) TAC :-
+deftac i (seq Gamma (impl # P # Q)) TAC :-
  TAC = then (conv dd) (thenl s [ andl, thenl conj [ h [], id ]]).
 
 /* p=>q |- q  -->  |- p */
 ppptac (mp P) (mp PP) :- ppp P PP.
 deftac (mp P) (seq Gamma Q) TAC :-
- TAC = then (andr P) (thenl (m P) [ then sym (thenl (m (impl ' P ' Q)) [ dd , h ]) , id ]).
+ TAC = then (andr P) (thenl (m P) [ then sym (thenl (m (impl # P # Q)) [ dd , h ]) , id ]).
 
 /* p=>q |- q  -->  |- p */
 ppptac mp mp.
 deftac mp (seq Gamma Q) (mp P) :-
- mem Gamma (impl ' P ' Q).
+ mem Gamma (impl # P # Q).
 
 /* |- q   -->   p |- q  and  |- p */
 ppptac (cut P) (cut PP) :- ppp P PP.
 deftac (cut P) (seq Gamma Q) TAC :-
- TAC = then (andr P) (thenl (m P) [then sym (thenl (m (impl ' P ' Q)) [then (conv (land_tac dd)) r, i] ) , id]). 
+ TAC = then (andr P) (thenl (m P) [then sym (thenl (m (impl # P # Q)) [then (conv (land_tac dd)) r, i] ) , id]). 
 
 /* |-q  --> p |- q   where the theorem T proves p */
 ppptac (cutth P) (cutth PP) :- ppp P PP.
@@ -799,22 +787,22 @@ deftac (applyth T) SEQ (then (cutth T) apply_last).
 ppptac (lapply P Q) (lapply PP PQ) :- ppp P PP, ppp Q PQ.
 deftac (lapply P Q) (seq Gamma F) TAC :-
  TAC =
-  thenl (m (impl ' Q ' F)) [ thenl s [ then (mp Q) (then (w (impl ' Q ' F)) (then (mp P) (w (impl ' P ' Q)))) , then i (h [A]) ] , then (w (impl ' P ' Q)) (then i id) ].
+  thenl (m (impl # Q # F)) [ thenl s [ then (mp Q) (then (w (impl # Q # F)) (then (mp P) (w (impl # P # Q)))) , then i (h [A]) ] , then (w (impl # P # Q)) (then i id) ].
 
 /* impl p q, Gamma |- f   --->   /*impl q f*/ Gamma |- p  ,  q, Gamma |- f */
 ppptac lapply lapply.
 deftac lapply (seq Gamma F) (lapply P Q) :-
- mem Gamma (impl ' P ' Q).
+ mem Gamma (impl # P # Q).
 
 /* impl p q, Gamma |- f   --->   /*impl q f*/ Gamma |- p  ,  q, Gamma |- f */
 ppptac lapply_last lapply_last.
-deftac lapply_last (seq ((impl ' P ' Q)::Gamma) F) (lapply P Q).
+deftac lapply_last (seq ((impl # P # Q)::Gamma) F) (lapply P Q).
 
 /* p |- f ---> p |- p ==> f */
 ppptac (g P) (g PP) :- ppp P PP.
 deftac (g P) (seq _ F) TAC :-
  TAC =
-  (thenl (m (impl ' P ' F)) [thenl s [then mp h , then i h] , id ]).
+  (thenl (m (impl # P # F)) [thenl s [then mp h , then i h] , id ]).
 
 /*** not ***/
 
@@ -825,9 +813,9 @@ deftac (g P) (seq _ F) TAC :-
 ppptac (apply X) (apply PX) :- ppp X PX.
 deftac (apply X) SEQ h :- var X, !.
 deftac (apply X) SEQ h.
-deftac (apply (impl ' P ' Q)) SEQ TAC :-
+deftac (apply (impl # P # Q)) SEQ TAC :-
  TAC = thenl (lapply P Q) [ id, apply_last ].
-deftac (apply (forall '' _ ' lam _ G)) SEQ TAC :-
+deftac (apply (forall ## _ # lam _ G)) SEQ TAC :-
  TAC = then (lforall G X) apply_last.
 
 ppptac apply_last apply_last.
@@ -839,20 +827,20 @@ deftac apply (seq Gamma F) (apply H) :-
 
 /********** conversion(als) ***********/
 
-strip_constant (I '' _) H :- !, strip_constant I H.
+strip_constant (I ## _) H :- !, strip_constant I H.
 strip_constant H H.
 
 /* expands definitions, even if applied to arguments */
 ppptac (dd L) (dd L).
-deftac (dd L) (seq _ (eq '' _ ' T ' X)) d :- strip_constant T H, bang (mem L H).
-deftac (dd L) (seq _ (eq '' _ ' (D ' T) ' X))
+deftac (dd L) (seq _ (eq ## _ # T # X)) d :- strip_constant T H, bang (mem L H).
+deftac (dd L) (seq _ (eq ## _ # (D # T) # X))
  (thenl (t A) [thenl c [dd L , r], b]).
 
 ppptac dd dd.
 deftac dd _ (dd L).
 
 ppptac beta_expand beta_expand.
-deftac beta_expand (seq _ (eq '' _ ' (lam _ x \ F x) ' (lam _ x \ (lam _ F) ' x))) TAC :-
+deftac beta_expand (seq _ (eq ## _ # (lam _ x \ F x) # (lam _ x \ (lam _ F) # x))) TAC :-
  TAC = then k (bind _ x \ then sym b).
 
 /* folds a definition, even if applied to arguments */
@@ -897,49 +885,49 @@ deftac (conv C) (seq Gamma F) TAC :-
 /* left tries to reduce the search space via focusing */
 ppptac left left.
 deftac left (seq Gamma _) TAC :-
- mem Gamma (not ' F),
+ mem Gamma (not # F),
  TAC =
   (!
    (then (cutth not_e)
     (then (lforall_last F)
-     (thenl lapply [ h, (w (not ' F)) ])))).
+     (thenl lapply [ h, (w (not # F)) ])))).
 deftac left (seq Gamma _) TAC :-
  /* A bit long because we want to beta-reduce the produced hypothesis.
     Maybe this should be automatized somewhere else. */
- mem Gamma (exists '' _ ' F),
+ mem Gamma (exists ## _ # F),
  TAC =
   (!
    (then (cutth exists_e)
     (then (lforall_last F)
-     (thenl lapply [ h, then (w (exists '' _ ' F)) (then apply_last (then forall_i (bind _ x \ then (try (conv (land_tac b))) i))) ])))).
+     (thenl lapply [ h, then (w (exists ## _ # F)) (then apply_last (then forall_i (bind _ x \ then (try (conv (land_tac b))) i))) ])))).
 deftac left (seq Gamma H) TAC :-
- mem Gamma (or ' F ' G),
+ mem Gamma (or # F # G),
  TAC =
   (!
    (then (cutth or_e)
     (then (lforall_last F)
      (then (lforall_last G)
       (then (lforall_last H)
-       (thenl lapply [ h, then (w (or ' F ' G)) (then apply_last i)])))))).
+       (thenl lapply [ h, then (w (or # F # G)) (then apply_last i)])))))).
 deftac left (seq Gamma H) TAC :-
- mem Gamma (and ' F ' G),
+ mem Gamma (and # F # G),
  TAC =
   (!
    (then (cutth and_e)
     (then (lforall_last F)
      (then (lforall_last G)
       (then (lforall_last H)
-       (thenl lapply [ h, then (w (and ' F ' G)) (then apply_last (then i i))])))))).
+       (thenl lapply [ h, then (w (and # F # G)) (then apply_last (then i i))])))))).
 deftac left (seq Gamma H) TAC :-
- mem Gamma (eq '' TY ' F ' G),
+ mem Gamma (eq ## TY # F # G),
  not (var TY), TY = prop,
  TAC =
-  (then (g (eq '' TY ' F ' G))
+  (then (g (eq ## TY # F # G))
    (then (conv (land_tac (then (applyth eq_to_impl) h)))
-     (then i (w (eq '' TY ' F ' G))))).
+     (then i (w (eq ## TY # F # G))))).
 
 ppptac not_i not_i.
-deftac not_i (seq _ (not ' _)) (applyth not_i).
+deftac not_i (seq _ (not # _)) (applyth not_i).
 
 ppptac inv inv.
 deftac inv _ TAC :-
@@ -953,15 +941,15 @@ ppptac (sync N) (sync N).
 deftac (sync N) (seq _ tt) (th tt_intro).
 deftac (sync N) (seq Gamma _) (then (applyth ff_elim) h) :-
  mem Gamma ff.
-deftac (sync N) (seq _ (or ' _ ' _))
+deftac (sync N) (seq _ (or # _ # _))
  (orelse (then (applyth orr) (itaut N)) (then (applyth orl) (itaut N))).
-deftac (sync N) (seq _ (exists '' _ ' _)) (then (applyth exists_i) (then (conv b) (itaut N2))) :-
+deftac (sync N) (seq _ (exists ## _ # _)) (then (applyth exists_i) (then (conv b) (itaut N2))) :-
  N2 is N - 2.
 
 ppptac (itaut N) (itaut N).
 deftac (itaut N) SEQ fail :- N =< 0, !.
 deftac (itaut N) SEQ TAC :-
- %$print (itaut N) SEQ,
+ %print (itaut N) SEQ,
  N1 is N - 1,
  N2 is N - 2,
  TAC =
@@ -978,31 +966,31 @@ deftac (itauteq N) _ (then (cutth eq_reflexive) (itaut N)).
 /********** inductive predicates package ********/
 
 ppptac monotone monotone.
-deftac monotone (seq _ (impl ' X ' X)) (! (then i h)) :- !.
-deftac monotone (seq [forall '' _ ' lam _ x \ impl ' (F ' x) ' (G ' x)] (impl ' (F ' T) ' (G ' T))) (! apply) :- !.
-deftac monotone (seq _ (impl ' (and ' _ ' _) ' _)) TAC :-
+deftac monotone (seq _ (impl # X # X)) (! (then i h)) :- !.
+deftac monotone (seq [forall ## _ # lam _ x \ impl # (F # x) # (G # x)] (impl # (F # T) # (G # T))) (! apply) :- !.
+deftac monotone (seq _ (impl # (and # _ # _) # _)) TAC :-
  TAC = then (applyth and_monotone) monotone.
-deftac monotone (seq _ (impl ' (or ' _ ' _) ' _)) TAC :-
+deftac monotone (seq _ (impl # (or # _ # _) # _)) TAC :-
  TAC = then (applyth or_monotone) monotone.
-deftac monotone (seq _ (impl ' (impl ' _ ' _) ' _)) TAC :-
+deftac monotone (seq _ (impl # (impl # _ # _) # _)) TAC :-
  TAC = then (applyth impl_monotone) monotone.
-deftac monotone (seq _ (impl ' (not ' _) ' _)) TAC :-
+deftac monotone (seq _ (impl # (not # _) # _)) TAC :-
  TAC = then (applyth not_monotone) monotone.
-deftac monotone (seq _ (impl ' (forall '' _ ' lam _ _) ' _)) TAC :-
+deftac monotone (seq _ (impl # (forall ## _ # lam _ _) # _)) TAC :-
  TAC =
   then (conv (land_tac (rand_tac beta_expand)))
    (then (conv (rand_tac (rand_tac beta_expand)))
      (then (applyth forall_monotone) (then forall_i (bind _ x \
        then (conv (depth_tac b)) (then (conv (depth_tac b)) monotone))))).
-deftac monotone (seq _ (impl ' (exists '' _ ' lam _ _) ' _)) TAC :-
+deftac monotone (seq _ (impl # (exists ## _ # lam _ _) # _)) TAC :-
  TAC =
   then (conv (land_tac (rand_tac beta_expand)))
    (then (conv (rand_tac (rand_tac beta_expand)))
      (then (applyth exists_monotone) (then forall_i (bind _ x \
        then (conv (depth_tac b)) (then (conv (depth_tac b)) monotone))))).
 
-/* expands "monotone ' (lam _ f \ lam _ x \ X f x)" into
-   "! x \ p ' x ==> q ' x |- X p y ==> X q y"
+/* expands "monotone # (lam _ f \ lam _ x \ X f x)" into
+   "! x \ p # x ==> q # x |- X p y ==> X q y"
    and then calls the monotone tactic */
 ppptac auto_monotone auto_monotone.
 deftac auto_monotone _ TAC :-
@@ -1043,10 +1031,10 @@ the_library L :-
      (lam (A --> prop) f \ f = (lam A g \ tt)))
   , def ff (prop,(! x \ x))
   , def and ((prop --> prop --> prop),
-     (lam _ x \ lam _ y \ (lam (prop --> prop --> prop) f \ f ' x ' y) = (lam _ f \ f ' tt ' tt)))
+     (lam _ x \ lam _ y \ (lam (prop --> prop --> prop) f \ f # x # y) = (lam _ f \ f # tt # tt)))
   , def impl ((prop --> prop --> prop),(lam _ a \ lam _ b \ a && b <=> a))
   , def exists (pi A \ ((A --> prop) --> prop),
-     (lam (A --> prop) f \ ! c \ (! a \ f ' a ==> c) ==> c))
+     (lam (A --> prop) f \ ! c \ (! a \ f # a ==> c) ==> c))
   , def not ((prop --> prop),(lam _ x \ x ==> ff))
   , def or ((prop --> prop --> prop),
      (lam _ x \ lam _ y \ ! c \ (x ==> c) ==> (y ==> c) ==> c))
@@ -1059,7 +1047,7 @@ the_library L :-
        then forall_i
         (bind prop x13 \
           then i (then sym h)))])
-  , theorem not_e ((! p \ not ' p ==> p ==> ff),
+  , theorem not_e ((! p \ not # p ==> p ==> ff),
      [then forall_i (bind prop x3 \ then (conv (land_tac dd)) (then i h))])
   , theorem conj ((! p \ ! q \ p ==> q ==> p && q),
     [then forall_i
@@ -1080,9 +1068,9 @@ the_library L :-
           (bind prop x13 \
             then forall_i
              (bind prop x14 \ then i (then i (thenl apply [andl, andr])))))])
-  , theorem not_i ((! p \ (p ==> ff) ==> not ' p),
+  , theorem not_i ((! p \ (p ==> ff) ==> not # p),
      [then forall_i (bind prop x2 \ then i (then (conv dd) h))])
-  , theorem orl ((! p \ ! q \ p ==> p `or q),
+  , theorem orl ((! p \ ! q \ p ==> p || q),
       [then forall_i
         (bind prop x12 \
           then forall_i
@@ -1090,7 +1078,7 @@ the_library L :-
              then i
               (then (conv dd)
                 (then forall_i (bind prop x14 \ then i (then i (then apply h)))))))])
-  , theorem orr ((! p \ ! q \ q ==> p `or q),
+  , theorem orr ((! p \ ! q \ q ==> p || q),
       [then forall_i
         (bind prop x12 \
           then forall_i
@@ -1098,7 +1086,7 @@ the_library L :-
              then i
               (then (conv dd)
                 (then forall_i (bind prop x14 \ then i (then i (then apply h)))))))])
-  , theorem or_e ((! p \ ! q \ ! c \ p `or q ==> (p ==> c) ==> (q ==> c) ==> c),
+  , theorem or_e ((! p \ ! q \ ! c \ p || q ==> (p ==> c) ==> (q ==> c) ==> c),
      [then forall_i
        (bind prop x12 \
          then forall_i
@@ -1106,9 +1094,9 @@ the_library L :-
             then forall_i
              (bind prop x14 \ then (conv (land_tac dd)) (then i forall_e))))])
   , theorem exists_e (pi T \
-     (! f \ (exists '' T ' f) ==> (! c \ (! x \ f ' x ==> c) ==> c)),
+     (! f \ (exists ## T # f) ==> (! c \ (! x \ f # x ==> c) ==> c)),
      [then forall_i (bind (T --> prop) x12 \ then (conv (land_tac dd)) (then i h))])
- , theorem exists_i (pi T \ (! f \ ! w \ f ' w ==> (exists '' T ' f)),
+ , theorem exists_i (pi T \ (! f \ ! w \ f # w ==> (exists ## T # f)),
     [then forall_i
      (bind (T --> prop) x12 \
        then forall_i
@@ -1125,52 +1113,52 @@ the_library L :-
        (bind prop x13 \ bind prop x14 \ itaut 2)]])
 
  /*********** Axiomatization of disjoint union ********/
-  , decl inj1_disj_union (pi A \pi B \ A --> disj_union '' A '' B)
-  , decl inj2_disj_union (pi A \ pi B \ B --> disj_union '' A '' B)
-  , decl case_disj_union (pi A \pi B \ pi C \ disj_union '' A '' B --> (A --> C) --> (B --> C) --> C)
+  , decl inj1_disj_union (pi A \pi B \ A --> disj_union ## A ## B)
+  , decl inj2_disj_union (pi A \ pi B \ B --> disj_union ## A ## B)
+  , decl case_disj_union (pi A \pi B \ pi C \ disj_union ## A ## B --> (A --> C) --> (B --> C) --> C)
   , axiom case_disj_union_inj1 (pi A \ pi B \ pi C \ (! b \ ! (A --> C) e1 \ ! (B --> C) e2  \
-    case_disj_union '' A '' B '' C ' (inj1_disj_union '' A '' B ' b) ' e1 ' e2 = e1 ' b))
+    case_disj_union ## A ## B ## C # (inj1_disj_union ## A ## B # b) # e1 # e2 = e1 # b))
   , axiom case_disj_union_inj2 (pi A \ pi B \ pi C \ (! b \ ! (A --> C) e1 \ ! (B --> C) e2  \
-    case_disj_union '' A '' B '' C ' (inj2_disj_union '' A '' B ' b) ' e1 ' e2 = e2 ' b))
+    case_disj_union ## A ## B ## C # (inj2_disj_union ## A ## B # b) # e1 # e2 = e2 # b))
 
  /*********** Axiomatization of the universe ********/
- , decl injection_univ (pi A \pi B \ A --> univ '' A '' B)
- , decl ejection_univ (pi A \pi B \ univ '' A '' B --> A)
- , decl inject_limit_univ (pi A \pi B \ (B --> univ '' A '' B) --> univ '' A '' B)
- , decl eject_limit_univ (pi A \ pi B \ univ '' A '' B --> (B --> univ '' A '' B))
- , decl pair_univ (pi A \pi B \ univ '' A '' B --> univ '' A '' B --> univ '' A '' B)
- , decl proj1_univ (pi A \ pi B \ univ '' A '' B --> univ '' A '' B)
- , decl proj2_univ (pi A \pi B \ univ '' A '' B --> univ '' A '' B)
- , decl inj1_univ (pi A \pi B \ univ '' A '' B --> univ '' A '' B)
- , decl inj2_univ (pi A \pi B \ univ '' A '' B --> univ '' A '' B)
- , decl case_univ (pi A \pi B \ pi C \ univ '' A '' B --> (univ '' A '' B --> C) --> (univ '' A '' B --> C) --> C)
+ , decl injection_univ (pi A \pi B \ A --> univ ## A ## B)
+ , decl ejection_univ (pi A \pi B \ univ ## A ## B --> A)
+ , decl inject_limit_univ (pi A \pi B \ (B --> univ ## A ## B) --> univ ## A ## B)
+ , decl eject_limit_univ (pi A \ pi B \ univ ## A ## B --> (B --> univ ## A ## B))
+ , decl pair_univ (pi A \pi B \ univ ## A ## B --> univ ## A ## B --> univ ## A ## B)
+ , decl proj1_univ (pi A \ pi B \ univ ## A ## B --> univ ## A ## B)
+ , decl proj2_univ (pi A \pi B \ univ ## A ## B --> univ ## A ## B)
+ , decl inj1_univ (pi A \pi B \ univ ## A ## B --> univ ## A ## B)
+ , decl inj2_univ (pi A \pi B \ univ ## A ## B --> univ ## A ## B)
+ , decl case_univ (pi A \pi B \ pi C \ univ ## A ## B --> (univ ## A ## B --> C) --> (univ ## A ## B --> C) --> C)
  , axiom ejection_injection_univ (pi A \ pi B \
-    ! A p \ ejection_univ '' A '' B ' (injection_univ '' A '' B ' p) = p)
+    ! A p \ ejection_univ ## A ## B # (injection_univ ## A ## B # p) = p)
  , axiom eject_inject_limit_univ (pi A \ pi B \
-    ! (B --> univ '' A '' B) p \ eject_limit_univ '' A '' B ' (inject_limit_univ '' A '' B ' p) = p)
- , axiom proj1_pair_univ (pi A \ pi B \ ! (univ '' A '' B) p1 \ ! p2 \
-    proj1_univ '' A '' B ' (pair_univ '' A '' B ' p1 ' p2) = p1)
- , axiom proj2_pair_univ (pi A \ pi B \ ! p1 \ ! (univ '' A '' B) p2 \
-    proj2_univ '' A '' B ' (pair_univ '' A '' B ' p1 ' p2) = p2)
- , axiom case_univ_inj1 (pi A \ pi B \ pi C \ (! b \ ! (univ '' A '' B --> C) e1 \ ! e2  \
-    case_univ '' A '' B '' C ' (inj1_univ '' A '' B ' b) ' e1 ' e2 = e1 ' b))
- , axiom case_univ_inj2 (pi A \ pi B \ pi C \ (! b \ ! (univ '' A '' B --> C) e1 \ ! e2 \
-    case_univ '' A '' B '' C ' (inj2_univ '' A '' B ' b) ' e1 ' e2 = e2 ' b))
+    ! (B --> univ ## A ## B) p \ eject_limit_univ ## A ## B # (inject_limit_univ ## A ## B # p) = p)
+ , axiom proj1_pair_univ (pi A \ pi B \ ! (univ ## A ## B) p1 \ ! p2 \
+    proj1_univ ## A ## B # (pair_univ ## A ## B # p1 # p2) = p1)
+ , axiom proj2_pair_univ (pi A \ pi B \ ! p1 \ ! (univ ## A ## B) p2 \
+    proj2_univ ## A ## B # (pair_univ ## A ## B # p1 # p2) = p2)
+ , axiom case_univ_inj1 (pi A \ pi B \ pi C \ (! b \ ! (univ ## A ## B --> C) e1 \ ! e2  \
+    case_univ ## A ## B ## C # (inj1_univ ## A ## B # b) # e1 # e2 = e1 # b))
+ , axiom case_univ_inj2 (pi A \ pi B \ pi C \ (! b \ ! (univ ## A ## B --> C) e1 \ ! e2 \
+    case_univ ## A ## B ## C # (inj2_univ ## A ## B # b) # e1 # e2 = e2 # b))
 
  /******************* Equality *****************/
  , theorem eq_reflexive (pi A \ ((! A a \ a = a),
    [ then forall_i (bind A x \ r) ]))
 
  /******************* Logic *****************/
- , theorem or_commutative ((! a \ ! b \ a `or b <=> b `or a),
+ , theorem or_commutative ((! a \ ! b \ a || b <=> b || a),
    [itaut 1])
- , theorem or_ff ((! a \ a `or ff <=> a),
+ , theorem or_ff ((! a \ a || ff <=> a),
    [itaut 1])
- , theorem or_tt ((! a \ a `or tt <=> tt),
+ , theorem or_tt ((! a \ a || tt <=> tt),
    [itaut 1])
- , theorem or_idempotent ((! a \ a `or a <=> a),
+ , theorem or_idempotent ((! a \ a || a <=> a),
    [itaut 1])
- , theorem or_associative ((! a \ ! b \ ! c \ a `or (b `or c) <=> (a `or b) `or c),
+ , theorem or_associative ((! a \ ! b \ ! c \ a || (b || c) <=> (a || b) || c),
    [itaut 1])
  , theorem and_commutative ((! a \ ! b \ a && b <=> b && a),
    [itaut 1])
@@ -1182,21 +1170,21 @@ the_library L :-
    [itaut 1])
  , theorem and_associative ((! a \ ! b \ ! c \ a && (b && c) <=> (a && b) && c),
    [itaut 1])
- , theorem and_or ((! a \ ! b \ ! c \ a && (b `or c) <=> (a && b) `or (a && c)),
+ , theorem and_or ((! a \ ! b \ ! c \ a && (b || c) <=> (a && b) || (a && c)),
    [itaut 1])
- , theorem or_and ((! a \ ! b \ ! c \ a `or (b && c) <=> (a `or b) && (a `or c)),
+ , theorem or_and ((! a \ ! b \ ! c \ a || (b && c) <=> (a || b) && (a || c)),
    [itaut 1])
- , theorem ads_or_and ((! a \ ! b \ (a && b) `or b <=> b),
+ , theorem ads_or_and ((! a \ ! b \ (a && b) || b <=> b),
    [itaut 1])
- , theorem ads_and_or ((! a \ ! b \ (a `or b) && b <=> b),
+ , theorem ads_and_or ((! a \ ! b \ (a || b) && b <=> b),
    [itaut 1])
- , theorem not_or ((! a \ ! b \ not ' a && not ' b <=> not ' (a `or b)),
+ , theorem not_or ((! a \ ! b \ not # a && not # b <=> not # (a || b)),
    [itaut 2])
- , theorem not_and ((! a \ ! b \ not ' a `or not ' b ==> not ' (a && b)),
+ , theorem not_and ((! a \ ! b \ not # a || not # b ==> not # (a && b)),
    [itaut 2])
- , theorem not_not_not ((! p \ not ' (not ' (not ' p)) <=> not ' p),
+ , theorem not_not_not ((! p \ not # (not # (not # p)) <=> not # p),
    [itaut 3])
- , theorem impl_not_not ((! a \ ! b \ (a ==> b) ==> (not ' b ==> not ' a)),
+ , theorem impl_not_not ((! a \ ! b \ (a ==> b) ==> (not # b ==> not # a)),
    [itaut 3])
  , theorem eq_to_impl_f ((! p \ ! q \ (p <=> q) ==> p ==> q),
     [itaut 2])
@@ -1205,31 +1193,31 @@ the_library L :-
 
 /*************** Properties inj/disj/univ ***********/
  , theorem pair_univ_inj_l 
-   (pi A \ pi B \ (! (univ '' A '' B) x20 \ ! x21 \ ! x22 \ ! x23 \ pair_univ '' A '' B ' x20 ' x22 = pair_univ '' A '' B ' x21 ' x23 ==> x20 = x21) ,
+   (pi A \ pi B \ (! (univ ## A ## B) x20 \ ! x21 \ ! x22 \ ! x23 \ pair_univ ## A ## B # x20 # x22 = pair_univ ## A ## B # x21 # x23 ==> x20 = x21) ,
    [then (repeat forall_i)
-     (bind (univ '' A '' B) x22 \
-       bind (univ '' A '' B) x23 \
-        bind (univ '' A '' B) x24 \
-         bind (univ '' A '' B) x25 \
+     (bind (univ ## A ## B) x22 \
+       bind (univ ## A ## B) x23 \
+        bind (univ ## A ## B) x24 \
+         bind (univ ## A ## B) x25 \
           then i
            (then (cutth proj1_pair_univ)
              (then (lforall x22)
                (then (conv (land_tac (then sym apply)))
                  (then (conv (depth_tac h)) (applyth proj1_pair_univ))))))])
  , theorem pair_univ_inj_r 
-   (pi A \ pi B \ (! (univ '' A '' B) x20 \ ! x21 \ ! x22 \ ! x23 \ pair_univ '' A '' B ' x20 ' x22 = pair_univ '' A '' B ' x21 ' x23 ==> x22 = x23) ,
+   (pi A \ pi B \ (! (univ ## A ## B) x20 \ ! x21 \ ! x22 \ ! x23 \ pair_univ ## A ## B # x20 # x22 = pair_univ ## A ## B # x21 # x23 ==> x22 = x23) ,
    [then (repeat forall_i)
-     (bind (univ '' A '' B) x22 \
-       bind (univ '' A '' B) x23 \
-        bind (univ '' A '' B) x24 \
-         bind (univ '' A '' B) x25 \
+     (bind (univ ## A ## B) x22 \
+       bind (univ ## A ## B) x23 \
+        bind (univ ## A ## B) x24 \
+         bind (univ ## A ## B) x25 \
           then i
            (then (cutth proj2_pair_univ)
              (then (lforall x22)
                (then (conv (land_tac (then sym apply)))
                  (then (conv (depth_tac h)) (applyth proj2_pair_univ))))))])
  , theorem injection_univ_inj
-   (pi A \ pi B \ (! A x20 \ ! x21 \ injection_univ '' A '' B ' x20 = injection_univ '' A '' B ' x21 ==> x20 = x21) ,
+   (pi A \ pi B \ (! A x20 \ ! x21 \ injection_univ ## A ## B # x20 = injection_univ ## A ## B # x21 ==> x20 = x21) ,
     [then forall_i
      (bind A x20 \
        then forall_i
@@ -1239,22 +1227,22 @@ the_library L :-
              (then i
                (thenl
                  (cut
-                   (ejection_univ '' A '' B ' (injection_univ '' A '' B ' x20) =
-                     ejection_univ '' A '' B ' (injection_univ '' A '' B ' x21)))
+                   (ejection_univ ## A ## B # (injection_univ ## A ## B # x20) =
+                     ejection_univ ## A ## B # (injection_univ ## A ## B # x21)))
                  [thenl
                    (cut
-                     ((ejection_univ '' A '' B ' (injection_univ '' A '' B ' x20) =
-                        ejection_univ '' A '' B ' (injection_univ '' A '' B ' x21)) =
+                     ((ejection_univ ## A ## B # (injection_univ ## A ## B # x20) =
+                        ejection_univ ## A ## B # (injection_univ ## A ## B # x21)) =
                        (x20 = x21)))
                    [then (conv (depth_tac (then sym h))) h,
                    thenl c [thenl c [r, h], h]], thenl c [r, h]])))))])
  , theorem inj1_univ_inj
-   (pi A \ pi B \ (! (univ '' A '' B) x20 \ ! x21 \ inj1_univ '' A '' B ' x20 = inj1_univ '' A '' B ' x21 ==> x20 = x21) ,
+   (pi A \ pi B \ (! (univ ## A ## B) x20 \ ! x21 \ inj1_univ ## A ## B # x20 = inj1_univ ## A ## B # x21 ==> x20 = x21) ,
     [then inv
-     (bind (univ '' A '' B) x20 \ bind (univ '' A '' B) x21 \
-        thenl (t (case_univ '' A '' B '' (univ '' A '' B) ' (inj1_univ '' A '' B ' x20) '
-             (lam (univ '' A '' B) x22 \ x22) '
-             (lam (univ '' A '' B) x22 \ x22)))
+     (bind (univ ## A ## B) x20 \ bind (univ ## A ## B) x21 \
+        thenl (t (case_univ ## A ## B ## (univ ## A ## B) # (inj1_univ ## A ## B # x20) '
+             (lam (univ ## A ## B) x22 \ x22) '
+             (lam (univ ## A ## B) x22 \ x22)))
          [then sym
            (then (conv (land_tac (applyth case_univ_inj1)))
              (then (conv (land_tac b)) r)),
@@ -1262,12 +1250,12 @@ the_library L :-
           (then (conv (land_tac (applyth case_univ_inj1)))
             (then (conv (land_tac b)) r))])])
  , theorem inj2_univ_inj
-   (pi A \ pi B \ (! (univ '' A '' B) x22 \ ! x23 \ inj2_univ '' A '' B ' x22 = inj2_univ '' A '' B ' x23 ==> x22 = x23) ,
+   (pi A \ pi B \ (! (univ ## A ## B) x22 \ ! x23 \ inj2_univ ## A ## B # x22 = inj2_univ ## A ## B # x23 ==> x22 = x23) ,
     [then inv
-     (bind (univ '' A '' B) x20 \ bind (univ '' A '' B) x21 \
-        thenl (t (case_univ '' A '' B '' (univ '' A '' B) ' (inj2_univ '' A '' B ' x20) '
-             (lam (univ '' A '' B) x22 \ x22) '
-             (lam (univ '' A '' B) x22 \ x22)))
+     (bind (univ ## A ## B) x20 \ bind (univ ## A ## B) x21 \
+        thenl (t (case_univ ## A ## B ## (univ ## A ## B) # (inj2_univ ## A ## B # x20) '
+             (lam (univ ## A ## B) x22 \ x22) '
+             (lam (univ ## A ## B) x22 \ x22)))
          [then sym
            (then (conv (land_tac (applyth case_univ_inj2)))
              (then (conv (land_tac b)) r)),
@@ -1275,15 +1263,15 @@ the_library L :-
           (then (conv (land_tac (applyth case_univ_inj2)))
             (then (conv (land_tac b)) r))])])
  , theorem not_eq_inj1_inj2_univ 
-   (pi A \ pi B \ (! (univ '' A '' B) x22 \ ! x23 \ inj1_univ '' A '' B ' x22 = inj2_univ '' A '' B ' x23 ==> ff) ,
+   (pi A \ pi B \ (! (univ ## A ## B) x22 \ ! x23 \ inj1_univ ## A ## B # x22 = inj2_univ ## A ## B # x23 ==> ff) ,
     [then inv
-     (bind (univ '' A '' B) x22 \
-       bind (univ '' A '' B) x23 \
+     (bind (univ ## A ## B) x22 \
+       bind (univ ## A ## B) x23 \
         then (cutth case_univ_inj1)
          (then (lforall x22)
-           (then (lforall (lam (univ '' A '' B) x24 \ ff))
-             (then (lforall (lam (univ '' A '' B) x24 \ tt))
-               (thenl (m ((lam (univ '' A '' B) x24 \ ff) ' x22)) [b,
+           (then (lforall (lam (univ ## A ## B) x24 \ ff))
+             (then (lforall (lam (univ ## A ## B) x24 \ tt))
+               (thenl (m ((lam (univ ## A ## B) x24 \ ff) # x22)) [b,
                  then (conv (then sym h))
                   (then (wl [])
                     (then (conv (depth_tac h))
@@ -1292,15 +1280,15 @@ the_library L :-
                           (then (conv b) (itaut 1))))))])))))])
  , theorem inj1_disj_union_inj (pi A \ pi B \
     ((! x \ ! y \
-     inj1_disj_union '' A '' B ' x = inj1_disj_union '' A '' B ' y ==> x = y) ,
+     inj1_disj_union ## A ## B # x = inj1_disj_union ## A ## B # y ==> x = y) ,
     [then inv
       (bind A x23 \
         bind A x24 \
          then (cutth case_disj_union_inj1)
           (then (lforall x23)
             (then (lforall (lam A x25 \ x25))
-              (then (lforall (lam B x25 \ choose '' A))
-                (thenl (t ((lam A x25 \ x25) ' x23))
+              (then (lforall (lam B x25 \ choose ## A))
+                (thenl (t ((lam A x25 \ x25) # x23))
                   [then (conv (rand_tac b)) r,
                   then (conv (land_tac (then sym h)))
                    (then (wl [])
@@ -1310,15 +1298,15 @@ the_library L :-
                            b))))])))))]))
  , theorem inj2_disj_union_inj (pi A \ pi B \
     ((! x \ ! y \
-     inj2_disj_union '' A '' B ' x = inj2_disj_union '' A '' B ' y ==> x = y) ,
+     inj2_disj_union ## A ## B # x = inj2_disj_union ## A ## B # y ==> x = y) ,
     [then inv
       (bind B x23 \
         bind B x24 \
          then (cutth case_disj_union_inj2)
           (then (lforall x23)
-            (then (lforall (lam A x25 \ choose '' B))
+            (then (lforall (lam A x25 \ choose ## B))
               (then (lforall (lam B x25 \ x25))
-                (thenl (t ((lam B x25 \ x25) ' x23))
+                (thenl (t ((lam B x25 \ x25) # x23))
                   [then (conv (rand_tac b)) r,
                   then (conv (land_tac (then sym h)))
                    (then (wl [])
@@ -1332,23 +1320,23 @@ the_library L :-
     (a1 ==> b1) ==> (a2 ==> b2) ==> a1 && a2 ==> b1 && b2),
     [itaut 2])
  , theorem or_monotone ((! a1 \ ! b1 \ ! a2 \ ! b2 \
-    (a1 ==> b1) ==> (a2 ==> b2) ==> a1 `or a2 ==> b1 `or b2),
+    (a1 ==> b1) ==> (a2 ==> b2) ==> a1 || a2 ==> b1 || b2),
     [itaut 2])
  , theorem impl_monotone ((! a1 \ ! b1 \ ! a2 \ ! b2 \
     (b1 ==> a1) ==> (a2 ==> b2) ==> (a1 ==> a2) ==> (b1 ==> b2)),
     [itaut 3])
- , theorem not_monotone ((! p \ ! q \ (p ==> q) ==> (not ' q) ==> (not ' p)),
+ , theorem not_monotone ((! p \ ! q \ (p ==> q) ==> (not # q) ==> (not # p)),
     [itaut 3])
  , theorem forall_monotone (pi A \ (! p \ ! q \
-    (! A x \ p ' x ==> q ' x) ==> (! x \ p ' x) ==> (! x \ q ' x)),
+    (! A x \ p # x ==> q # x) ==> (! x \ p # x) ==> (! x \ q # x)),
     [itaut 6])
  , theorem exists_monotone (pi A \ (! p \ ! q \
-    (! A x \ p ' x ==> q ' x) ==> (? x \ p ' x) ==> (? x \ q ' x)),
+    (! A x \ p # x ==> q # x) ==> (? x \ p # x) ==> (? x \ q # x)),
     [itaut 6])
 
  /********** Knaster-Tarski theorem *********/
   , def in (pi A \ (A --> (A --> prop) --> prop),
-     (lam A x \ lam (A --> prop) j \ j ' x))
+     (lam A x \ lam (A --> prop) j \ j # x))
   , def subseteq (pi A \ ((A --> prop) --> (A --> prop) --> prop),
      (lam (A --> prop) x \ lam (A --> prop) y \ ! z \ z #in x ==> z #in y))
   , theorem in_subseteq (pi A \ 
@@ -1359,13 +1347,13 @@ the_library L :-
           (bind (A --> prop) x10 \
             then forall_i (bind A x11 \ then (conv (land_tac dd)) (itaut 4))))])
   , def monotone (pi A \ (((A --> prop) --> (A --> prop)) --> prop),
-      (lam (_ A) f \ ! x \ ! y \ x <<= y ==> f ' x <<= f ' y))
+      (lam (_ A) f \ ! x \ ! y \ x <<= y ==> f # x <<= f # y))
   , def is_fixpoint (pi A \ (((A --> prop) --> (A --> prop)) --> ((A --> prop) --> prop)),
-     (lam (_ A) f \ lam (_ A) x \ (f ' x) <<= x && x <<= (f ' x)))
+     (lam (_ A) f \ lam (_ A) x \ (f # x) <<= x && x <<= (f # x)))
   , def fixpoint (pi A \ (((A --> prop) --> (A --> prop)) --> (A --> prop)),
-     (lam (_ A) f \ lam A a \ ! e \ f ' e <<= e ==> a #in e))
+     (lam (_ A) f \ lam A a \ ! e \ f # e <<= e ==> a #in e))
   , theorem fixpoint_subseteq_any_prefixpoint (pi A \
-     (! f \ ! x\ f ' x <<= x ==> fixpoint '' A ' f <<= x),
+     (! f \ ! x\ f # x <<= x ==> fixpoint ## A # f <<= x),
      [then inv
        (bind ((A --> prop) --> (A --> prop)) x9 \
          (bind (A --> prop) x10 \
@@ -1376,7 +1364,7 @@ the_library L :-
                   then (conv (land_tac dd))
                    (then (conv (land_tac b)) (itaut 4)))))))])
   , theorem fixpoint_subseteq_any_fixpoint (pi A \
-     (! f \ ! x\ is_fixpoint '' A ' f ' x ==> fixpoint '' A ' f <<= x),
+     (! f \ ! x\ is_fixpoint ## A # f # x ==> fixpoint ## A # f <<= x),
      [then forall_i
        (bind ((A --> prop) --> (A --> prop)) x9 \
          then forall_i
@@ -1384,13 +1372,13 @@ the_library L :-
             then (conv (land_tac dd))
              (then (cutth fixpoint_subseteq_any_prefixpoint) (itaut 8))))])
   , theorem prefixpoint_to_prefixpoint (pi A \
-     (! f \ ! x \ monotone '' A ' f ==> f ' x <<= x ==> f ' (f ' x) <<= f ' x),
+     (! f \ ! x \ monotone ## A # f ==> f # x <<= x ==> f # (f # x) <<= f # x),
     [then forall_i
       (bind ((A --> prop) --> (A --> prop)) x9 \
         then forall_i
          (bind (A --> prop) x10 \ then (conv (land_tac dd)) (itaut 6)))])
   , theorem fixpoint_is_prefixpoint (pi A \
-     (! f \ monotone '' A ' f ==> f ' (fixpoint '' A ' f)<<= fixpoint '' A ' f),
+     (! f \ monotone ## A # f ==> f # (fixpoint ## A # f)<<= fixpoint ## A # f),
      [then inv
        (bind ((A --> prop) --> (A --> prop)) x9 \
          then (conv dd)
@@ -1401,26 +1389,26 @@ the_library L :-
                  (then (conv b)
                    (then inv
                      (bind (A --> prop) x11 \
-                       thenl (cut (fixpoint '' A ' x9 <<= x11))
+                       thenl (cut (fixpoint ## A # x9 <<= x11))
                         [thenl
-                          (cut (x9 ' (fixpoint '' A ' x9) <<= x9 ' x11))
+                          (cut (x9 # (fixpoint ## A # x9) <<= x9 # x11))
                           [then (cutth in_subseteq)
-                            (then (lforall_last (x9 ' x11))
+                            (then (lforall_last (x9 # x11))
                               (then (lforall_last x11)
                                 (thenl apply_last [h,
                                   then (cutth in_subseteq) (itaut 10)]))),
                           thenl
-                           (m (monotone '' A ' x9 ==> x9 ' (fixpoint '' A ' x9) <<= x9 ' x11))
+                           (m (monotone ## A # x9 ==> x9 # (fixpoint ## A # x9) <<= x9 # x11))
                            [itaut 10, then (conv (land_tac dd)) (itaut 10)]],
                         then (applyth fixpoint_subseteq_any_prefixpoint) h])))))))])
   , theorem fixpoint_is_fixpoint (pi A \
-    (! f \ monotone '' A ' f ==> is_fixpoint '' A ' f ' (fixpoint '' A ' f)),
+    (! f \ monotone ## A # f ==> is_fixpoint ## A # f # (fixpoint ## A # f)),
     [then inv
       (bind ((A --> prop) --> (A --> prop)) x9 \
         then (conv (depth_tac (dd [is_fixpoint])))
          (thenl inv [then (applyth fixpoint_is_prefixpoint) h,
            then (applyth fixpoint_subseteq_any_prefixpoint)
-            (then (g (monotone '' A ' x9))
+            (then (g (monotone ## A # x9))
               (then (conv (land_tac dd))
                 (then inv
                   (then apply (then (applyth fixpoint_is_prefixpoint) h)))))]))])
@@ -1429,17 +1417,17 @@ the_library L :-
  , decl rec (pi A \pi B \ ((A --> B) --> (A --> B)) --> (A --> B))
  , inductive_def acc accF accF_monotone acc_i0 acc_e0 acc_e
     (pi A \ param (A --> A --> prop) lt \ acc \
-     [ (acc_i, ! x \ (! y \ lt ' y ' x ==> acc ' y) ==> acc ' x) ])
+     [ (acc_i, ! x \ (! y \ lt # y # x ==> acc # y) ==> acc # x) ])
 
  , def well_founded (pi A \ ((A --> A --> prop) --> prop,
-    lam (_ A) lt \ ! x \ acc '' A ' lt ' x))
+    lam (_ A) lt \ ! x \ acc ## A # lt # x))
 
  , axiom rec_is_fixpoint (pi A \ pi B \
-   (! lt \ well_founded '' A ' lt ==>
+   (! lt \ well_founded ## A # lt ==>
     ! ((A --> B) --> (A --> B)) h \
      (! f \ ! g \ ! i \
-       (! p \ lt ' p ' i ==> f ' p = g ' p) ==> h ' f ' i = h ' g ' i) ==>
-     rec '' A '' B ' h = h ' (rec '' A '' B ' h)))
+       (! p \ lt # p # i ==> f # p = g # p) ==> h # f # i = h # g # i) ==>
+     rec ## A ## B # h = h # (rec ## A ## B # h)))
  /******************* TESTS *****************/
  /* The first three tests are commented out because they require extra-hacks
     in the kernel to avoid quantifying over p, q and g.
@@ -1449,19 +1437,19 @@ the_library L :-
     [then i (then i (then apply h))])
  , theorem test_itaut_1 (((? x \ g x) ==> ! x \ (! y \ g y ==> x) ==> x),
    [itaut 4])*/
- , theorem test_monotone1 (monotone '' _ ' (lam _ p \ lam _ x \ not ' (p ' x) ==> tt && p ' tt `or p ' x),
+ , theorem test_monotone1 (monotone ## _ # (lam _ p \ lam _ x \ not # (p # x) ==> tt && p # tt || p # x),
    [ auto_monotone ])
- , theorem test_monotone2 (monotone '' _ ' (lam _ p \ lam _ x \ ? z \ not ' (p ' x) ==> tt && p ' tt `or z),
+ , theorem test_monotone2 (monotone ## _ # (lam _ p \ lam _ x \ ? z \ not # (p # x) ==> tt && p # tt || z),
    [ auto_monotone ])
- , theorem test_monotone3 (monotone '' _ ' (lam _ p \ lam _ x \ ! z \ ? y \ (not ' (p ' x) ==> z && p ' y `or y)),
+ , theorem test_monotone3 (monotone ## _ # (lam _ p \ lam _ x \ ! z \ ? y \ (not # (p # x) ==> z && p # y || y)),
    [ auto_monotone ])
  , inductive_def pnn pnnF pnnF_monotone pnn_i pnn_e0 pnn_e (pnn \
-     [ (pnn_tt, pnn ' tt)
-     , (pnn_not, ! x \ pnn ' x ==> pnn ' (not ' x))])
+     [ (pnn_tt, pnn # tt)
+     , (pnn_not, ! x \ pnn # x ==> pnn # (not # x))])
  , theorem pnn_e
     ((! x13 \
-       x13 ' tt && (! x14 \ x13 ' x14 ==> x13 ' (not ' x14)) ==>
-        (! x14 \ pnn ' x14 ==> x13 ' x14)) ,
+       x13 # tt && (! x14 \ x13 # x14 ==> x13 # (not # x14)) ==>
+        (! x14 \ pnn # x14 ==> x13 # x14)) ,
    [then forall_i
      (bind (prop --> prop) x13 \
        then (cutth pnn_e0)
@@ -1479,10 +1467,10 @@ the_library L :-
                           then left (then (conv (depth_tac h)) (itaut 8)))]))),
               h]))))])
  , theorem pnn_has_two_values
-    ((! x13 \ pnn ' x13 ==> x13 = tt `or x13 = ff) ,
+    ((! x13 \ pnn # x13 ==> x13 = tt || x13 = ff) ,
     % applying an elimination principle is hard: it should be automatized
     [then (cutth pnn_e)
-      (then (lforall (lam prop x13 \ or ' (eq '' prop ' x13 ' tt) ' (eq '' prop ' x13 ' ff)))
+      (then (lforall (lam prop x13 \ or # (eq ## prop # x13 # tt) # (eq ## prop # x13 # ff)))
         (thenl lapply
           [thenl conj [then (conv b) (itaut 1),
             then (repeat (conv (depth_tac b)))
@@ -1493,27 +1481,27 @@ the_library L :-
               (thenl lapply [h,
                 then
                  (g
-                   ((lam prop x14 \ or ' (eq '' prop ' x14 ' tt) ' (eq '' prop ' x14 ' ff)) '
+                   ((lam prop x14 \ or # (eq ## prop # x14 # tt) # (eq ## prop # x14 # ff)) '
                      x13))
                  (then (repeat (conv (depth_tac b)))
                    (then
                      (w
-                       ((lam prop x14 \ or ' (eq '' prop ' x14 ' tt) ' (eq '' prop ' x14 ' ff))
-                         ' x13)) (then (w (pnn ' x13)) (itaut 2))))]))]))])
+                       ((lam prop x14 \ or # (eq ## prop # x14 # tt) # (eq ## prop # x14 # ff))
+                         # x13)) (then (w (pnn # x13)) (itaut 2))))]))]))])
  , inductive_def in_two in_twoF in_twoF_monotone in_two_i in_two_e0 in_two_e (in_two \
-     [ (in_two_tt, in_two ' tt)
-     , (in_two_ff, in_two ' ff) ])
+     [ (in_two_tt, in_two # tt)
+     , (in_two_ff, in_two # ff) ])
  , new_basic_type bool2 myrep2 myabs2 myrepabs2 myabsrep2 myproprep2
     (pnn,
     [then (cutth pnn_tt) (then (applyth exists_i) h)])
- , def mytt (bool2,(myabs2 ' tt))
- , def mynot ((bool2 --> bool2),(lam _ x \ myabs2 ' (not ' (myrep2 ' x))))
+ , def mytt (bool2,(myabs2 # tt))
+ , def mynot ((bool2 --> bool2),(lam _ x \ myabs2 # (not # (myrep2 # x))))
  , theorem mytt_transfer
-   (myrep2 ' mytt = tt ,
+   (myrep2 # mytt = tt ,
      [then (conv (depth_tac (dd [mytt])))
        (then (applyth myrepabs2) (applyth pnn_tt))])
  , theorem mynot_transfer
-   ((! x18 \ myrep2 ' (mynot ' x18) = not ' (myrep2 ' x18)) ,
+   ((! x18 \ myrep2 # (mynot # x18) = not # (myrep2 # x18)) ,
      [then (conv (depth_tac (dd [mynot])))
        (then forall_i
          (bind bool2 x18 \
@@ -1521,53 +1509,53 @@ the_library L :-
             (then (applyth pnn_not) (applyth myproprep2))))])
  , theorem mybool2_e
  ((! x18 \
-    x18 ' mytt && (! x19 \ x18 ' x19 ==> x18 ' (mynot ' x19)) ==>
-     (! x19 \ x18 ' x19)) ,
+    x18 # mytt && (! x19 \ x18 # x19 ==> x18 # (mynot # x19)) ==>
+     (! x19 \ x18 # x19)) ,
    [thenl
      (cut
-       (forall '' (bool2 --> prop) '
+       (forall ## (bool2 --> prop) '
          (lam (bool2 --> prop) x18 \
            impl '
-            (and ' (x18 ' (myabs2 ' (myrep2 ' mytt))) '
-              (forall '' bool2 '
+            (and # (x18 # (myabs2 # (myrep2 # mytt))) '
+              (forall ## bool2 '
                 (lam bool2 x19 \
-                  impl ' (x18 ' (myabs2 ' (myrep2 ' x19))) '
+                  impl # (x18 # (myabs2 # (myrep2 # x19))) '
                    (x18 '
                      (myabs2 '
-                       (myrep2 ' (mynot ' (myabs2 ' (myrep2 ' x19)))))))))
+                       (myrep2 # (mynot # (myabs2 # (myrep2 # x19)))))))))
             '
-            (forall '' bool2 '
-              (lam bool2 x19 \ x18 ' (myabs2 ' (myrep2 ' x19)))))))
+            (forall ## bool2 '
+              (lam bool2 x19 \ x18 # (myabs2 # (myrep2 # x19)))))))
      [then
        (g
-         (forall '' (bool2 --> prop) '
+         (forall ## (bool2 --> prop) '
            (lam (bool2 --> prop) x18 \
              impl '
-              (and ' (x18 ' (myabs2 ' (myrep2 ' mytt))) '
-                (forall '' bool2 '
+              (and # (x18 # (myabs2 # (myrep2 # mytt))) '
+                (forall ## bool2 '
                   (lam bool2 x19 \
-                    impl ' (x18 ' (myabs2 ' (myrep2 ' x19))) '
+                    impl # (x18 # (myabs2 # (myrep2 # x19))) '
                      (x18 '
                        (myabs2 '
-                         (myrep2 ' (mynot ' (myabs2 ' (myrep2 ' x19)))))))))
+                         (myrep2 # (mynot # (myabs2 # (myrep2 # x19)))))))))
               '
-              (forall '' bool2 '
-                (lam bool2 x19 \ x18 ' (myabs2 ' (myrep2 ' x19)))))))
+              (forall ## bool2 '
+                (lam bool2 x19 \ x18 # (myabs2 # (myrep2 # x19)))))))
        (then
          (w
-           (forall '' (bool2 --> prop) '
+           (forall ## (bool2 --> prop) '
              (lam (bool2 --> prop) x18 \
                impl '
-                (and ' (x18 ' (myabs2 ' (myrep2 ' mytt))) '
-                  (forall '' bool2 '
+                (and # (x18 # (myabs2 # (myrep2 # mytt))) '
+                  (forall ## bool2 '
                     (lam bool2 x19 \
-                      impl ' (x18 ' (myabs2 ' (myrep2 ' x19))) '
+                      impl # (x18 # (myabs2 # (myrep2 # x19))) '
                        (x18 '
                          (myabs2 '
-                           (myrep2 ' (mynot ' (myabs2 ' (myrep2 ' x19)))))))))
+                           (myrep2 # (mynot # (myabs2 # (myrep2 # x19)))))))))
                 '
-                (forall '' bool2 '
-                  (lam bool2 x19 \ x18 ' (myabs2 ' (myrep2 ' x19)))))))
+                (forall ## bool2 '
+                  (lam bool2 x19 \ x18 # (myabs2 # (myrep2 # x19)))))))
          (then (repeat (conv (depth_tac (applyth myabsrep2)))) (then i h))),
      then forall_i
       (bind (bool2 --> prop) x18 \
@@ -1575,26 +1563,26 @@ the_library L :-
          (then
            (lforall
              (lam prop x19 \
-               exists '' bool2 '
+               exists ## bool2 '
                 (lam bool2 x20 \
-                  and ' (eq '' _ ' x19 ' (myrep2 ' x20)) '
-                   (x18 ' (myabs2 ' x19)))))
+                  and # (eq ## _ # x19 # (myrep2 # x20)) '
+                   (x18 # (myabs2 # x19)))))
            (then inv
              (bind bool2 x19 \
                thenl
                 (cut
                   ((lam prop x20 \
-                     exists '' bool2 '
+                     exists ## bool2 '
                       (lam bool2 x21 \
-                        and ' (eq '' _ ' x20 ' (myrep2 ' x21)) '
-                         (x18 ' (myabs2 ' x20)))) ' (myrep2 ' x19)))
+                        and # (eq ## _ # x20 # (myrep2 # x21)) '
+                         (x18 # (myabs2 # x20)))) # (myrep2 # x19)))
                 [then
                   (g
                     ((lam prop x20 \
-                       exists '' bool2 '
+                       exists ## bool2 '
                         (lam bool2 x21 \
-                          and ' (eq '' _ ' x20 ' (myrep2 ' x21)) '
-                           (x18 ' (myabs2 ' x20)))) ' (myrep2 ' x19)))
+                          and # (eq ## _ # x20 # (myrep2 # x21)) '
+                           (x18 # (myabs2 # x20)))) # (myrep2 # x19)))
                   (then (conv (depth_tac b)) inv),
                 thenl apply
                  [then (repeat (conv (depth_tac b)))
@@ -1603,8 +1591,8 @@ the_library L :-
                        (then
                          (lforall_last
                            (lam bool2 x20 \
-                             and ' (eq '' _ ' tt ' (myrep2 ' x20)) '
-                              (x18 ' (myabs2 ' tt))))
+                             and # (eq ## _ # tt # (myrep2 # x20)) '
+                              (x18 # (myabs2 # tt))))
                          (then (lforall_last mytt)
                            (then apply_last (then (conv b)
                             (thenl inv
@@ -1612,7 +1600,7 @@ the_library L :-
                                (then (conv (depth_tac h)) (applyth tt_intro)),
                              (applyth tt_intro),
                              then (cutth mytt_transfer)
-                              (then (g (x18 ' (myabs2 ' (myrep2 ' mytt))))
+                              (then (g (x18 # (myabs2 # (myrep2 # mytt))))
                                 (then (conv (depth_tac h)) (then i h)))]))))),
                      (bind prop x20 \
                        bind bool2 x21 \
@@ -1620,26 +1608,26 @@ the_library L :-
                          (then
                            (lforall_last
                              (lam bool2 x22 \
-                               and ' (eq '' _ ' (not ' x20) ' (myrep2 ' x22)) '
-                                (x18 ' (myabs2 ' (not ' x20)))))
-                           (then (lforall_last (mynot ' x21))
+                               and # (eq ## _ # (not # x20) # (myrep2 # x22)) '
+                                (x18 # (myabs2 # (not # x20)))))
+                           (then (lforall_last (mynot # x21))
                              (then apply_last (then (conv b)
     (thenl inv
      [then (conv (applyth mynot_transfer))
        (then (conv (depth_tac (dd [not]))) (then inv (itaut 3))),
-     then (g (myrep2 ' (mynot ' x21)))
+     then (g (myrep2 # (mynot # x21)))
       (then (conv (land_tac (applyth mynot_transfer)))
         (then (conv (depth_tac (dd [not]))) (then inv (itaut 3)))),
-     then (lforall (myabs2 ' x20))
+     then (lforall (myabs2 # x20))
       (thenl lapply [then (conv (depth_tac (applyth myabsrep2))) h,
         then
          (g
            (x18 '
              (myabs2 '
-               (myrep2 ' (mynot ' (myabs2 ' (myrep2 ' (myabs2 ' x20))))))))
+               (myrep2 # (mynot # (myabs2 # (myrep2 # (myabs2 # x20))))))))
          (then (conv (depth_tac (applyth myabsrep2)))
            (then (conv (depth_tac (applyth myabsrep2)))
-             (thenl (cut (x20 = myrep2 ' x21))
+             (thenl (cut (x20 = myrep2 # x21))
                [then (conv (depth_tac h))
                  (then (conv (depth_tac h))
                    (then (conv (depth_tac (applyth myabsrep2)))
@@ -1653,27 +1641,27 @@ the_library L :-
                  applyth myproprep2]]))))]])
 
 , theorem step0
-    ((! x13 \ mynot ' (mynot ' (mynot ' x13)) = mynot ' x13) ,
+    ((! x13 \ mynot # (mynot # (mynot # x13)) = mynot # x13) ,
      [then inv
       (bind bool2 x13 \
         then (repeat (conv (depth_tac (dd [mynot]))))
          (thenl (conv (land_tac (rand_tac (rand_tac (applyth myrepabs2)))))
           [then (cutth pnn_not)
-            (then (lforall (myrep2 ' (myabs2 ' (not ' (myrep2 ' x13)))))
+            (then (lforall (myrep2 # (myabs2 # (not # (myrep2 # x13)))))
               (then (cutth myproprep2)
-                (then (lforall (myabs2 ' (not ' (myrep2 ' x13))))
+                (then (lforall (myabs2 # (not # (myrep2 # x13))))
                   (then apply h)))),
           thenl
            (conv
              (land_tac
                (rand_tac (rand_tac (rand_tac (applyth myrepabs2))))))
            [then (cutth pnn_not)
-             (then (lforall (myrep2 ' x13))
+             (then (lforall (myrep2 # x13))
                (then (cutth myproprep2)
                  (then (lforall x13) (then apply h)))),
            then (conv (land_tac (rand_tac (applyth not_not_not)))) r]]))])
  , theorem mynot_mynot_mytt
-    (mynot ' (mynot ' mytt) = mytt ,
+    (mynot # (mynot # mytt) = mytt ,
      [then (conv (depth_tac (dd [mynot])))
       (then (cutth mynot_transfer)
         (then (lforall mytt)
@@ -1682,18 +1670,18 @@ the_library L :-
               (then (conv (depth_tac h))
                 (then (conv (depth_tac (dd [mytt]))) (thenl c [r, itaut 3])))))))])
  , theorem step1
-    ((! x18 \ x18 = mytt `or x18 = mynot ' mytt) ,
+    ((! x18 \ x18 = mytt || x18 = mynot # mytt) ,
      [then forall_i
       (bind bool2 x18 \
        then (cutth mybool2_e)
         (thenl
           (cut
             ((lam bool2 x19 \
-               or ' (eq '' _ ' x19 ' mytt) ' (eq '' _ ' x19 ' (mynot ' mytt))) ' x18))
+               or # (eq ## _ # x19 # mytt) # (eq ## _ # x19 # (mynot # mytt))) # x18))
           [then
             (g
               ((lam bool2 x19 \
-                 or ' (eq '' _ ' x19 ' mytt) ' (eq '' _ ' x19 ' (mynot ' mytt))) '
+                 or # (eq ## _ # x19 # mytt) # (eq ## _ # x19 # (mynot # mytt))) '
                 x18)) (then (conv (depth_tac b)) (then i h)),
           then apply
            (then (repeat (conv (depth_tac b)))
@@ -1708,43 +1696,43 @@ the_library L :-
  /* TODO: this is an inductive type as well: generalize
     inductive_type to type abstractions */
  , def is_pair (pi A \ pi B \
-  (univ '' (disj_union '' A '' B) '' prop --> prop),
+  (univ ## (disj_union ## A ## B) ## prop --> prop),
   lam (_ A B) p \ ? A a \ ? B b \
    p =
-    pair_univ '' (_ A B) '' _ '
-     (injection_univ '' (_ A B) '' _ ' (inj1_disj_union '' A '' B ' a)) '
-     (injection_univ '' (_ A B) '' _ ' (inj2_disj_union '' A '' B ' b)))
+    pair_univ ## (_ A B) ## _ '
+     (injection_univ ## (_ A B) ## _ # (inj1_disj_union ## A ## B # a)) '
+     (injection_univ ## (_ A B) ## _ # (inj2_disj_union ## A ## B # b)))
  , new_basic_type prod prod_rep prod_abs prod_repabs prod_absrep prod_proprep
-    (pi A \ pi B \ is_pair '' A '' B, [daemon])
+    (pi A \ pi B \ is_pair ## A ## B, [daemon])
  , def pair (pi A \ pi B \
-    (A --> B --> prod '' A '' B,
+    (A --> B --> prod ## A ## B,
     lam A a \ lam B b \
-     prod_abs '' A '' B '
-      (pair_univ '' (_ A B) '' _ '
-       (injection_univ '' (_ A B) '' _ ' (inj1_disj_union '' A '' B ' a)) '
-       (injection_univ '' (_ A B) '' _ ' (inj2_disj_union '' A '' B ' b)))
+     prod_abs ## A ## B '
+      (pair_univ ## (_ A B) ## _ '
+       (injection_univ ## (_ A B) ## _ # (inj1_disj_union ## A ## B # a)) '
+       (injection_univ ## (_ A B) ## _ # (inj2_disj_union ## A ## B # b)))
     ))
  /* TODO: define fst and snd and prove the usual lemmas
-    fst ' (pair ' a ' b) = a */
+    fst # (pair # a # b) = a */
 
   /************* Natural numbers ***************/
  , inductive_def is_nat is_natF is_nat_monotone is_nat_i is_nat_e0 is_nat_e
    (is_nat \
-     [ (is_nat_z, is_nat ' (inj1_univ '' prop '' prop ' (injection_univ '' prop '' prop ' ff)))
-     , (is_nat_s, ! x \ is_nat ' x ==> is_nat ' (inj2_univ '' prop '' prop ' x))])
+     [ (is_nat_z, is_nat # (inj1_univ ## prop ## prop # (injection_univ ## prop ## prop # ff)))
+     , (is_nat_s, ! x \ is_nat # x ==> is_nat # (inj2_univ ## prop ## prop # x))])
  , new_basic_type nat nat_rep nat_abs nat_repabs nat_absrep nat_proprep
     (is_nat,
     [then (cutth is_nat_z) (then (applyth exists_i) h)])
- , def z (nat, nat_abs ' (inj1_univ '' prop '' prop ' (injection_univ '' prop '' prop ' ff)))
+ , def z (nat, nat_abs # (inj1_univ ## prop ## prop # (injection_univ ## prop ## prop # ff)))
  , def s (nat --> nat,
-    (lam _ x \ nat_abs ' (inj2_univ '' prop '' prop ' (nat_rep ' x))))
+    (lam _ x \ nat_abs # (inj2_univ ## prop ## prop # (nat_rep # x))))
  /* TODO: consequence of is_nat_e by transfer principles */
- , theorem nat_e ((! p \ p ' z ==> (! n \ p ' n ==> p ' (s ' n)) ==> ! n \ p ' n), [ daemon ])
+ , theorem nat_e ((! p \ p # z ==> (! n \ p # n ==> p # (s # n)) ==> ! n \ p # n), [ daemon ])
  , theorem nat_abs_inj
    ((! x18 \
       ! x19 \
-       is_nat ' x18 ==>
-        is_nat ' x19 ==> nat_abs ' x18 = nat_abs ' x19 ==> x18 = x19) ,
+       is_nat # x18 ==>
+        is_nat # x19 ==> nat_abs # x18 = nat_abs # x19 ==> x18 = x19) ,
      [then inv
        (bind _ x18 \
          bind _ x19 \
@@ -1752,14 +1740,14 @@ the_library L :-
            thenl (conv (rand_tac (then sym (applyth nat_repabs)))) [h,
             then (conv (depth_tac h)) r]])])
  , theorem nat_rep_inj
-   ((! x18 \ ! x19 \ nat_rep ' x18 = nat_rep ' x19 ==> x18 = x19) ,
+   ((! x18 \ ! x19 \ nat_rep # x18 = nat_rep # x19 ==> x18 = x19) ,
      [then inv
        (bind nat x18 \
          bind nat x19 \
           then (conv (land_tac (then sym (applyth nat_absrep))))
            (then (conv (rand_tac (then sym (applyth nat_absrep))))
              (then (conv (depth_tac h)) r)))])
- , theorem s_inj ((! x18 \ ! x19 \ s ' x18 = s ' x19 ==> x18 = x19) ,
+ , theorem s_inj ((! x18 \ ! x19 \ s # x18 = s # x19 ==> x18 = x19) ,
      [then (repeat (conv (depth_tac (dd [s]))))
        (then inv
          (bind nat x18 \
@@ -1769,7 +1757,7 @@ the_library L :-
                (thenl (applyth nat_abs_inj)
                  [then (applyth is_nat_s) (applyth nat_proprep),
                  then (applyth is_nat_s) (applyth nat_proprep), h]))))])
- , theorem not_equal_z_s ((! x20 \ not ' (z = s ' x20)) ,
+ , theorem not_equal_z_s ((! x20 \ not # (z = s # x20)) ,
      [then (repeat (conv (depth_tac (dd [z]))))
        (then (repeat (conv (depth_tac (dd [s]))))
          (then (repeat (conv (depth_tac (dd [not]))))
@@ -1781,8 +1769,8 @@ the_library L :-
                   then (applyth is_nat_s) (applyth nat_proprep)])))))])
  , def nat_case (pi A \ (nat --> A --> (nat --> A) --> A,
     lam _ n \ lam (_ A) a \ lam (_ A) f \
-     case_univ '' prop '' prop '' A ' (nat_rep ' n) ' (lam _ x \ a) ' (lam _ p \ f ' (nat_abs ' p))))
- , theorem nat_case_z (pi A \ ((! x21 \ ! x22 \ nat_case '' A ' z ' x21 ' x22 = x21) ,
+     case_univ ## prop ## prop ## A # (nat_rep # n) # (lam _ x \ a) # (lam _ p \ f # (nat_abs # p))))
+ , theorem nat_case_z (pi A \ ((! x21 \ ! x22 \ nat_case ## A # z # x21 # x22 = x21) ,
       [then (conv (depth_tac (dd [nat_case])))
         (then (conv (depth_tac (dd [z])))
           (then forall_i
@@ -1796,7 +1784,7 @@ the_library L :-
                     (then (conv (depth_tac b)) r)]))))]))
  , theorem nat_case_s
    (pi A \ (! x21 \ ! x22 \ ! x23 \
-     nat_case '' A ' (s ' x21) ' x22 ' x23 = x23 ' x21),
+     nat_case ## A # (s # x21) # x22 # x23 = x23 # x21),
      [then (conv (depth_tac (dd [nat_case])))
        (then (conv (depth_tac (dd [s])))
          (then forall_i
@@ -1814,7 +1802,7 @@ the_library L :-
 
 
  , theorem pred_well_founded
-   (well_founded '' nat ' (lam nat x21 \ lam nat x22 \ x22 = s ' x21) ,
+   (well_founded ## nat # (lam nat x21 \ lam nat x22 \ x22 = s # x21) ,
    [then (conv dd)
      (then forall_i
        (bind nat x21 \
@@ -1838,13 +1826,13 @@ the_library L :-
  , def nat_recF (pi A \
     A --> (nat --> A --> A) --> (nat --> A) --> (nat --> A)
     , lam A a \ lam (_ A) f \ lam (_ A) rec \ lam _ n \
-       nat_case '' A ' n ' a ' (lam _ p \ f ' p ' (rec ' p)))
+       nat_case ## A # n # a # (lam _ p \ f # p # (rec # p)))
  , def nat_rec (pi A \
     A --> (nat --> A --> A) --> nat --> A
-    , lam A a \ lam (_ A) f \ rec '' nat '' A ' (nat_recF '' A ' a ' f))
+    , lam A a \ lam (_ A) f \ rec ## nat ## A # (nat_recF ## A # a # f))
  , theorem nat_rec_ok0 (pi A \
    ((! a \ ! f \
-     nat_rec '' A ' a ' f = nat_recF '' A ' a ' f ' (nat_rec '' A ' a ' f)) ,
+     nat_rec ## A # a # f = nat_recF ## A # a # f # (nat_rec ## A # a # f)) ,
    [then inv
      (bind A x22 \
        bind (nat --> A --> A) x23 \
@@ -1873,8 +1861,8 @@ the_library L :-
                                       then (conv (land_tac (rand_tac h))) r]))))))])))))]))]))
  , theorem nat_rec_ok (pi A \
    (! a \ ! f \ ! n \
-     nat_rec '' A ' a ' f ' n =
-      nat_case '' A ' n ' a ' (lam _ p \ f ' p ' (nat_rec '' A ' a ' f ' p))),
+     nat_rec ## A # a # f # n =
+      nat_case ## A # n # a # (lam _ p \ f # p # (nat_rec ## A # a # f # p))),
    [then inv
      (bind A x22 \
        bind (nat --> A --> A) x23 \
@@ -1885,14 +1873,14 @@ the_library L :-
  /************* Arithmetics: plus ***************/
  , def plus (nat --> nat --> nat,
     lam _ n \ lam _ m \
-     nat_rec '' _ ' m ' (lam _ p \ lam _ sum \ s ' sum)' n)
+     nat_rec ## _ # m # (lam _ p \ lam _ sum \ s # sum)' n)
  , theorem plus_z ((! n \ z + n = n),
    [then (conv (depth_tac (dd [plus])))
      (then inv
        (bind nat x21 \
          then (conv (land_tac (applyth nat_rec_ok)))
           (then (conv (land_tac (applyth nat_case_z))) r)))])
- , theorem plus_s ((! n \ ! m \  s ' n + m = s ' (n + m)),
+ , theorem plus_s ((! n \ ! m \  s # n + m = s # (n + m)),
    [then (repeat (conv (depth_tac (dd [plus]))))
      (then inv
        (bind nat x21 \
@@ -1908,7 +1896,7 @@ the_library L :-
           (bind nat x21 \
             then (conv (land_tac (applyth plus_s)))
              (then (conv (depth_tac h)) r)))])])
- , theorem plus_n_s ((! n \ ! m \ n + (s ' m) = s ' (n + m)),
+ , theorem plus_n_s ((! n \ ! m \ n + (s # m) = s # (n + m)),
    [then (conv (rand_tac beta_expand))
      (thenl (applyth nat_e)
        [then (conv b)

--- a/tests/sources/hollight_legacy.elpi
+++ b/tests/sources/hollight_legacy.elpi
@@ -1,0 +1,2007 @@
+% vim: set ft=lprolog:
+
+infixr --> 126. % type arrow
+infixl '   255. % infix application
+infixl ''  255. % infix System-F application
+infixl &&  128. % and
+infixl `or  127. % or
+infixr ==> 126. % implication
+infixr <=> 125. % iff
+infix  #in 135. % membership
+infix  <<= 130. % subseteq
+
+/* Untrusted predicates called from the kernel:
+ * next_object            next object to check
+ * callback_proved        proof completed
+ * next_tactic            next tactic to use
+ * update_certificate     get new certificate after tactic application
+ * end_of_proof           is the certificate/proof empty?
+ * ppterm                 for pretty-printing messages
+ * deftac                 tactic definition
+ */
+
+/* Predicates exported from the trusted library:
+ * append
+ * fold2_append
+ * put_binds
+ */
+ 
+/* Predicates exported from the kernel:
+ * proves
+ * check
+ */
+
+{ /***** Trusted code base *******/
+
+/***** Trusted library functions *****/
+
+/* The names with ' at the end are trusted; the ones without are
+   exported and therefore untrusted. */
+local append', fold2_append', put_binds'.
+
+append' [] L L.
+append' [ X | XS ] L [ X | RES ] :- append' XS L RES.
+append A B C :- append' A B C.
+
+fold2_append' [] [] _ [].
+fold2_append' [ X | XS ] [ Y | YS ] F OUTS :-
+ F X Y OUT, fold2_append' XS YS F OUTS2, append' OUT OUTS2 OUTS.
+fold2_append A B C D :- fold2_append' A B C D.
+
+% put_binds : list 'b -> 'a -> 'c -> list (bounded 'b) -> o
+% put_binds [ f1,...,fn ] x t [ bind t x \ f1,...,bind t x fn ]
+% binding all the xs that occur in f1,...,fn
+put_binds' [] _ _ [].
+put_binds' [ YX | YSX ] X A [ bind A Y | YYS ] :-
+ YX = Y X, put_binds' YSX X A YYS.
+put_binds A B C D :- put_binds' A B C D.
+
+/***** The HOL kernel *****/
+
+local thm, provable, def0, term, typ, typ', loop, prove, check1,
+ check1def, check1thm, check1axm, check1nbt,
+ reterm, not_defined, check_hyps.
+
+proves T TY :- provable T TY.
+
+typ T :- !. % this line temporarily drops checking of well-formedness for types
+            % to avoid too much slow down. It is ultimately due to re-typing
+            % terms that should be recognized as already well typed.
+typ T :- var T, !, declare_constraint (typ T) [ T ].
+typ T :- typ' T.
+typ' prop.
+typ' (univ '' A '' B) :- typ A, typ B.
+typ' (A --> B) :- typ A, typ B.
+typ' (disj_union '' A '' B) :- typ A, typ B.
+
+mode (term i o).
+term (lam A F) (A --> B) :- typ A, pi x\ term x A => term (F x) B.
+term (F ' T) B :- term F (A --> B), term T A.
+term (eq '' A) (A --> A --> prop) :- typ A.
+term (uvar as T) TY :- declare_constraint (term T TY) T.
+
+/* like term, but on terms that are already known to be well-typed */
+mode (reterm i o).
+reterm (lam A F) (A --> B) :- pi x\ reterm x A => reterm (F x) B.
+reterm (F ' T) B :- reterm F (A --> B).
+reterm (eq '' A) (A --> A --> prop).
+reterm (uvar as T) TY :- declare_constraint (reterm T TY) T.
+
+constraint term reterm { /* No propagation rules for now */}
+
+% thm : bounded tactic -> bounded sequent -> list (bounded sequent) -> o
+thm C (seq Gamma G) _ :- debug, $print Gamma "|- " G " := " C, fail.
+
+/* << HACKS FOR DEBUGGING */
+thm daemon (seq Gamma F) [].
+/* >> HACKS FOR DEBUGGING */
+
+thm r (seq Gamma (eq '' _ ' X ' X)) [].
+thm (t Y) (seq Gamma (eq '' A ' X ' Z))
+ [ seq Gamma (eq '' A ' X ' Y), seq Gamma (eq '' A ' Y ' Z) ] :- term Y A.
+thm (m P) (seq Gamma Q) [ seq Gamma (eq '' prop ' P ' Q), seq Gamma P ] :- term P prop.
+thm b (seq Gamma (eq '' _ ' ((lam _ F) ' X) ' (F X))) [].
+thm c (seq Gamma (eq '' B ' (F ' X) ' (G ' Y)))
+ [ seq Gamma (eq '' (A --> B) ' F ' G) , seq Gamma (eq '' A ' X ' Y) ] :- reterm X A, reterm Y A.
+thm k (seq Gamma (eq '' (A --> B) ' (lam A S) ' (lam A T)))
+ [ bind A x \ seq Gamma (eq '' B ' (S x) ' (T x)) ].
+thm s (seq Gamma (eq '' prop ' P ' Q)) [ seq (P :: Gamma) Q, seq (Q :: Gamma) P ].
+thm (h IGN) (seq Gamma P) [] :- append' IGN [ P | Gamma2 ] Gamma.
+
+thm d (seq Gamma (eq '' _ ' C ' A)) [] :- def0 C A.
+thm (th NAME) (seq _ G) [] :- provable NAME G.
+
+thm (thenll TAC1 TACN) SEQ SEQS :-
+ thm TAC1 SEQ NEW,
+ deftacl TACN NEW TACL,
+ fold2_append' TACL NEW thm SEQS.
+
+/*debprint _ (then _ _) :- !.
+debprint _ (thenl _ _) :- !.
+debprint O T :- $print O T.*/
+
+thm TAC SEQ SEQS :-
+ deftac TAC SEQ XTAC,
+ /*debprint "<<" TAC,
+ (*/ thm XTAC SEQ SEQS /*, debprint ">>" TAC
+ ; debprint "XX" TAC, fail)*/.
+
+thm (! TAC) SEQ SEQS :-
+ thm TAC SEQ SEQS,
+ !.
+
+thm id SEQ [ SEQ ].
+
+thm (wl Gamma1) (seq Gamma F) [ seq WGamma F ] :-
+ append' Gamma1 [ P | Gamma2 ] Gamma,
+ append' Gamma1 Gamma2 WGamma.
+
+thm (bind A TAC) (bind A SEQ) NEWL :-
+ pi x \ term x A => reterm x A => thm (TAC x) (SEQ x) (NEW x), put_binds' (NEW x) x A NEWL.
+
+thm ww (bind A x \ SEQ) [ SEQ ].
+
+/* debuggin only, remove it */
+%thm A B C :- $print "FAILED " (thm A B C), fail.
+
+% loop : list (bounded sequent) -> certificate -> o
+%loop SEQS TACS :- $print "LOOP" (loop SEQS TACS), fail.
+loop [] CERTIFICATE :- end_of_proof CERTIFICATE.
+loop [ SEQ | OLD ] CERTIFICATE :-
+ next_tactic [ SEQ | OLD ] CERTIFICATE ITAC,
+ thm ITAC SEQ NEW,
+ append' NEW OLD SEQS,
+ update_certificate CERTIFICATE ITAC NEW NEW_CERTIFICATE,
+ loop SEQS NEW_CERTIFICATE.
+
+prove G TACS :-
+ (term G prop, ! ; ppterm PG G, $print "Bad statement:" PG, fail),
+% (TACS = (false,_), ! ;
+ loop [ seq [] G ] TACS
+. % ).
+
+not_defined P NAME :-
+ not (P NAME _) ; $print "Error:" NAME already defined, fail.
+
+check_hyps HS (typ' TYPE) :-
+ (not (typ' TYPE) ; $print "Error:" TYPE already defined, fail), $print HS new TYPE.
+check_hyps HS (def0 NAME DEF) :- ppterm PDEF DEF, $print HS NAME "=" PDEF.
+check_hyps HS (term NAME TYPE) :-
+ not_defined term NAME, ppterm PTYPE TYPE, $print HS NAME ":" PTYPE.
+check_hyps HS (reterm _ _).
+check_hyps HS (provable NAME TYPE) :-
+ not_defined provable NAME, ppterm PTYPE TYPE, $print HS NAME ":" PTYPE.
+check_hyps HS (H1,H2) :- check_hyps HS H1, check_hyps HS H2.
+check_hyps HS (pi H) :- pi x \ typ' x => check_hyps [x | HS] (H x).
+check_hyps HS (_ => H2) :- check_hyps HS H2.
+
+/* check1 I O
+   checks the declaration I
+   returns the new assumption O */
+check1 (theorem NAME GOALTACTICS) HYPS :- check1thm NAME GOALTACTICS HYPS, !.
+check1 (axiom NAME ST) HYPS :- check1axm NAME ST HYPS, !.
+check1 (new_basic_type TYPE REP ABS REPABS ABSREP PREPH P_TACTICS) HYPS :- check1nbt TYPE REP ABS REPABS ABSREP PREPH P_TACTICS true HYPS, !.
+check1 (def NAME TYPDEF) HYPS :- check1def NAME TYPDEF true HYPS, !.
+check1 (decl NAME TYP) HYPS :- check1decl NAME TYP true HYPS, !.
+
+check1def NAME (pi I) HYPSUCHTHAT (pi HYPS) :-
+ pi x \ typ' x => check1def (NAME '' x) (I x) (HYPSUCHTHAT, typ x) (HYPS x).
+check1def NAME (TYP,DEF) HYPSUCHTHAT HYPS :-
+ typ TYP, term DEF TYP,
+ HYPS = ((HYPSUCHTHAT => term NAME TYP), reterm NAME TYP, def0 NAME DEF).
+
+check1decl NAME (pi I) HYPSUCHTHAT (pi HYPS) :-
+ pi x \ typ' x => check1decl (NAME '' x) (I x) (HYPSUCHTHAT, typ x) (HYPS x).
+check1decl NAME TYP HYPSUCHTHAT HYPS :-
+ typ TYP, HYPS = ((HYPSUCHTHAT => term NAME TYP), reterm NAME TYP).
+
+check1thm NAME (pi I) (pi HYPS) :-
+ pi x \ typ' x => check1thm NAME (I x) (HYPS x).
+check1thm NAME (GOAL,TACTICS) (provable NAME GOAL) :-
+  prove GOAL TACTICS,
+  callback_proved NAME GOAL TACTICS.
+
+check1axm NAME (pi I) (pi HYPS) :- !,
+ pi x \ typ' x => check1axm NAME (I x) (HYPS x).
+check1axm NAME GOAL (provable NAME GOAL) :-
+ term GOAL prop, ! ; ppterm PGOAL GOAL, $print "Bad statement:" PGOAL, fail.
+
+check1nbt TYPE REP ABS REPABS ABSREP PREPH (pi P_TACTICS) HYPSUCHTHAT (pi HYPS) :-
+ pi x \ typ' x => check1nbt (TYPE '' x) (REP '' x) (ABS '' x) REPABS ABSREP PREPH (P_TACTICS x) (HYPSUCHTHAT, typ x) (HYPS x).
+check1nbt TYPE REP ABS REPABS ABSREP PREPH (P,TACTICS) HYPSUCHTHAT HYPS :-
+  term P (X --> prop),
+  prove (exists '' _ ' P ) TACTICS,
+  callback_proved existence_condition (exists '' _ ' P) TACTICS,
+  REPTYP = (TYPE --> X),
+  ABSTYP = (X --> TYPE),
+  ABSREPTYP = (forall '' TYPE ' lam TYPE x \ eq '' TYPE ' (ABS ' (REP ' x)) ' x),
+  REPABSTYP = (forall '' X ' lam X x \ impl ' (P ' x) ' (eq '' X ' (REP ' (ABS ' x)) ' x)),
+  PREPHTYP = (forall '' TYPE ' lam TYPE x \ (P ' (REP ' x))),
+  !,
+  HYPS =
+   ( (HYPSUCHTHAT => typ' TYPE)
+   , (HYPSUCHTHAT => term REP REPTYP), reterm REP REPTYP
+   , (HYPSUCHTHAT => term ABS ABSTYP), reterm ABS ABSTYP
+   , provable ABSREP ABSREPTYP
+   , provable REPABS REPABSTYP, provable PREPH PREPHTYP).
+
+check WHAT :-
+ next_object WHAT C CONT,
+ (C = stop, !, K = true ; check1 C H , check_hyps [] H, $print_constraints, K = (H => check CONT)),
+ !, K.
+
+}
+
+/************ parsing and pretty-printing ********/
+% ppterm/parseterm
+%ppterm X Y :- ppp X Y. parseterm X Y :- ppp X Y.
+%ppp X Y :- var X, var Y, !, X = Y.
+%ppp X (F ' G) :- var X, (var F ; var G), !, X = (F ' G).
+%ppp X (F ' G ' H) :- var X, (var F ; var G ; var H), !,
+% X = (F ' G ' H).
+
+mode (ppp o i) xas ppterm, (ppp i o) xas parseterm.
+
+ppp (! F2) (forall '' _ ' lam _ F1) :- !, pi x \ ppp (F2 x) (F1 x).
+ppp (! TY F2) (forall '' TY ' lam TY F1) :- !, pi x \ ppp (F2 x) (F1 x).
+ppp (? F2) (exists '' _ ' lam _ F1) :- !, pi x \ ppp (F2 x) (F1 x).
+ppp (? TY F2) (exists '' TY ' lam TY F1) :- !, pi x \ ppp (F2 x) (F1 x).
+ppp (F2 <=> G2) (eq '' prop ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (F2 = G2) (eq '' _ ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (F2 && G2) (and ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (F2 `or G2) (or ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (F2 ==> G2) (impl ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (X2 #in S2) (in '' _ ' X1 ' S1) :- !, ppp X2 X1, ppp S2 S1.
+ppp (U2 <<= V2) (subseteq '' _ ' U1 ' V1) :- !, ppp U2 U1, ppp V2 V1.
+ppp (F2 + G2) (plus ' F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (F2 ' G2) (F1 ' G1) :- !, ppp F2 F1, ppp G2 G1.
+ppp (lam A F2) (lam A F1) :- !, pi x \ ppp (F2 x) (F1 x).
+ppp A A.
+
+/* safe_list_map that unifies the two lists if they are both flexible
+   probably only useful for parsing/pretty-printing */
+safe_list_map L1 _ L2 :- var L1, var L2, !, L1 = L2.
+safe_list_map L1 F L2 :- list_map L1 F L2.
+
+% pptac(ppterm)/parsetac(parseterm)
+% pptac X Y :- ppptac X Y.  parsetac X Y :- ppptac X Y.
+
+mode (ppptac i o) xas parsetac(ppp -> parseterm),
+     (ppptac o i) xas pptac(ppp -> ppterm).
+
+ppptac daemon daemon.
+ppptac r r.
+ppptac (t Y) (t PY) :- ppp Y PY.
+ppptac (m Y) (m PY) :- ppp Y PY.
+ppptac b b.
+ppptac c c.
+ppptac k k.
+ppptac s s.
+ppptac (h Gamma) (h PGamma) :- safe_list_map Gamma ppp PGamma.
+ppptac d d.
+ppptac (th NAME) (th NAME).
+ppptac (thenll TAC1 TACN) (thenll PTAC1 PTACN) :-
+ ppptac TAC1 PTAC1, ppptac TACN PTACN.
+ppptac (! TAC) (! PTAC) :- ppptac TAC PTAC.
+ppptac id id.
+ppptac (wl Gamma) (wl PGamma) :- safe_list_map Gamma ppp PGamma.
+ppptac (bind A TAC) (bind PA PTAC) :-
+ ppp A PA, pi x \ ppptac (TAC x) (PTAC x).
+ppptac ww ww.
+
+/************ interactive and non interactive loops ********/
+
+ppptac interactive interactive.
+
+parse_obj (theorem NAME PSTTAC) [theorem NAME STTAC] :-
+ parse_thm NAME PSTTAC STTAC.
+parse_obj (axiom NAME PTYP) [axiom NAME TYP] :- parse_axiom PTYP TYP.
+parse_obj (new_basic_type TYPE REP ABS REPABS ABSREP PREP PP_TACTICS)
+ [new_basic_type TYPE REP ABS REPABS ABSREP PREP P_TACTICS] :- parse_nbt PP_TACTICS P_TACTICS.
+parse_obj (def NAME PTYBO) [def NAME TYBO] :- parse_def PTYBO TYBO.
+parse_obj (decl NAME TY) [decl NAME TY].
+parse_obj (inductive_def PRED PREDF PREDF_MON PRED_I PRED_E0 PRED_E K) EXP :-
+ inductive_def_pkg PRED PREDF PREDF_MON PRED_I PRED_E0 PRED_E K EXP.
+parse_obj stop [stop].
+
+parse_def (pi I) (pi O) :- pi x \ parse_def (I x) (O x).
+parse_def (TY,PB) (TY,B) :- parseterm PB B.
+
+parse_axiom (pi I) (pi O) :- !, pi x \ parse_axiom (I x) (O x).
+parse_axiom PST ST :- parseterm PST ST.
+
+parse_thm NAME (pi I) (pi O) :- pi x \ parse_thm NAME (I x) (O x).
+parse_thm _ (PST,TAC) (ST,(false,TAC)) :- !, parseterm PST ST.
+parse_thm NAME PST (ST,(true,[_])) :-
+ (not (proves NAME _) ; $print "Error:" NAME already defined, fail),
+ parseterm PST ST.
+
+parse_nbt (pi I) (pi O) :- !, pi x \ parse_nbt (I x) (O x).
+parse_nbt (PP,TACTICS) (P,(false,TACTICS)) :- parseterm PP P.
+parse_nbt PP (P,(true,[_])) :- parseterm PP P.
+
+next_object [ C | NEXT ] CT CONTNEXT :-
+  parse_obj C [ CT | CONT ], append CONT NEXT CONTNEXT.
+next_object [] C CONT :- 
+ $print "Welcome to HOL extra-light",
+ toplevel_loop [ C | CONT ].
+next_object toplevel C CONT :- toplevel_loop [ C | CONT ].
+
+read_cmd H :-
+ $print "Enter a command or \"stop.\"",
+ flush std_out, $readterm std_in H,
+ !.
+read_cmd H :- read_cmd H.
+
+toplevel_loop G :-
+ read_cmd H,
+ ( H = stop, !, G = [stop]
+ ; parse_obj H PH, !, (append PH toplevel G ; $print "error", toplevel_loop G)
+ ; $print "bad command", toplevel_loop G ).
+
+callback_proved _ _ (false,_).
+callback_proved NAME G (true, [ TAC ]) :-
+ canonical TAC CANONICALTAC,
+ pptac PCANONICALTAC CANONICALTAC,
+ ppterm PG G,
+ $print (theorem NAME (PG , [ PCANONICALTAC ] )).
+
+end_of_proof (true, []) :- $print "proof completed".
+end_of_proof (false, []).
+
+next_tactic0 [ SEQ | OLD ] (true, [ _ | _ ]) ITAC :-
+ $print,
+ list_iter_rev [ SEQ | OLD ] print_sequent,
+ read_in_context SEQ ITAC BACKTRACK,
+ BACKTRACK.
+next_tactic0 SEQS (true, CERT) ITAC :-
+ $print "error",
+ next_tactic SEQS (true, CERT) ITAC.
+next_tactic0 SEQS (true_then_false, (_,INT_TACS,_)) ITAC :-
+ next_tactic0 SEQS (true, INT_TACS) ITAC.
+next_tactic0 SEQS (false, [ interactive | _ ]) ITAC :-
+ next_tactic0 SEQS (true, [ _ ]) ITAC.
+next_tactic0 [ SEQ | OLD ] (false, [ TAC | _ ]) TAC.
+next_tactic0 _ (false, _) ITAC :-
+ $print "aborted",
+ halt.
+
+next_tactic SEQS CERT TAC :- next_tactic0 SEQS CERT PTAC, parsetac PTAC TAC.
+
+update_certificate (true, [ TAC | OTHER_TACS ]) ITAC NEW (true, TACS) :-
+ mk_script ITAC NEW NEW_TACS TAC,
+ append NEW_TACS OTHER_TACS TACS.
+update_certificate (false, [ interactive | NON_INTERACTIVE_TACS ]) ITAC NEW CERTIFICATE :-
+ update_certificate (true_then_false, (SCRIPT, [ SCRIPT ], NON_INTERACTIVE_TACS)) ITAC NEW CERTIFICATE.
+update_certificate (true_then_false, (SCRIPT,[ TAC | OTHER_TACS ],NON_INTERACTIVE_TACS)) ITAC NEW CERTIFICATE :- !,
+ mk_script ITAC NEW NEW_INTERACTIVE_TACS TAC,
+ append NEW_INTERACTIVE_TACS OTHER_TACS INTERACTIVE_TACS,
+ ( INTERACTIVE_TACS = [ _ | _ ], !,
+   CERTIFICATE =
+    (true_then_false, (SCRIPT,INTERACTIVE_TACS,NON_INTERACTIVE_TACS))
+ ; CERTIFICATE = (false, NON_INTERACTIVE_TACS),
+   $print "INTERACTIVE SUBPROOF COMPLETED",
+   canonical SCRIPT CSCRIPT,
+   pptac PSCRIPT CSCRIPT,
+   $print PSCRIPT).
+update_certificate (false, [ _ | OTHER_TACS ]) _ _ (false, OTHER_TACS).
+
+mk_script (bind A T) NEW NEW_TACS (bind A T2) :- !,
+ pi x \
+  put_binds (NEW2 x) x A NEW,
+  mk_script (T x) (NEW2 x) (NEWT x) (T2 x),
+  put_binds (NEWT x) x A NEW_TACS.
+mk_script ITAC NEW NEW_TACS (thenl ITAC NEW_TACS) :-
+ mk_list_of_bounded_fresh NEW NEW_TACS.
+
+read_in_context (bind A K) (bind A TAC) BACKTRACK :-
+ pi x \ /* term x A => reterm ' x A => */ read_in_context (K x) (TAC x) BACKTRACK.
+read_in_context (seq A B) TAC BACKTRACK :-
+ flush std_out, $readterm std_in TAC,
+ (TAC = backtrack, !, BACKTRACK = (!, fail) ; BACKTRACK = true).
+
+print_sequent (seq Gamma G) :-
+ $print,
+ list_iter_rev Gamma (x \ sigma PX \ ppterm PX x, $print PX),
+ $print "|------------------",
+ ppterm PG G, $print PG.
+print_sequent (bind A F) :- pi x \ print_sequent (F x).
+
+/* turns thenl into then */
+canonical (bind A T1) (bind A T2) :- !,
+ pi x \ canonical (T1 x) (T2 x).
+canonical (thenl T L) OTAC :- !,
+ list_map L canonical L2,
+ (mk_constant_list L2 S L2, !,
+  (S = [], !, OTAC = T ; OTAC = then T S)
+ ; OTAC = thenl T L2).
+canonical T T.
+
+/************ inductive_def package ********/
+parse_inductive_def_spec (pi F) (pi PF) :- !,
+ pi A \ parse_inductive_def_spec (F A) (PF A).
+parse_inductive_def_spec (param TY F) (param PTY PF) :- !,
+ ppp TY PTY, pi x \ parse_inductive_def_spec (F x) (PF x).
+parse_inductive_def_spec L PL :-
+ (pi p \ list_map (L p)
+  (x \ px \ sigma A \ sigma B \ sigma PB \ x = (A, B), parseterm B PB, px = (A, PB))
+  (PL p)).
+
+build_quantified_predicate (pi I) (pi O) :- !,
+ pi A \ build_quantified_predicate (I A) (O A).
+build_quantified_predicate (param TY I) (TY --> TYP, lam TY BO) :- !,
+ pi x \ build_quantified_predicate (I x) (TYP, BO x).
+build_quantified_predicate L (_, lam _ p \ lam _ x \ P p x) :-
+ pi p \ pi x \ build_predicate (L p) p x (P p x).
+
+build_predicate [ (_,K) ] P X R :- !,
+ process_constructor K P X R.
+build_predicate [ (_,K) | REST ] P X (or ' Q ' R) :-
+ process_constructor K P X Q,
+ build_predicate REST P X R.
+
+process_constructor (forall '' TY ' lam TY Q) P X (exists '' TY ' lam TY R) :-
+ pi y \ process_constructor (Q y) P X (R y).
+process_constructor (impl ' H ' K) P X (and ' H ' R) :-
+ process_constructor K P X R.
+process_constructor (P ' T) P X (eq '' _ ' X ' T).
+
+prove_monotonicity_thm (pi F) PREDF APREDF (pi THM) :- !,
+ pi A \ prove_monotonicity_thm (F A) PREDF (APREDF '' A) (THM A).
+prove_monotonicity_thm (param TY F) PREDF APREDF (forall '' TY ' lam TY STM, PROOF) :- !,
+ pi x \ prove_monotonicity_thm (F x) PREDF (APREDF ' x) (STM x, PROOF).
+prove_monotonicity_thm _ PREDF APREDF THM :-
+ THM =
+  (monotone '' _ ' APREDF,
+   [ then inv (bind* (then (conv (depth_tac (dd [PREDF]))) auto_monotone)) ]).
+
+state_fixpoint_def (pi F) PREDF (pi DEF) :- !,
+ pi A \ state_fixpoint_def (F A) (PREDF '' A) (DEF A).
+state_fixpoint_def (param TY F) PREDF (_, lam TY BO) :- !,
+ pi x \ state_fixpoint_def (F x) (PREDF ' x) (_, BO x).
+state_fixpoint_def _ PREDF (_, fixpoint '' _ ' PREDF).
+
+prove_fix_intro_thm (pi F) PREDF PRED PREDF_MONOTONE (pi THM) :- !,
+ pi A \ prove_fix_intro_thm (F A) (PREDF '' A) (PRED '' A) PREDF_MONOTONE (THM A).
+prove_fix_intro_thm (param TY F) PREDF PRED PREDF_MONOTONE (forall '' TY ' lam TY STM, [ then forall_i (bind _ PROOF) ]) :- !,
+ pi x \ prove_fix_intro_thm (F x) (PREDF ' x) (PRED ' x) PREDF_MONOTONE (STM x, [ PROOF x ]).
+prove_fix_intro_thm _ PREDF PRED PREDF_MONOTONE THM :-
+ THM =
+  ((! x \ PREDF ' PRED ' x ==> PRED ' x),
+   [then forall_i
+     (bind _ x13 \
+       then (conv (rand_tac (rator_tac dd)))
+        (then (conv (land_tac (rator_tac (rand_tac dd))))
+          (then inv
+            (then (cutth fixpoint_is_prefixpoint)
+              (then (lforall PREDF)
+                (thenl lapply [applyth PREDF_MONOTONE,
+                  then
+                   (g
+                     (subseteq '' _ '
+                       (PREDF ' (fixpoint '' _ ' PREDF)) '
+                       (fixpoint '' _ ' PREDF)))
+                   (then (conv (depth_tac (dd [subseteq])))
+                     (then (conv (depth_tac (dd [in])))
+                       (then (conv (depth_tac (dd [in])))(itaut 4))))]))))))]).
+
+prove_fix_elim_thm (pi F) PREDF PRED OPRED (pi THM) :- !,
+ pi A \ prove_fix_elim_thm (F A) (PREDF '' A) (PRED '' A) OPRED (THM A).
+prove_fix_elim_thm (param TY F) PREDF PRED OPRED (forall '' TY ' lam TY STM, [ then forall_i (bind _ PROOF) ]) :- !,
+ pi x \ prove_fix_elim_thm (F x) (PREDF ' x) (PRED ' x) OPRED (STM x, [ PROOF x ]).
+prove_fix_elim_thm _ PREDF PRED OPRED THM :-
+ THM =
+  ((! x13 \
+     (! x14 \ PREDF ' x13 ' x14 ==> x13 ' x14) ==>
+      (! x14 \ PRED ' x14 ==> x13 ' x14)) ,
+    [then forall_i
+      (bind _ x23 \
+        then (cutth fixpoint_subseteq_any_prefixpoint)
+         (then (lforall PREDF)
+           (then (lforall x23)
+             (then (conv (depth_tac (dd [OPRED])))
+               (then inv
+                 (bind _ x24 \
+                   then
+                    (g
+                      (impl ' (subseteq '' _ ' (PREDF ' x23) ' x23) '
+                        (subseteq '' _ ' (fixpoint '' _ ' PREDF) ' x23)))
+                    (then (conv (depth_tac (dd [subseteq])))
+                      (then (conv (depth_tac (dd [subseteq])))
+                        (then (conv (depth_tac (dd [in])))
+                          (then (conv (depth_tac (dd [in])))
+                            (then (conv (depth_tac (dd [in])))
+                              (then (conv (depth_tac (dd [in])))
+                                (then
+                                  (w
+                                    (impl '
+                                      (subseteq '' _ ' (PREDF ' x23) ' x23) '
+                                      (subseteq '' _ '
+                                        (fixpoint '' _ ' PREDF) ' x23)))
+                                  (then inv
+                                    (thenl lapply_last [h,
+                                      then (lforall_last x24)
+                                       (then lapply_last h)])))))))))))))))]).
+
+prove_intro_thms (pi F) PRED PRED_I INTROTHMS :- !,
+ pi A \
+  prove_intro_thms (F A) (PRED '' A) PRED_I (OUT A),
+  list_map (OUT A)
+   (i \ o \ sigma Y \ i = (theorem NAME (P A)), o = theorem NAME (pi P))
+   INTROTHMS.
+prove_intro_thms (param TY F) PRED PRED_I INTROTHMS :- !,
+ pi x \
+  prove_intro_thms (F x) (PRED ' x) PRED_I (OUT x),
+  list_map (OUT x)
+   (i \ o \ sigma Y \
+     i = (theorem NAME (STM x, [ PROOF x ])),
+     o = theorem NAME (forall '' TY ' lam TY STM, [ then forall_i (bind TY PROOF) ]))
+   INTROTHMS.
+prove_intro_thms L PRED PRED_I INTROTHMS :-
+ list_map (L PRED) (mk_intro_thm PRED_I) INTROTHMS.
+
+mk_intro_thm PRED_I (NAME,ST)
+ (theorem NAME (ST,
+   [ daemon /*(then inv (bind* (then (applyth PRED_I) (then (conv dd) (itauteq 6)))))*/ /* TOO MANY GOALS DELAYED ON typ (?): USE daemon INSTEAD */ ])).
+
+inductive_def_pkg PRED PREDF PREDF_MONOTONE PRED_I PRED_E0 PRED_E L OUT :-
+ parse_inductive_def_spec L PL,
+ build_quantified_predicate PL F,
+ prove_monotonicity_thm PL PREDF PREDF MONTHM,
+ state_fixpoint_def PL PREDF FIXDEF,
+ prove_fix_intro_thm PL PREDF PRED PREDF_MONOTONE INTROTHM,
+ prove_intro_thms PL PRED PRED_I INTROTHMS,
+ prove_fix_elim_thm PL PREDF PRED PRED ELIMTHM,
+ OUT1 =
+  [ def PREDF F
+  , theorem PREDF_MONOTONE MONTHM
+  , def PRED FIXDEF
+  , theorem PRED_I INTROTHM
+  , theorem PRED_E0 ELIMTHM ],
+ append OUT1 INTROTHMS OUT.
+
+/************ library of basic data types ********/
+mk_bounded_fresh (bind _ F) (bind _ G) :- !, pi x\ mk_bounded_fresh (F x) (G x).
+mk_bounded_fresh _ X.
+
+mk_list_of_bounded_fresh [] [].
+mk_list_of_bounded_fresh [S|L] [X|R] :-
+ mk_bounded_fresh S X, mk_list_of_bounded_fresh L R.
+
+/* list functions */
+
+list_map [] _ [].
+list_map [X|XS] F [Y|YS] :- F X Y, list_map XS F YS.
+
+list_iter_rev [] _.
+list_iter_rev [X|XS] F :- list_iter_rev XS F, F X.
+
+mem [ X | _ ] X, !.
+mem [ _ | XS ] X :- mem XS X.
+
+mk_constant_list [] _ [].
+mk_constant_list [_|L] X [X|R] :- mk_constant_list L X R.
+
+bang P :- P, !.
+
+/********** tacticals ********/
+
+% BUG in runtime.ml if the sigma is uncommented out. It does not matter btw.
+/*sigma ff \*/ deftac fail SEQ ff.
+
+ppptac (constant_tacl TACL) (constant_tacl PTACL) :-
+ list_map TACL ppptac PTACL.
+deftacl (constant_tacl TACL) SEQS TACL.
+
+ppptac (thenl TAC TACL) (thenl PTAC PTACL) :-
+ ppptac TAC PTAC, list_map TACL ppptac PTACL. 
+deftac (thenl TAC TACL) SEQ XTAC :-
+ XTAC = thenll TAC (constant_tacl TACL).
+
+ppptac (all_equals_list TAC) (all_equals_list PTAC) :- ppptac TAC PTAC.
+deftacl (all_equals_list TAC2) SEQS TACL :-
+ mk_constant_list SEQS TAC2 TACL.
+
+ppptac (then TAC1 TAC2) (then PTAC1 PTAC2) :-
+ ppptac TAC1 PTAC1, ppptac TAC2 PTAC2.
+deftac (then TAC1 TAC2) SEQ XTAC :-
+ XTAC = thenll TAC1 (all_equals_list TAC2).
+
+ppptac (then! TAC1 TAC2) (then! PTAC1 PTAC2) :-
+ ppptac TAC1 PTAC1, ppptac TAC2 PTAC2.
+deftac (then! TAC1 TAC2) _ (then (! TAC1) TAC2).
+
+ppptac (orelse TAC1 TAC2) (orelse PTAC1 PTAC2) :-
+ ppptac TAC1 PTAC1, ppptac TAC2 PTAC2.
+deftac (orelse TAC1 TAC2) SEQ XTAC :-
+ XTAC = TAC1 ; XTAC = TAC2.
+
+ppptac (orelse! TAC1 TAC2) (orelse! PTAC1 PTAC2) :-
+ ppptac TAC1 PTAC1, ppptac TAC2 PTAC2.
+deftac (orelse! TAC1 TAC2) _ (orelse (! TAC1) TAC2).
+
+ppptac (bind* TAC) (bind* PTAC) :- ppptac TAC PTAC.
+deftac (bind* TAC) SEQ (orelse! (bind _ x \ bind* TAC) TAC).
+
+ppptac (repeat TAC) (repeat PTAC) :- ppptac TAC PTAC.
+deftac (repeat TAC) SEQ XTAC :-
+ ( XTAC = then TAC (repeat (bind* TAC))
+ ; XTAC = id).
+
+ppptac (repeat! TAC) (repeat! PTAC) :- ppptac TAC PTAC.
+deftac (repeat! TAC) SEQ (orelse! (then! TAC (repeat! (bind* TAC))) id).
+
+ppptac (pptac TAC) (pptac PTAC) :- ppptac TAC PTAC.
+deftac (pptac TAC) SEQ TAC :-
+ $print "SEQ" SEQ ":=" TAC.
+
+ppptac (time TAC) (time PTAC) :- ppptac TAC PTAC.
+deftac (time TAC) SEQ XTAC :-
+ $gettimeofday B,
+ XTAC = thenll TAC (time_after TAC B).
+
+ppptac (time_after TAC B) (time_after PTAC B) :- ppptac TAC PTAC.
+deftacl (time_after TAC B) SEQS TACL :-
+ $gettimeofday A,
+ D is A - B,
+ mk_constant_list SEQS id TACL,
+ $print "TIME SPENT " D "FOR" TAC.
+
+/* For debugging only (?) For capturing metavariables */
+ppptac (inspect (seq Gamma F) TAC) (inspect (seq PGamma PF) PTAC) :-
+ list_map SEQ ppp PSEQ, ppp F PF, ppptac TAC PTAC.
+deftac (inspect SEQ TAC) SEQ TAC.
+
+/********** tactics ********/
+
+ppptac (w G) (w PG) :- ppp G PG.
+deftac (w G) (seq Gamma _) (wl Gamma1) :-
+ append Gamma1 [ G | _ ] Gamma.
+
+ppptac h h.
+deftac h SEQ (h L).
+
+/*** eq ***/
+
+ppptac sym sym.
+deftac sym (seq Gamma (eq '' T ' L ' R)) TAC :-
+ TAC = thenl (m (eq '' T ' R ' R)) [ thenl c [ thenl c [ r , id ] , r ] , r ].
+
+ppptac eq_true_intro eq_true_intro.
+deftac eq_true_intro (seq Gamma (eq '' prop ' P ' tt)) TAC :-
+ TAC = thenl s [ th tt_intro, wl [] ].
+
+/*** true ***/
+
+/*** and ***/
+
+ppptac conj conj.
+deftac conj (seq Gamma (and ' P ' Q)) TAC :-
+ TAC =
+  then
+   (then (conv dd)
+     (then k (bind _ x \
+       thenl c
+        [ thenl c [ r, eq_true_intro ] ,
+          eq_true_intro ])))
+   ww.
+
+/* Gamma  "|-"  q    --->   Gamma "|-" and ' p ' q*/
+ppptac (andr P) (andr PP) :- ppp P PP.
+deftac (andr P) (seq Gamma Q) TAC :-
+ TAC =
+  (thenl (m ((lam _ f \ f ' P ' Q) ' (lam _ x \ lam _ y \ y)))
+    [ then
+       %(repeat (conv (depth_tac b))) ROBUS VERSION LINE BELOW
+       (then (conv (land_tac b)) (then (conv (land_tac (rator_tac b))) (conv (land_tac b))))
+      r
+    , thenl (conv (rator_tac id))
+       [ then (thenl (t (lam _ f \ f ' tt ' tt)) [ id, r ])
+          (thenl (m (and ' P ' Q)) [ dd , id ])
+       , then (repeat (conv (depth_tac b))) (th tt_intro) ]]).
+
+/* (and ' p ' q) :: nil  "|-"  q */
+ppptac andr andr.
+deftac andr (seq Gamma Q) TAC :-
+ mem Gamma (and ' P ' Q),
+ TAC = then (andr P) h.
+
+/* Gamma  "|-"  p    --->   Gamma "|-" and ' p ' q*/
+ppptac (andl P) (andl PP) :- ppp P PP.
+deftac (andl Q) (seq Gamma P) TAC :-
+ TAC =
+  (thenl (m ((lam _ f \ f ' P ' Q) ' (lam _ x \ lam _ y \ x)))
+    [ then
+       %(repeat (conv (depth_tac b))) ROBUS VERSION LINE BELOW
+       (then (conv (land_tac b)) (then (conv (land_tac (rator_tac b))) (conv (land_tac b))))
+      r
+    , thenl (conv (rator_tac id))
+       [ then (thenl (t (lam _ f \ f ' tt ' tt)) [ id, r ])
+          (thenl (m (and ' P ' Q)) [ dd , id ])
+       , then (repeat (conv (depth_tac b))) (th tt_intro) ]]).
+
+/* (and ' p ' q) :: nil  "|-"  p */
+ppptac andl andl.
+deftac andl (seq Gamma P) TAC :-
+ mem Gamma (and ' P ' Q),
+ TAC = then (andl Q) h.
+
+
+/*** forall ***/
+
+/* |- forall ' F  -->   |- F ' x */
+ppptac forall_i forall_i.
+deftac forall_i (seq Gamma (forall '' _ ' lam _ G)) TAC :-
+ TAC = then (conv dd) (then k (bind _ x \ eq_true_intro)).
+
+/* forall ' F |- F ' T */
+ppptac forall_e forall_e.
+deftac forall_e (seq Gamma GX) TAC :-
+ mem Gamma (forall '' _ ' (lam _ G)), GX = G X,
+ TAC = thenl (m ((lam _ G) ' X)) [ b, thenl (m ((lam _ z \ tt) ' X))
+  [ thenl c [ then sym (thenl (m (forall '' _ ' lam _ G)) [dd,h ]), r ]
+  , then (conv b) (th tt_intro) ] ].
+
+/* forall ' F |- f  -->  F ' a, forall ' F |- f */
+ppptac (lforall F A) (lforall PF PA) :- ppp F PF, ppp A PA.
+deftac (lforall F A) (seq Gamma G) TAC :-
+ TAC = thenl (m (impl ' (F A) ' G))
+  [ thenl s [ then mp forall_e, then i h ] , then (w (forall '' _ ' lam _ F)) i ].
+
+/* forall ' F |- f  -->  F ' a, forall ' F |- f */
+ppptac (lforall A) (lforall PA) :- ppp A PA.
+deftac (lforall A) (seq Gamma G) (lforall F A) :-
+ mem Gamma (forall '' _ ' lam _ F).
+
+/* forall ' F |- f  -->  F ' a, forall ' F |- f */
+ppptac lforall lforall.
+deftac lforall (seq Gamma G) (lforall A).
+
+/* forall ' F |- f  -->  F ' a, forall ' F |- f */
+ppptac (lforall_last A) (lforall_last PA) :- ppp A PA.
+deftac (lforall_last A) (seq ((forall '' _ ' lam _ F)::Gamma) G) (lforall F A).
+
+/*** false ***/
+              
+/*** impl ***/
+
+/* |- p=>q  -->  p |- q */
+ppptac i i.
+deftac i (seq Gamma (impl ' P ' Q)) TAC :-
+ TAC = then (conv dd) (thenl s [ andl, thenl conj [ h [], id ]]).
+
+/* p=>q |- q  -->  |- p */
+ppptac (mp P) (mp PP) :- ppp P PP.
+deftac (mp P) (seq Gamma Q) TAC :-
+ TAC = then (andr P) (thenl (m P) [ then sym (thenl (m (impl ' P ' Q)) [ dd , h ]) , id ]).
+
+/* p=>q |- q  -->  |- p */
+ppptac mp mp.
+deftac mp (seq Gamma Q) (mp P) :-
+ mem Gamma (impl ' P ' Q).
+
+/* |- q   -->   p |- q  and  |- p */
+ppptac (cut P) (cut PP) :- ppp P PP.
+deftac (cut P) (seq Gamma Q) TAC :-
+ TAC = then (andr P) (thenl (m P) [then sym (thenl (m (impl ' P ' Q)) [then (conv (land_tac dd)) r, i] ) , id]). 
+
+/* |-q  --> p |- q   where the theorem T proves p */
+ppptac (cutth P) (cutth PP) :- ppp P PP.
+deftac (cutth T) SEQ TAC :-
+ proves T X,
+ TAC = (thenl (cut X) [ id, th T ]).
+
+/* applies the theorem T */
+ppptac (applyth P) (applyth PP) :- ppp P PP.
+deftac (applyth T) SEQ (then (cutth T) apply_last).
+
+/* impl p q, Gamma |- f   --->   /*impl q f*/ Gamma |- p  ,  q, Gamma |- f */
+ppptac (lapply P Q) (lapply PP PQ) :- ppp P PP, ppp Q PQ.
+deftac (lapply P Q) (seq Gamma F) TAC :-
+ TAC =
+  thenl (m (impl ' Q ' F)) [ thenl s [ then (mp Q) (then (w (impl ' Q ' F)) (then (mp P) (w (impl ' P ' Q)))) , then i (h [A]) ] , then (w (impl ' P ' Q)) (then i id) ].
+
+/* impl p q, Gamma |- f   --->   /*impl q f*/ Gamma |- p  ,  q, Gamma |- f */
+ppptac lapply lapply.
+deftac lapply (seq Gamma F) (lapply P Q) :-
+ mem Gamma (impl ' P ' Q).
+
+/* impl p q, Gamma |- f   --->   /*impl q f*/ Gamma |- p  ,  q, Gamma |- f */
+ppptac lapply_last lapply_last.
+deftac lapply_last (seq ((impl ' P ' Q)::Gamma) F) (lapply P Q).
+
+/* p |- f ---> p |- p ==> f */
+ppptac (g P) (g PP) :- ppp P PP.
+deftac (g P) (seq _ F) TAC :-
+ TAC =
+  (thenl (m (impl ' P ' F)) [thenl s [then mp h , then i h] , id ]).
+
+/*** not ***/
+
+/*** exists ***/
+
+/**** apply, i.e. forall + impl ****/
+
+ppptac (apply X) (apply PX) :- ppp X PX.
+deftac (apply X) SEQ h :- var X, !.
+deftac (apply X) SEQ h.
+deftac (apply (impl ' P ' Q)) SEQ TAC :-
+ TAC = thenl (lapply P Q) [ id, apply_last ].
+deftac (apply (forall '' _ ' lam _ G)) SEQ TAC :-
+ TAC = then (lforall G X) apply_last.
+
+ppptac apply_last apply_last.
+deftac apply_last (seq (H::Gamma) F) (apply H).
+
+ppptac apply apply.
+deftac apply (seq Gamma F) (apply H) :-
+ mem Gamma H.
+
+/********** conversion(als) ***********/
+
+strip_constant (I '' _) H :- !, strip_constant I H.
+strip_constant H H.
+
+/* expands definitions, even if applied to arguments */
+ppptac (dd L) (dd L).
+deftac (dd L) (seq _ (eq '' _ ' T ' X)) d :- strip_constant T H, bang (mem L H).
+deftac (dd L) (seq _ (eq '' _ ' (D ' T) ' X))
+ (thenl (t A) [thenl c [dd L , r], b]).
+
+ppptac dd dd.
+deftac dd _ (dd L).
+
+ppptac beta_expand beta_expand.
+deftac beta_expand (seq _ (eq '' _ ' (lam _ x \ F x) ' (lam _ x \ (lam _ F) ' x))) TAC :-
+ TAC = then k (bind _ x \ then sym b).
+
+/* folds a definition, even if applied to arguments */
+/* BUG: it seems to fail with restriction errors in some cases */
+ppptac f f.
+deftac f SEQ (then sym dd).
+
+ppptac (rand_tac C) (rand_tac PC) :- ppptac C PC.
+deftac (rand_tac C) SEQ TAC :-
+  TAC = thenl c [ r , C ].
+
+ppptac (rator_tac C) (rator_tac PC) :- ppptac C PC.
+deftac (rator_tac C) SEQ TAC :-
+  TAC = thenl c [ C , r ].
+
+ppptac (abs_tac C) (abs_tac PC) :- ppptac C PC.
+deftac (abs_tac C) SEQ TAC :-
+  TAC = then k (bind A x \ C).
+
+ppptac (land_tac C) (land_tac PC) :- ppptac C PC.
+deftac (land_tac C) SEQ TAC :-
+  TAC = thenl c [ thenl c [ r, C ] , r ].
+
+ppptac (sub_tac C) (sub_tac PC) :- ppptac C PC.
+deftac (sub_tac C) SEQ TAC :-
+  TAC = orelse (rand_tac C) (orelse (rator_tac C) (abs_tac C)).
+
+ppptac (try TAC) (try PTAC) :- ppptac TAC PTAC.
+deftac (try TAC) SEQ (orelse TAC id).
+
+ppptac (depth_tac C) (depth_tac PC) :- ppptac C PC.
+deftac (depth_tac C) SEQ TAC :-
+  TAC = then (try C) (sub_tac (depth_tac C)).
+
+ppptac (conv C) (conv PC) :- ppptac C PC.
+deftac (conv C) (seq Gamma F) TAC :-
+ TAC = thenl (m G) [ then sym C , id ].
+
+/********** Automation ***********/
+/* TODO:
+ 1) our lforall gets rid of the hypothesis (bad) */
+/* left tries to reduce the search space via focusing */
+ppptac left left.
+deftac left (seq Gamma _) TAC :-
+ mem Gamma (not ' F),
+ TAC =
+  (!
+   (then (cutth not_e)
+    (then (lforall_last F)
+     (thenl lapply [ h, (w (not ' F)) ])))).
+deftac left (seq Gamma _) TAC :-
+ /* A bit long because we want to beta-reduce the produced hypothesis.
+    Maybe this should be automatized somewhere else. */
+ mem Gamma (exists '' _ ' F),
+ TAC =
+  (!
+   (then (cutth exists_e)
+    (then (lforall_last F)
+     (thenl lapply [ h, then (w (exists '' _ ' F)) (then apply_last (then forall_i (bind _ x \ then (try (conv (land_tac b))) i))) ])))).
+deftac left (seq Gamma H) TAC :-
+ mem Gamma (or ' F ' G),
+ TAC =
+  (!
+   (then (cutth or_e)
+    (then (lforall_last F)
+     (then (lforall_last G)
+      (then (lforall_last H)
+       (thenl lapply [ h, then (w (or ' F ' G)) (then apply_last i)])))))).
+deftac left (seq Gamma H) TAC :-
+ mem Gamma (and ' F ' G),
+ TAC =
+  (!
+   (then (cutth and_e)
+    (then (lforall_last F)
+     (then (lforall_last G)
+      (then (lforall_last H)
+       (thenl lapply [ h, then (w (and ' F ' G)) (then apply_last (then i i))])))))).
+deftac left (seq Gamma H) TAC :-
+ mem Gamma (eq '' TY ' F ' G),
+ not (var TY), TY = prop,
+ TAC =
+  (then (g (eq '' TY ' F ' G))
+   (then (conv (land_tac (then (applyth eq_to_impl) h)))
+     (then i (w (eq '' TY ' F ' G))))).
+
+ppptac not_i not_i.
+deftac not_i (seq _ (not ' _)) (applyth not_i).
+
+ppptac inv inv.
+deftac inv _ TAC :-
+ TAC =
+ (then!
+  (repeat!
+   (orelse! conj (orelse! forall_i (orelse! i (orelse! not_i s)))))
+  (bind* (repeat! left))).
+
+ppptac (sync N) (sync N).
+deftac (sync N) (seq _ tt) (th tt_intro).
+deftac (sync N) (seq Gamma _) (then (applyth ff_elim) h) :-
+ mem Gamma ff.
+deftac (sync N) (seq _ (or ' _ ' _))
+ (orelse (then (applyth orr) (itaut N)) (then (applyth orl) (itaut N))).
+deftac (sync N) (seq _ (exists '' _ ' _)) (then (applyth exists_i) (then (conv b) (itaut N2))) :-
+ N2 is N - 2.
+
+ppptac (itaut N) (itaut N).
+deftac (itaut N) SEQ fail :- N =< 0, !.
+deftac (itaut N) SEQ TAC :-
+ %$print (itaut N) SEQ,
+ N1 is N - 1,
+ N2 is N - 2,
+ TAC =
+ (then! inv
+  (bind*
+   (orelse h
+   (orelse (sync N)
+   (orelse /* Hypothesis not moved to front */ (then lforall (itaut N2))
+   (then lapply (itaut N1))))))).
+
+ppptac (itauteq N) (itauteq N).
+deftac (itauteq N) _ (then (cutth eq_reflexive) (itaut N)).
+
+/********** inductive predicates package ********/
+
+ppptac monotone monotone.
+deftac monotone (seq _ (impl ' X ' X)) (! (then i h)) :- !.
+deftac monotone (seq [forall '' _ ' lam _ x \ impl ' (F ' x) ' (G ' x)] (impl ' (F ' T) ' (G ' T))) (! apply) :- !.
+deftac monotone (seq _ (impl ' (and ' _ ' _) ' _)) TAC :-
+ TAC = then (applyth and_monotone) monotone.
+deftac monotone (seq _ (impl ' (or ' _ ' _) ' _)) TAC :-
+ TAC = then (applyth or_monotone) monotone.
+deftac monotone (seq _ (impl ' (impl ' _ ' _) ' _)) TAC :-
+ TAC = then (applyth impl_monotone) monotone.
+deftac monotone (seq _ (impl ' (not ' _) ' _)) TAC :-
+ TAC = then (applyth not_monotone) monotone.
+deftac monotone (seq _ (impl ' (forall '' _ ' lam _ _) ' _)) TAC :-
+ TAC =
+  then (conv (land_tac (rand_tac beta_expand)))
+   (then (conv (rand_tac (rand_tac beta_expand)))
+     (then (applyth forall_monotone) (then forall_i (bind _ x \
+       then (conv (depth_tac b)) (then (conv (depth_tac b)) monotone))))).
+deftac monotone (seq _ (impl ' (exists '' _ ' lam _ _) ' _)) TAC :-
+ TAC =
+  then (conv (land_tac (rand_tac beta_expand)))
+   (then (conv (rand_tac (rand_tac beta_expand)))
+     (then (applyth exists_monotone) (then forall_i (bind _ x \
+       then (conv (depth_tac b)) (then (conv (depth_tac b)) monotone))))).
+
+/* expands "monotone ' (lam _ f \ lam _ x \ X f x)" into
+   "! x \ p ' x ==> q ' x |- X p y ==> X q y"
+   and then calls the monotone tactic */
+ppptac auto_monotone auto_monotone.
+deftac auto_monotone _ TAC :-
+ TAC =
+  then (conv dd)
+   (then forall_i (bind _ p \ (then forall_i (bind _ q \
+     then (conv (land_tac dd))
+      (then (conv (land_tac (depth_tac (dd [in]))))
+        (then (conv (land_tac (depth_tac (dd [in]))))
+          (then i
+            (then (conv dd)
+              (then forall_i (bind _ x \
+                (then (conv (land_tac dd))
+                  (then (conv (rand_tac dd))
+                    (then (conv (land_tac (rator_tac b)))
+                      (then (conv (land_tac b))
+                        (then (conv (rand_tac (rator_tac b)))
+                          (then (conv (rand_tac b))
+                            monotone)))))))))))))))).
+
+/********** the library ********/
+
+main :- the_library L, append L [stop] Lstop, check Lstop.
+
+go :- the_library L, check L.
+
+the_library L :-
+ L =
+  [ /******** Primivite operators hard-coded in the kernel ******/
+  % decl eq (pi A \ A --> A --> prop)
+
+  /********** Axiomatization of choice over types ********/
+    decl choose (pi A \ A)
+
+  /*********** Connectives and quantifiers ********/
+  , def tt (prop,((lam prop x \ x) = (lam prop x \ x)))
+  , def forall (pi A \ ((A --> prop) --> prop),
+     (lam (A --> prop) f \ f = (lam A g \ tt)))
+  , def ff (prop,(! x \ x))
+  , def and ((prop --> prop --> prop),
+     (lam _ x \ lam _ y \ (lam (prop --> prop --> prop) f \ f ' x ' y) = (lam _ f \ f ' tt ' tt)))
+  , def impl ((prop --> prop --> prop),(lam _ a \ lam _ b \ a && b <=> a))
+  , def exists (pi A \ ((A --> prop) --> prop),
+     (lam (A --> prop) f \ ! c \ (! a \ f ' a ==> c) ==> c))
+  , def not ((prop --> prop),(lam _ x \ x ==> ff))
+  , def or ((prop --> prop --> prop),
+     (lam _ x \ lam _ y \ ! c \ (x ==> c) ==> (y ==> c) ==> c))
+  , theorem tt_intro (tt,[then (conv dd) (then k (bind _ x12 \ r))])
+  , theorem ff_elim ((! p \ ff ==> p),
+    [then forall_i (bind prop x3\ then (conv (land_tac dd)) (then i forall_e))])
+  , theorem sym ((! p \ ! q \ p = q ==> q = p),
+    [then forall_i
+     (bind prop x12 \
+       then forall_i
+        (bind prop x13 \
+          then i (then sym h)))])
+  , theorem not_e ((! p \ not ' p ==> p ==> ff),
+     [then forall_i (bind prop x3 \ then (conv (land_tac dd)) (then i h))])
+  , theorem conj ((! p \ ! q \ p ==> q ==> p && q),
+    [then forall_i
+     (bind prop x12 \
+      then forall_i (bind prop x13 \ then i (then i (then conj h))))])
+  , theorem andl ((! p \ ! q \ p && q ==> p),
+    [then forall_i
+     (bind prop x12 \
+      then forall_i (bind prop x13 \ then i (then (andl x13) h)))])
+  , theorem andr ((! p \ ! q \ p && q ==> q),
+    [then forall_i
+     (bind prop x12 \
+      then forall_i (bind prop x13 \ then i (then (andr x12) h)))])
+  , theorem and_e ((! p \ ! q \ ! c \ p && q ==> (p ==> q ==> c) ==> c),
+     [then forall_i
+       (bind prop x12 \
+         then forall_i
+          (bind prop x13 \
+            then forall_i
+             (bind prop x14 \ then i (then i (thenl apply [andl, andr])))))])
+  , theorem not_i ((! p \ (p ==> ff) ==> not ' p),
+     [then forall_i (bind prop x2 \ then i (then (conv dd) h))])
+  , theorem orl ((! p \ ! q \ p ==> p `or q),
+      [then forall_i
+        (bind prop x12 \
+          then forall_i
+           (bind prop x13 \
+             then i
+              (then (conv dd)
+                (then forall_i (bind prop x14 \ then i (then i (then apply h)))))))])
+  , theorem orr ((! p \ ! q \ q ==> p `or q),
+      [then forall_i
+        (bind prop x12 \
+          then forall_i
+           (bind prop x13 \
+             then i
+              (then (conv dd)
+                (then forall_i (bind prop x14 \ then i (then i (then apply h)))))))])
+  , theorem or_e ((! p \ ! q \ ! c \ p `or q ==> (p ==> c) ==> (q ==> c) ==> c),
+     [then forall_i
+       (bind prop x12 \
+         then forall_i
+          (bind prop x13 \
+            then forall_i
+             (bind prop x14 \ then (conv (land_tac dd)) (then i forall_e))))])
+  , theorem exists_e (pi T \
+     (! f \ (exists '' T ' f) ==> (! c \ (! x \ f ' x ==> c) ==> c)),
+     [then forall_i (bind (T --> prop) x12 \ then (conv (land_tac dd)) (then i h))])
+ , theorem exists_i (pi T \ (! f \ ! w \ f ' w ==> (exists '' T ' f)),
+    [then forall_i
+     (bind (T --> prop) x12 \
+       then forall_i
+        (bind T x13 \
+          then i
+           (then (conv dd)
+             (then forall_i
+               (bind prop x14 \ then i (then (lforall x13) (then apply h)))))))])
+  , theorem eq_to_impl
+     ((! x13 \ ! x14 \ (x13 = x14) = ((x13 ==> x14) && (x14 ==> x13))),
+     [thenl inv [(bind prop x13 \ bind prop x14 \ then (conv (then sym h)) h),
+       (bind prop x13 \ bind prop x14 \ then (conv h) h),
+       (bind prop x13 \ bind prop x14 \ itaut 2),
+       (bind prop x13 \ bind prop x14 \ itaut 2)]])
+
+ /*********** Axiomatization of disjoint union ********/
+  , decl inj1_disj_union (pi A \pi B \ A --> disj_union '' A '' B)
+  , decl inj2_disj_union (pi A \ pi B \ B --> disj_union '' A '' B)
+  , decl case_disj_union (pi A \pi B \ pi C \ disj_union '' A '' B --> (A --> C) --> (B --> C) --> C)
+  , axiom case_disj_union_inj1 (pi A \ pi B \ pi C \ (! b \ ! (A --> C) e1 \ ! (B --> C) e2  \
+    case_disj_union '' A '' B '' C ' (inj1_disj_union '' A '' B ' b) ' e1 ' e2 = e1 ' b))
+  , axiom case_disj_union_inj2 (pi A \ pi B \ pi C \ (! b \ ! (A --> C) e1 \ ! (B --> C) e2  \
+    case_disj_union '' A '' B '' C ' (inj2_disj_union '' A '' B ' b) ' e1 ' e2 = e2 ' b))
+
+ /*********** Axiomatization of the universe ********/
+ , decl injection_univ (pi A \pi B \ A --> univ '' A '' B)
+ , decl ejection_univ (pi A \pi B \ univ '' A '' B --> A)
+ , decl inject_limit_univ (pi A \pi B \ (B --> univ '' A '' B) --> univ '' A '' B)
+ , decl eject_limit_univ (pi A \ pi B \ univ '' A '' B --> (B --> univ '' A '' B))
+ , decl pair_univ (pi A \pi B \ univ '' A '' B --> univ '' A '' B --> univ '' A '' B)
+ , decl proj1_univ (pi A \ pi B \ univ '' A '' B --> univ '' A '' B)
+ , decl proj2_univ (pi A \pi B \ univ '' A '' B --> univ '' A '' B)
+ , decl inj1_univ (pi A \pi B \ univ '' A '' B --> univ '' A '' B)
+ , decl inj2_univ (pi A \pi B \ univ '' A '' B --> univ '' A '' B)
+ , decl case_univ (pi A \pi B \ pi C \ univ '' A '' B --> (univ '' A '' B --> C) --> (univ '' A '' B --> C) --> C)
+ , axiom ejection_injection_univ (pi A \ pi B \
+    ! A p \ ejection_univ '' A '' B ' (injection_univ '' A '' B ' p) = p)
+ , axiom eject_inject_limit_univ (pi A \ pi B \
+    ! (B --> univ '' A '' B) p \ eject_limit_univ '' A '' B ' (inject_limit_univ '' A '' B ' p) = p)
+ , axiom proj1_pair_univ (pi A \ pi B \ ! (univ '' A '' B) p1 \ ! p2 \
+    proj1_univ '' A '' B ' (pair_univ '' A '' B ' p1 ' p2) = p1)
+ , axiom proj2_pair_univ (pi A \ pi B \ ! p1 \ ! (univ '' A '' B) p2 \
+    proj2_univ '' A '' B ' (pair_univ '' A '' B ' p1 ' p2) = p2)
+ , axiom case_univ_inj1 (pi A \ pi B \ pi C \ (! b \ ! (univ '' A '' B --> C) e1 \ ! e2  \
+    case_univ '' A '' B '' C ' (inj1_univ '' A '' B ' b) ' e1 ' e2 = e1 ' b))
+ , axiom case_univ_inj2 (pi A \ pi B \ pi C \ (! b \ ! (univ '' A '' B --> C) e1 \ ! e2 \
+    case_univ '' A '' B '' C ' (inj2_univ '' A '' B ' b) ' e1 ' e2 = e2 ' b))
+
+ /******************* Equality *****************/
+ , theorem eq_reflexive (pi A \ ((! A a \ a = a),
+   [ then forall_i (bind A x \ r) ]))
+
+ /******************* Logic *****************/
+ , theorem or_commutative ((! a \ ! b \ a `or b <=> b `or a),
+   [itaut 1])
+ , theorem or_ff ((! a \ a `or ff <=> a),
+   [itaut 1])
+ , theorem or_tt ((! a \ a `or tt <=> tt),
+   [itaut 1])
+ , theorem or_idempotent ((! a \ a `or a <=> a),
+   [itaut 1])
+ , theorem or_associative ((! a \ ! b \ ! c \ a `or (b `or c) <=> (a `or b) `or c),
+   [itaut 1])
+ , theorem and_commutative ((! a \ ! b \ a && b <=> b && a),
+   [itaut 1])
+ , theorem and_tt ((! a \ a && tt <=> a),
+   [itaut 1])
+ , theorem and_ff ((! a \ a && ff <=> ff),
+   [itaut 1])
+ , theorem and_idempotent ((! a \ a && a <=> a),
+   [itaut 1])
+ , theorem and_associative ((! a \ ! b \ ! c \ a && (b && c) <=> (a && b) && c),
+   [itaut 1])
+ , theorem and_or ((! a \ ! b \ ! c \ a && (b `or c) <=> (a && b) `or (a && c)),
+   [itaut 1])
+ , theorem or_and ((! a \ ! b \ ! c \ a `or (b && c) <=> (a `or b) && (a `or c)),
+   [itaut 1])
+ , theorem ads_or_and ((! a \ ! b \ (a && b) `or b <=> b),
+   [itaut 1])
+ , theorem ads_and_or ((! a \ ! b \ (a `or b) && b <=> b),
+   [itaut 1])
+ , theorem not_or ((! a \ ! b \ not ' a && not ' b <=> not ' (a `or b)),
+   [itaut 2])
+ , theorem not_and ((! a \ ! b \ not ' a `or not ' b ==> not ' (a && b)),
+   [itaut 2])
+ , theorem not_not_not ((! p \ not ' (not ' (not ' p)) <=> not ' p),
+   [itaut 3])
+ , theorem impl_not_not ((! a \ ! b \ (a ==> b) ==> (not ' b ==> not ' a)),
+   [itaut 3])
+ , theorem eq_to_impl_f ((! p \ ! q \ (p <=> q) ==> p ==> q),
+    [itaut 2])
+ , theorem eq_to_impl_b ((! p \ ! q \ (p <=> q) ==> q ==> p),
+    [itaut 2])
+
+/*************** Properties inj/disj/univ ***********/
+ , theorem pair_univ_inj_l 
+   (pi A \ pi B \ (! (univ '' A '' B) x20 \ ! x21 \ ! x22 \ ! x23 \ pair_univ '' A '' B ' x20 ' x22 = pair_univ '' A '' B ' x21 ' x23 ==> x20 = x21) ,
+   [then (repeat forall_i)
+     (bind (univ '' A '' B) x22 \
+       bind (univ '' A '' B) x23 \
+        bind (univ '' A '' B) x24 \
+         bind (univ '' A '' B) x25 \
+          then i
+           (then (cutth proj1_pair_univ)
+             (then (lforall x22)
+               (then (conv (land_tac (then sym apply)))
+                 (then (conv (depth_tac h)) (applyth proj1_pair_univ))))))])
+ , theorem pair_univ_inj_r 
+   (pi A \ pi B \ (! (univ '' A '' B) x20 \ ! x21 \ ! x22 \ ! x23 \ pair_univ '' A '' B ' x20 ' x22 = pair_univ '' A '' B ' x21 ' x23 ==> x22 = x23) ,
+   [then (repeat forall_i)
+     (bind (univ '' A '' B) x22 \
+       bind (univ '' A '' B) x23 \
+        bind (univ '' A '' B) x24 \
+         bind (univ '' A '' B) x25 \
+          then i
+           (then (cutth proj2_pair_univ)
+             (then (lforall x22)
+               (then (conv (land_tac (then sym apply)))
+                 (then (conv (depth_tac h)) (applyth proj2_pair_univ))))))])
+ , theorem injection_univ_inj
+   (pi A \ pi B \ (! A x20 \ ! x21 \ injection_univ '' A '' B ' x20 = injection_univ '' A '' B ' x21 ==> x20 = x21) ,
+    [then forall_i
+     (bind A x20 \
+       then forall_i
+        (bind A x21 \
+          then (then (cutth ejection_injection_univ) (lforall x21))
+           (then (then (cutth ejection_injection_univ) (lforall x20))
+             (then i
+               (thenl
+                 (cut
+                   (ejection_univ '' A '' B ' (injection_univ '' A '' B ' x20) =
+                     ejection_univ '' A '' B ' (injection_univ '' A '' B ' x21)))
+                 [thenl
+                   (cut
+                     ((ejection_univ '' A '' B ' (injection_univ '' A '' B ' x20) =
+                        ejection_univ '' A '' B ' (injection_univ '' A '' B ' x21)) =
+                       (x20 = x21)))
+                   [then (conv (depth_tac (then sym h))) h,
+                   thenl c [thenl c [r, h], h]], thenl c [r, h]])))))])
+ , theorem inj1_univ_inj
+   (pi A \ pi B \ (! (univ '' A '' B) x20 \ ! x21 \ inj1_univ '' A '' B ' x20 = inj1_univ '' A '' B ' x21 ==> x20 = x21) ,
+    [then inv
+     (bind (univ '' A '' B) x20 \ bind (univ '' A '' B) x21 \
+        thenl (t (case_univ '' A '' B '' (univ '' A '' B) ' (inj1_univ '' A '' B ' x20) '
+             (lam (univ '' A '' B) x22 \ x22) '
+             (lam (univ '' A '' B) x22 \ x22)))
+         [then sym
+           (then (conv (land_tac (applyth case_univ_inj1)))
+             (then (conv (land_tac b)) r)),
+         then (conv (depth_tac h))
+          (then (conv (land_tac (applyth case_univ_inj1)))
+            (then (conv (land_tac b)) r))])])
+ , theorem inj2_univ_inj
+   (pi A \ pi B \ (! (univ '' A '' B) x22 \ ! x23 \ inj2_univ '' A '' B ' x22 = inj2_univ '' A '' B ' x23 ==> x22 = x23) ,
+    [then inv
+     (bind (univ '' A '' B) x20 \ bind (univ '' A '' B) x21 \
+        thenl (t (case_univ '' A '' B '' (univ '' A '' B) ' (inj2_univ '' A '' B ' x20) '
+             (lam (univ '' A '' B) x22 \ x22) '
+             (lam (univ '' A '' B) x22 \ x22)))
+         [then sym
+           (then (conv (land_tac (applyth case_univ_inj2)))
+             (then (conv (land_tac b)) r)),
+         then (conv (depth_tac h))
+          (then (conv (land_tac (applyth case_univ_inj2)))
+            (then (conv (land_tac b)) r))])])
+ , theorem not_eq_inj1_inj2_univ 
+   (pi A \ pi B \ (! (univ '' A '' B) x22 \ ! x23 \ inj1_univ '' A '' B ' x22 = inj2_univ '' A '' B ' x23 ==> ff) ,
+    [then inv
+     (bind (univ '' A '' B) x22 \
+       bind (univ '' A '' B) x23 \
+        then (cutth case_univ_inj1)
+         (then (lforall x22)
+           (then (lforall (lam (univ '' A '' B) x24 \ ff))
+             (then (lforall (lam (univ '' A '' B) x24 \ tt))
+               (thenl (m ((lam (univ '' A '' B) x24 \ ff) ' x22)) [b,
+                 then (conv (then sym h))
+                  (then (wl [])
+                    (then (conv (depth_tac h))
+                      (then (wl [])
+                        (then (conv (applyth case_univ_inj2))
+                          (then (conv b) (itaut 1))))))])))))])
+ , theorem inj1_disj_union_inj (pi A \ pi B \
+    ((! x \ ! y \
+     inj1_disj_union '' A '' B ' x = inj1_disj_union '' A '' B ' y ==> x = y) ,
+    [then inv
+      (bind A x23 \
+        bind A x24 \
+         then (cutth case_disj_union_inj1)
+          (then (lforall x23)
+            (then (lforall (lam A x25 \ x25))
+              (then (lforall (lam B x25 \ choose '' A))
+                (thenl (t ((lam A x25 \ x25) ' x23))
+                  [then (conv (rand_tac b)) r,
+                  then (conv (land_tac (then sym h)))
+                   (then (wl [])
+                     (then (conv (depth_tac h))
+                       (then (wl [])
+                         (then (conv (land_tac (applyth case_disj_union_inj1)))
+                           b))))])))))]))
+ , theorem inj2_disj_union_inj (pi A \ pi B \
+    ((! x \ ! y \
+     inj2_disj_union '' A '' B ' x = inj2_disj_union '' A '' B ' y ==> x = y) ,
+    [then inv
+      (bind B x23 \
+        bind B x24 \
+         then (cutth case_disj_union_inj2)
+          (then (lforall x23)
+            (then (lforall (lam A x25 \ choose '' B))
+              (then (lforall (lam B x25 \ x25))
+                (thenl (t ((lam B x25 \ x25) ' x23))
+                  [then (conv (rand_tac b)) r,
+                  then (conv (land_tac (then sym h)))
+                   (then (wl [])
+                     (then (conv (depth_tac h))
+                       (then (wl [])
+                         (then (conv (land_tac (applyth case_disj_union_inj2)))
+                           b))))])))))]))
+
+ /********** Monotonicity of logical connectives *********/
+ , theorem and_monotone ((! a1 \ ! b1 \ ! a2 \ ! b2 \
+    (a1 ==> b1) ==> (a2 ==> b2) ==> a1 && a2 ==> b1 && b2),
+    [itaut 2])
+ , theorem or_monotone ((! a1 \ ! b1 \ ! a2 \ ! b2 \
+    (a1 ==> b1) ==> (a2 ==> b2) ==> a1 `or a2 ==> b1 `or b2),
+    [itaut 2])
+ , theorem impl_monotone ((! a1 \ ! b1 \ ! a2 \ ! b2 \
+    (b1 ==> a1) ==> (a2 ==> b2) ==> (a1 ==> a2) ==> (b1 ==> b2)),
+    [itaut 3])
+ , theorem not_monotone ((! p \ ! q \ (p ==> q) ==> (not ' q) ==> (not ' p)),
+    [itaut 3])
+ , theorem forall_monotone (pi A \ (! p \ ! q \
+    (! A x \ p ' x ==> q ' x) ==> (! x \ p ' x) ==> (! x \ q ' x)),
+    [itaut 6])
+ , theorem exists_monotone (pi A \ (! p \ ! q \
+    (! A x \ p ' x ==> q ' x) ==> (? x \ p ' x) ==> (? x \ q ' x)),
+    [itaut 6])
+
+ /********** Knaster-Tarski theorem *********/
+  , def in (pi A \ (A --> (A --> prop) --> prop),
+     (lam A x \ lam (A --> prop) j \ j ' x))
+  , def subseteq (pi A \ ((A --> prop) --> (A --> prop) --> prop),
+     (lam (A --> prop) x \ lam (A --> prop) y \ ! z \ z #in x ==> z #in y))
+  , theorem in_subseteq (pi A \ 
+     (! s \ ! t \ ! x \ s <<= t ==> x #in s ==> x #in t),
+     [then forall_i
+       (bind (A --> prop) x9 \
+         then forall_i
+          (bind (A --> prop) x10 \
+            then forall_i (bind A x11 \ then (conv (land_tac dd)) (itaut 4))))])
+  , def monotone (pi A \ (((A --> prop) --> (A --> prop)) --> prop),
+      (lam (_ A) f \ ! x \ ! y \ x <<= y ==> f ' x <<= f ' y))
+  , def is_fixpoint (pi A \ (((A --> prop) --> (A --> prop)) --> ((A --> prop) --> prop)),
+     (lam (_ A) f \ lam (_ A) x \ (f ' x) <<= x && x <<= (f ' x)))
+  , def fixpoint (pi A \ (((A --> prop) --> (A --> prop)) --> (A --> prop)),
+     (lam (_ A) f \ lam A a \ ! e \ f ' e <<= e ==> a #in e))
+  , theorem fixpoint_subseteq_any_prefixpoint (pi A \
+     (! f \ ! x\ f ' x <<= x ==> fixpoint '' A ' f <<= x),
+     [then inv
+       (bind ((A --> prop) --> (A --> prop)) x9 \
+         (bind (A --> prop) x10 \
+           then (conv (land_tac dd))
+            (then (conv dd)
+              (then forall_i
+                (bind A x11 \
+                  then (conv (land_tac dd))
+                   (then (conv (land_tac b)) (itaut 4)))))))])
+  , theorem fixpoint_subseteq_any_fixpoint (pi A \
+     (! f \ ! x\ is_fixpoint '' A ' f ' x ==> fixpoint '' A ' f <<= x),
+     [then forall_i
+       (bind ((A --> prop) --> (A --> prop)) x9 \
+         then forall_i
+          (bind (A --> prop) x10 \
+            then (conv (land_tac dd))
+             (then (cutth fixpoint_subseteq_any_prefixpoint) (itaut 8))))])
+  , theorem prefixpoint_to_prefixpoint (pi A \
+     (! f \ ! x \ monotone '' A ' f ==> f ' x <<= x ==> f ' (f ' x) <<= f ' x),
+    [then forall_i
+      (bind ((A --> prop) --> (A --> prop)) x9 \
+        then forall_i
+         (bind (A --> prop) x10 \ then (conv (land_tac dd)) (itaut 6)))])
+  , theorem fixpoint_is_prefixpoint (pi A \
+     (! f \ monotone '' A ' f ==> f ' (fixpoint '' A ' f)<<= fixpoint '' A ' f),
+     [then inv
+       (bind ((A --> prop) --> (A --> prop)) x9 \
+         then (conv dd)
+          (then inv
+            (bind A x10 \
+              then (conv (depth_tac (dd [fixpoint])))
+               (then (conv dd)
+                 (then (conv b)
+                   (then inv
+                     (bind (A --> prop) x11 \
+                       thenl (cut (fixpoint '' A ' x9 <<= x11))
+                        [thenl
+                          (cut (x9 ' (fixpoint '' A ' x9) <<= x9 ' x11))
+                          [then (cutth in_subseteq)
+                            (then (lforall_last (x9 ' x11))
+                              (then (lforall_last x11)
+                                (thenl apply_last [h,
+                                  then (cutth in_subseteq) (itaut 10)]))),
+                          thenl
+                           (m (monotone '' A ' x9 ==> x9 ' (fixpoint '' A ' x9) <<= x9 ' x11))
+                           [itaut 10, then (conv (land_tac dd)) (itaut 10)]],
+                        then (applyth fixpoint_subseteq_any_prefixpoint) h])))))))])
+  , theorem fixpoint_is_fixpoint (pi A \
+    (! f \ monotone '' A ' f ==> is_fixpoint '' A ' f ' (fixpoint '' A ' f)),
+    [then inv
+      (bind ((A --> prop) --> (A --> prop)) x9 \
+        then (conv (depth_tac (dd [is_fixpoint])))
+         (thenl inv [then (applyth fixpoint_is_prefixpoint) h,
+           then (applyth fixpoint_subseteq_any_prefixpoint)
+            (then (g (monotone '' A ' x9))
+              (then (conv (land_tac dd))
+                (then inv
+                  (then apply (then (applyth fixpoint_is_prefixpoint) h)))))]))])
+
+ /*********** Axiomatization of well-founded recursion ********/
+ , decl rec (pi A \pi B \ ((A --> B) --> (A --> B)) --> (A --> B))
+ , inductive_def acc accF accF_monotone acc_i0 acc_e0 acc_e
+    (pi A \ param (A --> A --> prop) lt \ acc \
+     [ (acc_i, ! x \ (! y \ lt ' y ' x ==> acc ' y) ==> acc ' x) ])
+
+ , def well_founded (pi A \ ((A --> A --> prop) --> prop,
+    lam (_ A) lt \ ! x \ acc '' A ' lt ' x))
+
+ , axiom rec_is_fixpoint (pi A \ pi B \
+   (! lt \ well_founded '' A ' lt ==>
+    ! ((A --> B) --> (A --> B)) h \
+     (! f \ ! g \ ! i \
+       (! p \ lt ' p ' i ==> f ' p = g ' p) ==> h ' f ' i = h ' g ' i) ==>
+     rec '' A '' B ' h = h ' (rec '' A '' B ' h)))
+ /******************* TESTS *****************/
+ /* The first three tests are commented out because they require extra-hacks
+    in the kernel to avoid quantifying over p, q and g.
+ , theorem test_apply (p ==> (p ==> p ==> q) ==> q,
+    [then i (then i (then apply h))])
+ , theorem test_apply2 (p ==> (! x \ ! y \ x ==> x ==> y) ==> q,
+    [then i (then i (then apply h))])
+ , theorem test_itaut_1 (((? x \ g x) ==> ! x \ (! y \ g y ==> x) ==> x),
+   [itaut 4])*/
+ , theorem test_monotone1 (monotone '' _ ' (lam _ p \ lam _ x \ not ' (p ' x) ==> tt && p ' tt `or p ' x),
+   [ auto_monotone ])
+ , theorem test_monotone2 (monotone '' _ ' (lam _ p \ lam _ x \ ? z \ not ' (p ' x) ==> tt && p ' tt `or z),
+   [ auto_monotone ])
+ , theorem test_monotone3 (monotone '' _ ' (lam _ p \ lam _ x \ ! z \ ? y \ (not ' (p ' x) ==> z && p ' y `or y)),
+   [ auto_monotone ])
+ , inductive_def pnn pnnF pnnF_monotone pnn_i pnn_e0 pnn_e (pnn \
+     [ (pnn_tt, pnn ' tt)
+     , (pnn_not, ! x \ pnn ' x ==> pnn ' (not ' x))])
+ , theorem pnn_e
+    ((! x13 \
+       x13 ' tt && (! x14 \ x13 ' x14 ==> x13 ' (not ' x14)) ==>
+        (! x14 \ pnn ' x14 ==> x13 ' x14)) ,
+   [then forall_i
+     (bind (prop --> prop) x13 \
+       then (cutth pnn_e0)
+        (then (lforall x13)
+          (then i
+            (thenl lapply
+              [then (conv (depth_tac (dd [pnnF])))
+                (then forall_i
+                  (bind prop x14 \
+                    then i
+                     % from now on the proof is ad-hoc + fragile
+                     (thenl left [then (conv (depth_tac h)) (itaut 1),
+                       then left
+                        (bind prop x15 \
+                          then left (then (conv (depth_tac h)) (itaut 8)))]))),
+              h]))))])
+ , theorem pnn_has_two_values
+    ((! x13 \ pnn ' x13 ==> x13 = tt `or x13 = ff) ,
+    % applying an elimination principle is hard: it should be automatized
+    [then (cutth pnn_e)
+      (then (lforall (lam prop x13 \ or ' (eq '' prop ' x13 ' tt) ' (eq '' prop ' x13 ' ff)))
+        (thenl lapply
+          [thenl conj [then (conv b) (itaut 1),
+            then (repeat (conv (depth_tac b)))
+             (then forall_i (bind prop x13 \ then i (then left (itaut 8))))],
+          then inv
+           (bind prop x13 \
+             then (lforall x13)
+              (thenl lapply [h,
+                then
+                 (g
+                   ((lam prop x14 \ or ' (eq '' prop ' x14 ' tt) ' (eq '' prop ' x14 ' ff)) '
+                     x13))
+                 (then (repeat (conv (depth_tac b)))
+                   (then
+                     (w
+                       ((lam prop x14 \ or ' (eq '' prop ' x14 ' tt) ' (eq '' prop ' x14 ' ff))
+                         ' x13)) (then (w (pnn ' x13)) (itaut 2))))]))]))])
+ , inductive_def in_two in_twoF in_twoF_monotone in_two_i in_two_e0 in_two_e (in_two \
+     [ (in_two_tt, in_two ' tt)
+     , (in_two_ff, in_two ' ff) ])
+ , new_basic_type bool2 myrep2 myabs2 myrepabs2 myabsrep2 myproprep2
+    (pnn,
+    [then (cutth pnn_tt) (then (applyth exists_i) h)])
+ , def mytt (bool2,(myabs2 ' tt))
+ , def mynot ((bool2 --> bool2),(lam _ x \ myabs2 ' (not ' (myrep2 ' x))))
+ , theorem mytt_transfer
+   (myrep2 ' mytt = tt ,
+     [then (conv (depth_tac (dd [mytt])))
+       (then (applyth myrepabs2) (applyth pnn_tt))])
+ , theorem mynot_transfer
+   ((! x18 \ myrep2 ' (mynot ' x18) = not ' (myrep2 ' x18)) ,
+     [then (conv (depth_tac (dd [mynot])))
+       (then forall_i
+         (bind bool2 x18 \
+           then (applyth myrepabs2)
+            (then (applyth pnn_not) (applyth myproprep2))))])
+ , theorem mybool2_e
+ ((! x18 \
+    x18 ' mytt && (! x19 \ x18 ' x19 ==> x18 ' (mynot ' x19)) ==>
+     (! x19 \ x18 ' x19)) ,
+   [thenl
+     (cut
+       (forall '' (bool2 --> prop) '
+         (lam (bool2 --> prop) x18 \
+           impl '
+            (and ' (x18 ' (myabs2 ' (myrep2 ' mytt))) '
+              (forall '' bool2 '
+                (lam bool2 x19 \
+                  impl ' (x18 ' (myabs2 ' (myrep2 ' x19))) '
+                   (x18 '
+                     (myabs2 '
+                       (myrep2 ' (mynot ' (myabs2 ' (myrep2 ' x19)))))))))
+            '
+            (forall '' bool2 '
+              (lam bool2 x19 \ x18 ' (myabs2 ' (myrep2 ' x19)))))))
+     [then
+       (g
+         (forall '' (bool2 --> prop) '
+           (lam (bool2 --> prop) x18 \
+             impl '
+              (and ' (x18 ' (myabs2 ' (myrep2 ' mytt))) '
+                (forall '' bool2 '
+                  (lam bool2 x19 \
+                    impl ' (x18 ' (myabs2 ' (myrep2 ' x19))) '
+                     (x18 '
+                       (myabs2 '
+                         (myrep2 ' (mynot ' (myabs2 ' (myrep2 ' x19)))))))))
+              '
+              (forall '' bool2 '
+                (lam bool2 x19 \ x18 ' (myabs2 ' (myrep2 ' x19)))))))
+       (then
+         (w
+           (forall '' (bool2 --> prop) '
+             (lam (bool2 --> prop) x18 \
+               impl '
+                (and ' (x18 ' (myabs2 ' (myrep2 ' mytt))) '
+                  (forall '' bool2 '
+                    (lam bool2 x19 \
+                      impl ' (x18 ' (myabs2 ' (myrep2 ' x19))) '
+                       (x18 '
+                         (myabs2 '
+                           (myrep2 ' (mynot ' (myabs2 ' (myrep2 ' x19)))))))))
+                '
+                (forall '' bool2 '
+                  (lam bool2 x19 \ x18 ' (myabs2 ' (myrep2 ' x19)))))))
+         (then (repeat (conv (depth_tac (applyth myabsrep2)))) (then i h))),
+     then forall_i
+      (bind (bool2 --> prop) x18 \
+        then (cutth pnn_e)
+         (then
+           (lforall
+             (lam prop x19 \
+               exists '' bool2 '
+                (lam bool2 x20 \
+                  and ' (eq '' _ ' x19 ' (myrep2 ' x20)) '
+                   (x18 ' (myabs2 ' x19)))))
+           (then inv
+             (bind bool2 x19 \
+               thenl
+                (cut
+                  ((lam prop x20 \
+                     exists '' bool2 '
+                      (lam bool2 x21 \
+                        and ' (eq '' _ ' x20 ' (myrep2 ' x21)) '
+                         (x18 ' (myabs2 ' x20)))) ' (myrep2 ' x19)))
+                [then
+                  (g
+                    ((lam prop x20 \
+                       exists '' bool2 '
+                        (lam bool2 x21 \
+                          and ' (eq '' _ ' x20 ' (myrep2 ' x21)) '
+                           (x18 ' (myabs2 ' x20)))) ' (myrep2 ' x19)))
+                  (then (conv (depth_tac b)) inv),
+                thenl apply
+                 [then (repeat (conv (depth_tac b)))
+                   (thenl inv
+                     [then (cutth exists_i)
+                       (then
+                         (lforall_last
+                           (lam bool2 x20 \
+                             and ' (eq '' _ ' tt ' (myrep2 ' x20)) '
+                              (x18 ' (myabs2 ' tt))))
+                         (then (lforall_last mytt)
+                           (then apply_last (then (conv b)
+                            (thenl inv
+                             [then (cutth mytt_transfer)
+                               (then (conv (depth_tac h)) (applyth tt_intro)),
+                             (applyth tt_intro),
+                             then (cutth mytt_transfer)
+                              (then (g (x18 ' (myabs2 ' (myrep2 ' mytt))))
+                                (then (conv (depth_tac h)) (then i h)))]))))),
+                     (bind prop x20 \
+                       bind bool2 x21 \
+                        then (cutth exists_i)
+                         (then
+                           (lforall_last
+                             (lam bool2 x22 \
+                               and ' (eq '' _ ' (not ' x20) ' (myrep2 ' x22)) '
+                                (x18 ' (myabs2 ' (not ' x20)))))
+                           (then (lforall_last (mynot ' x21))
+                             (then apply_last (then (conv b)
+    (thenl inv
+     [then (conv (applyth mynot_transfer))
+       (then (conv (depth_tac (dd [not]))) (then inv (itaut 3))),
+     then (g (myrep2 ' (mynot ' x21)))
+      (then (conv (land_tac (applyth mynot_transfer)))
+        (then (conv (depth_tac (dd [not]))) (then inv (itaut 3)))),
+     then (lforall (myabs2 ' x20))
+      (thenl lapply [then (conv (depth_tac (applyth myabsrep2))) h,
+        then
+         (g
+           (x18 '
+             (myabs2 '
+               (myrep2 ' (mynot ' (myabs2 ' (myrep2 ' (myabs2 ' x20))))))))
+         (then (conv (depth_tac (applyth myabsrep2)))
+           (then (conv (depth_tac (applyth myabsrep2)))
+             (thenl (cut (x20 = myrep2 ' x21))
+               [then (conv (depth_tac h))
+                 (then (conv (depth_tac h))
+                   (then (conv (depth_tac (applyth myabsrep2)))
+                     (then i
+                       (then
+                         (conv
+                           (rand_tac
+                             (rand_tac (then sym (applyth mynot_transfer)))))
+                         (then (conv (depth_tac (applyth myabsrep2))) h))))),
+               itaut 2])))])]))))))]),
+                 applyth myproprep2]]))))]])
+
+, theorem step0
+    ((! x13 \ mynot ' (mynot ' (mynot ' x13)) = mynot ' x13) ,
+     [then inv
+      (bind bool2 x13 \
+        then (repeat (conv (depth_tac (dd [mynot]))))
+         (thenl (conv (land_tac (rand_tac (rand_tac (applyth myrepabs2)))))
+          [then (cutth pnn_not)
+            (then (lforall (myrep2 ' (myabs2 ' (not ' (myrep2 ' x13)))))
+              (then (cutth myproprep2)
+                (then (lforall (myabs2 ' (not ' (myrep2 ' x13))))
+                  (then apply h)))),
+          thenl
+           (conv
+             (land_tac
+               (rand_tac (rand_tac (rand_tac (applyth myrepabs2))))))
+           [then (cutth pnn_not)
+             (then (lforall (myrep2 ' x13))
+               (then (cutth myproprep2)
+                 (then (lforall x13) (then apply h)))),
+           then (conv (land_tac (rand_tac (applyth not_not_not)))) r]]))])
+ , theorem mynot_mynot_mytt
+    (mynot ' (mynot ' mytt) = mytt ,
+     [then (conv (depth_tac (dd [mynot])))
+      (then (cutth mynot_transfer)
+        (then (lforall mytt)
+          (then (conv (depth_tac h))
+            (then (cutth mytt_transfer)
+              (then (conv (depth_tac h))
+                (then (conv (depth_tac (dd [mytt]))) (thenl c [r, itaut 3])))))))])
+ , theorem step1
+    ((! x18 \ x18 = mytt `or x18 = mynot ' mytt) ,
+     [then forall_i
+      (bind bool2 x18 \
+       then (cutth mybool2_e)
+        (thenl
+          (cut
+            ((lam bool2 x19 \
+               or ' (eq '' _ ' x19 ' mytt) ' (eq '' _ ' x19 ' (mynot ' mytt))) ' x18))
+          [then
+            (g
+              ((lam bool2 x19 \
+                 or ' (eq '' _ ' x19 ' mytt) ' (eq '' _ ' x19 ' (mynot ' mytt))) '
+                x18)) (then (conv (depth_tac b)) (then i h)),
+          then apply
+           (then (repeat (conv (depth_tac b)))
+             (thenl conj [then (applyth orl) r,
+               thenl inv
+                [(bind bool2 x19 \
+                   then (applyth orr) (then (conv (depth_tac h)) r)),
+                (bind bool2 x19 \
+                  then (applyth orl) (then (conv (depth_tac h)) (applyth mynot_mynot_mytt)))]]))]))])
+
+ /******* Cartesian product of types ******/
+ /* TODO: this is an inductive type as well: generalize
+    inductive_type to type abstractions */
+ , def is_pair (pi A \ pi B \
+  (univ '' (disj_union '' A '' B) '' prop --> prop),
+  lam (_ A B) p \ ? A a \ ? B b \
+   p =
+    pair_univ '' (_ A B) '' _ '
+     (injection_univ '' (_ A B) '' _ ' (inj1_disj_union '' A '' B ' a)) '
+     (injection_univ '' (_ A B) '' _ ' (inj2_disj_union '' A '' B ' b)))
+ , new_basic_type prod prod_rep prod_abs prod_repabs prod_absrep prod_proprep
+    (pi A \ pi B \ is_pair '' A '' B, [daemon])
+ , def pair (pi A \ pi B \
+    (A --> B --> prod '' A '' B,
+    lam A a \ lam B b \
+     prod_abs '' A '' B '
+      (pair_univ '' (_ A B) '' _ '
+       (injection_univ '' (_ A B) '' _ ' (inj1_disj_union '' A '' B ' a)) '
+       (injection_univ '' (_ A B) '' _ ' (inj2_disj_union '' A '' B ' b)))
+    ))
+ /* TODO: define fst and snd and prove the usual lemmas
+    fst ' (pair ' a ' b) = a */
+
+  /************* Natural numbers ***************/
+ , inductive_def is_nat is_natF is_nat_monotone is_nat_i is_nat_e0 is_nat_e
+   (is_nat \
+     [ (is_nat_z, is_nat ' (inj1_univ '' prop '' prop ' (injection_univ '' prop '' prop ' ff)))
+     , (is_nat_s, ! x \ is_nat ' x ==> is_nat ' (inj2_univ '' prop '' prop ' x))])
+ , new_basic_type nat nat_rep nat_abs nat_repabs nat_absrep nat_proprep
+    (is_nat,
+    [then (cutth is_nat_z) (then (applyth exists_i) h)])
+ , def z (nat, nat_abs ' (inj1_univ '' prop '' prop ' (injection_univ '' prop '' prop ' ff)))
+ , def s (nat --> nat,
+    (lam _ x \ nat_abs ' (inj2_univ '' prop '' prop ' (nat_rep ' x))))
+ /* TODO: consequence of is_nat_e by transfer principles */
+ , theorem nat_e ((! p \ p ' z ==> (! n \ p ' n ==> p ' (s ' n)) ==> ! n \ p ' n), [ daemon ])
+ , theorem nat_abs_inj
+   ((! x18 \
+      ! x19 \
+       is_nat ' x18 ==>
+        is_nat ' x19 ==> nat_abs ' x18 = nat_abs ' x19 ==> x18 = x19) ,
+     [then inv
+       (bind _ x18 \
+         bind _ x19 \
+          thenl (conv (land_tac (then sym (applyth nat_repabs)))) [h,
+           thenl (conv (rand_tac (then sym (applyth nat_repabs)))) [h,
+            then (conv (depth_tac h)) r]])])
+ , theorem nat_rep_inj
+   ((! x18 \ ! x19 \ nat_rep ' x18 = nat_rep ' x19 ==> x18 = x19) ,
+     [then inv
+       (bind nat x18 \
+         bind nat x19 \
+          then (conv (land_tac (then sym (applyth nat_absrep))))
+           (then (conv (rand_tac (then sym (applyth nat_absrep))))
+             (then (conv (depth_tac h)) r)))])
+ , theorem s_inj ((! x18 \ ! x19 \ s ' x18 = s ' x19 ==> x18 = x19) ,
+     [then (repeat (conv (depth_tac (dd [s]))))
+       (then inv
+         (bind nat x18 \
+           bind nat x19 \
+            then (applyth nat_rep_inj)
+             (then (applyth inj2_univ_inj)
+               (thenl (applyth nat_abs_inj)
+                 [then (applyth is_nat_s) (applyth nat_proprep),
+                 then (applyth is_nat_s) (applyth nat_proprep), h]))))])
+ , theorem not_equal_z_s ((! x20 \ not ' (z = s ' x20)) ,
+     [then (repeat (conv (depth_tac (dd [z]))))
+       (then (repeat (conv (depth_tac (dd [s]))))
+         (then (repeat (conv (depth_tac (dd [not]))))
+           (then inv
+             (bind nat x20 \
+               then (applyth not_eq_inj1_inj2_univ)
+                (thenl (thenl (applyth nat_abs_inj) [id, id, h])
+                  [applyth is_nat_z,
+                  then (applyth is_nat_s) (applyth nat_proprep)])))))])
+ , def nat_case (pi A \ (nat --> A --> (nat --> A) --> A,
+    lam _ n \ lam (_ A) a \ lam (_ A) f \
+     case_univ '' prop '' prop '' A ' (nat_rep ' n) ' (lam _ x \ a) ' (lam _ p \ f ' (nat_abs ' p))))
+ , theorem nat_case_z (pi A \ ((! x21 \ ! x22 \ nat_case '' A ' z ' x21 ' x22 = x21) ,
+      [then (conv (depth_tac (dd [nat_case])))
+        (then (conv (depth_tac (dd [z])))
+          (then forall_i
+            (bind A x21 \
+              then forall_i
+               (bind (nat --> A) x22 \
+                 thenl
+                  (conv (land_tac (rator_tac (land_tac (applyth nat_repabs)))))
+                  [applyth is_nat_z,
+                   then (conv (depth_tac (applyth case_univ_inj1)))
+                    (then (conv (depth_tac b)) r)]))))]))
+ , theorem nat_case_s
+   (pi A \ (! x21 \ ! x22 \ ! x23 \
+     nat_case '' A ' (s ' x21) ' x22 ' x23 = x23 ' x21),
+     [then (conv (depth_tac (dd [nat_case])))
+       (then (conv (depth_tac (dd [s])))
+         (then forall_i
+           (bind nat x21 \
+             then forall_i
+              (bind A x22 \
+                then forall_i
+                 (bind (nat --> A) x23 \
+                   thenl
+                    (conv (land_tac (rator_tac (land_tac (applyth nat_repabs)))))
+                    [then (applyth is_nat_s) (applyth nat_proprep),
+                     then (conv (depth_tac (applyth case_univ_inj2)))
+                     (then (conv (depth_tac b))
+                       (then (conv (depth_tac (applyth nat_absrep))) r))])))))])
+
+
+ , theorem pred_well_founded
+   (well_founded '' nat ' (lam nat x21 \ lam nat x22 \ x22 = s ' x21) ,
+   [then (conv dd)
+     (then forall_i
+       (bind nat x21 \
+         thenl (applyth nat_e)
+          [then (applyth acc_i)
+            (then (repeat (conv (depth_tac b)))
+              (then inv
+                (bind nat x22 \
+                  then (applyth ff_elim) (then (cutth not_equal_z_s) (itaut 4))))),
+          then inv
+           (bind nat x22 \
+             then (applyth acc_i)
+              (then (repeat (conv (depth_tac b)))
+                (then inv
+                  (bind nat x23 \
+                    then (cutth s_inj)
+                     (then (lforall x22)
+                       (then (lforall x23)
+                         (thenl lapply [h,
+                           then (conv (rand_tac (then sym h))) h])))))))]))])
+ , def nat_recF (pi A \
+    A --> (nat --> A --> A) --> (nat --> A) --> (nat --> A)
+    , lam A a \ lam (_ A) f \ lam (_ A) rec \ lam _ n \
+       nat_case '' A ' n ' a ' (lam _ p \ f ' p ' (rec ' p)))
+ , def nat_rec (pi A \
+    A --> (nat --> A --> A) --> nat --> A
+    , lam A a \ lam (_ A) f \ rec '' nat '' A ' (nat_recF '' A ' a ' f))
+ , theorem nat_rec_ok0 (pi A \
+   ((! a \ ! f \
+     nat_rec '' A ' a ' f = nat_recF '' A ' a ' f ' (nat_rec '' A ' a ' f)) ,
+   [then inv
+     (bind A x22 \
+       bind (nat --> A --> A) x23 \
+        then (repeat (conv (depth_tac (dd [nat_rec]))))
+         (thenl (applyth rec_is_fixpoint) [applyth pred_well_founded,
+           then (repeat (conv (depth_tac b)))
+            (then (repeat (conv (depth_tac (dd [nat_recF]))))
+              (then forall_i
+                (bind (nat --> A) x24 \
+                  then forall_i
+                   (bind (nat --> A) x25 \
+                     then (conv (rand_tac beta_expand))
+                      (thenl (applyth nat_e)
+                        [then (conv (depth_tac b))
+                          (then inv
+                            (then (conv (land_tac (applyth nat_case_z)))
+                              (then (conv (rand_tac (applyth nat_case_z))) r))),
+                        then (repeat (conv (depth_tac b)))
+                         (then inv
+                           (bind nat x26 \
+                             then (conv (rand_tac (applyth nat_case_s)))
+                              (then (conv (land_tac (applyth nat_case_s)))
+                                (then (repeat (conv (depth_tac b)))
+                                  (then (lforall x26)
+                                    (thenl lapply [r,
+                                      then (conv (land_tac (rand_tac h))) r]))))))])))))]))]))
+ , theorem nat_rec_ok (pi A \
+   (! a \ ! f \ ! n \
+     nat_rec '' A ' a ' f ' n =
+      nat_case '' A ' n ' a ' (lam _ p \ f ' p ' (nat_rec '' A ' a ' f ' p))),
+   [then inv
+     (bind A x22 \
+       bind (nat --> A --> A) x23 \
+        bind nat x24 \
+         then (conv (land_tac (rator_tac (applyth nat_rec_ok0))))
+          (then (conv (depth_tac (dd [nat_recF]))) r))])
+
+ /************* Arithmetics: plus ***************/
+ , def plus (nat --> nat --> nat,
+    lam _ n \ lam _ m \
+     nat_rec '' _ ' m ' (lam _ p \ lam _ sum \ s ' sum)' n)
+ , theorem plus_z ((! n \ z + n = n),
+   [then (conv (depth_tac (dd [plus])))
+     (then inv
+       (bind nat x21 \
+         then (conv (land_tac (applyth nat_rec_ok)))
+          (then (conv (land_tac (applyth nat_case_z))) r)))])
+ , theorem plus_s ((! n \ ! m \  s ' n + m = s ' (n + m)),
+   [then (repeat (conv (depth_tac (dd [plus]))))
+     (then inv
+       (bind nat x21 \
+         bind nat x22 \
+          then (conv (land_tac (applyth nat_rec_ok)))
+           (then (conv (land_tac (applyth nat_case_s)))
+             (then (repeat (conv (depth_tac b))) r))))])
+ , theorem plus_n_z ((! n \ n + z = n),
+   [then (conv (rand_tac beta_expand))
+     (thenl (applyth nat_e) [then (conv b) (applyth plus_z),
+       then (repeat (conv (depth_tac b)))
+        (then inv
+          (bind nat x21 \
+            then (conv (land_tac (applyth plus_s)))
+             (then (conv (depth_tac h)) r)))])])
+ , theorem plus_n_s ((! n \ ! m \ n + (s ' m) = s ' (n + m)),
+   [then (conv (rand_tac beta_expand))
+     (thenl (applyth nat_e)
+       [then (conv b)
+         (then inv
+           (bind nat x21 \ then (repeat (conv (depth_tac (applyth plus_z)))) r)),
+       then (repeat (conv (depth_tac b)))
+        (then inv
+          (bind nat x21 \
+            bind nat x22 \
+             then (conv (land_tac (applyth plus_s)))
+              (thenl c [r,
+                then (conv (land_tac apply)) (then sym (applyth plus_s))])))])])
+ , theorem plus_comm ((! n \ ! m \ n + m = m + n),
+   [then (conv (rand_tac beta_expand))
+     (thenl (applyth nat_e)
+       [then (conv b)
+         (then inv
+           (bind nat x21 \
+             then (conv (land_tac (applyth plus_z)))
+              (then sym (applyth plus_n_z)))),
+       then (repeat (conv (depth_tac b)))
+        (then inv
+          (bind nat x21 \
+            bind nat x22 \
+             then (conv (land_tac (applyth plus_s)))
+              (then sym
+                (then (conv (land_tac (applyth plus_n_s)))
+                  (thenl c [r, then sym apply])))))])])
+
+ ].
+
+/* Status and dependencies of the tactics:
++dd:
++sym:
++eq_true_intro: (th tt_intro)
++forall_i: dd eq_true_intro
++conj: dd eq_true_intro
++andr: dd tt_intro
++andl: dd tt_intro
++forall_e: sym dd
++mp: andr sym dd
++i: dd andl conj
++cut: andr sym dd i
++cutth: cut
++lapply*: mp
++lforall*: mp forall_e
++apply*: lapply lforall
++applyth: cutth apply*
+
+- f converional sometimes fails
+- conv (depth_tac) diverges when applied to terms that contain
+  metavariables
+- repeat is not implemented using progress, that is not even there
+*/
+
+/*
+-2.5) in the proof for myprop, at the end I provide the
+  witness (and X X) where X remains free (and it is not even pi-quantified).
+  If prop was empty, then X could not exist. On the other hand, if X was
+  empty, then there would be no need to provide the proof at all.
+  In any case, the symptom for X remaining free at the end of a proof is
+  one or more goals delayed on it. We never check for them and we have
+  no way atm to do that. See bug -3)
+
+-2) the test apply_2 is very slow: why?
+    same for the witness for myprop
+
+0) definitions must not be recursive; typing should capture it
+   (but not if declare_constraint is commented out...)
+
+0.25) occurr check in bind case still missing :-(
+
+0.50) case AppUvar vs AppUVar in unification is bugged (e.g.)
+      X^2 x0 x1 = X^2 x0 x1
+
+2) we need to fix the ELPI problems about handling of metavariables.
+ I have already discussed with Enrico about them and he could have a
+ shot at them. Namely:
+ a) occur check + optimization to avoid it when possible (IN PROGRESS)
+ b) unimplemented cases of restriction (IN PROGRESS)
+
+3) once we let metavariables reach the goals, the current HOL-light 
+ tactic implementation becomes too fragile. We should let the user 
+ refer to hypotheses at least by number if not by name. But we better
+ have a bidirectional successor/predecessor via declare_constraint
+
+5) we could implement an automated theorem prover in lambdaProlog
+ that works or is interfaced with the HOL-light code. There are
+ complete provers like leanCOP 2.0 that are only 10 lines of code,
+ but use some Prolog tricks.
+
+6) we should do a small formalization, possibly developing a tactic,
+ to prove that everything is working. For example, a decision procedure
+ for rings or for linear inequations.
+
+*/

--- a/tests/sources/hollight_legacy.elpi
+++ b/tests/sources/hollight_legacy.elpi
@@ -90,7 +90,7 @@ reterm (uvar as T) TY :- declare_constraint (reterm T TY) T.
 constraint term reterm { /* No propagation rules for now */}
 
 % thm : bounded tactic -> bounded sequent -> list (bounded sequent) -> o
-thm C (seq Gamma G) _ :- debug, $print Gamma "|- " G " := " C, fail.
+thm C (seq Gamma G) _ :- debug, print Gamma "|- " G " := " C, fail.
 
 /* << HACKS FOR DEBUGGING */
 thm daemon (seq Gamma F) [].
@@ -118,7 +118,7 @@ thm (thenll TAC1 TACN) SEQ SEQS :-
 
 /*debprint _ (then _ _) :- !.
 debprint _ (thenl _ _) :- !.
-debprint O T :- $print O T.*/
+debprint O T :- print O T.*/
 
 thm TAC SEQ SEQS :-
  deftac TAC SEQ XTAC,
@@ -142,10 +142,10 @@ thm (bind A TAC) (bind A SEQ) NEWL :-
 thm ww (bind A x \ SEQ) [ SEQ ].
 
 /* debuggin only, remove it */
-%thm A B C :- $print "FAILED " (thm A B C), fail.
+%thm A B C :- print "FAILED " (thm A B C), fail.
 
 % loop : list (bounded sequent) -> certificate -> o
-%loop SEQS TACS :- $print "LOOP" (loop SEQS TACS), fail.
+%loop SEQS TACS :- print "LOOP" (loop SEQS TACS), fail.
 loop [] CERTIFICATE :- end_of_proof CERTIFICATE.
 loop [ SEQ | OLD ] CERTIFICATE :-
  next_tactic [ SEQ | OLD ] CERTIFICATE ITAC,
@@ -155,22 +155,22 @@ loop [ SEQ | OLD ] CERTIFICATE :-
  loop SEQS NEW_CERTIFICATE.
 
 prove G TACS :-
- (term G prop, ! ; ppterm PG G, $print "Bad statement:" PG, fail),
+ (term G prop, ! ; ppterm PG G, print "Bad statement:" PG, fail),
 % (TACS = (false,_), ! ;
  loop [ seq [] G ] TACS
 . % ).
 
 not_defined P NAME :-
- not (P NAME _) ; $print "Error:" NAME already defined, fail.
+ not (P NAME _) ; print "Error:" NAME already defined, fail.
 
 check_hyps HS (typ' TYPE) :-
- (not (typ' TYPE) ; $print "Error:" TYPE already defined, fail), $print HS new TYPE.
-check_hyps HS (def0 NAME DEF) :- ppterm PDEF DEF, $print HS NAME "=" PDEF.
+ (not (typ' TYPE) ; print "Error:" TYPE already defined, fail), print HS new TYPE.
+check_hyps HS (def0 NAME DEF) :- ppterm PDEF DEF, print HS NAME "=" PDEF.
 check_hyps HS (term NAME TYPE) :-
- not_defined term NAME, ppterm PTYPE TYPE, $print HS NAME ":" PTYPE.
+ not_defined term NAME, ppterm PTYPE TYPE, print HS NAME ":" PTYPE.
 check_hyps HS (reterm _ _).
 check_hyps HS (provable NAME TYPE) :-
- not_defined provable NAME, ppterm PTYPE TYPE, $print HS NAME ":" PTYPE.
+ not_defined provable NAME, ppterm PTYPE TYPE, print HS NAME ":" PTYPE.
 check_hyps HS (H1,H2) :- check_hyps HS H1, check_hyps HS H2.
 check_hyps HS (pi H) :- pi x \ typ' x => check_hyps [x | HS] (H x).
 check_hyps HS (_ => H2) :- check_hyps HS H2.
@@ -204,7 +204,7 @@ check1thm NAME (GOAL,TACTICS) (provable NAME GOAL) :-
 check1axm NAME (pi I) (pi HYPS) :- !,
  pi x \ typ' x => check1axm NAME (I x) (HYPS x).
 check1axm NAME GOAL (provable NAME GOAL) :-
- term GOAL prop, ! ; ppterm PGOAL GOAL, $print "Bad statement:" PGOAL, fail.
+ term GOAL prop, ! ; ppterm PGOAL GOAL, print "Bad statement:" PGOAL, fail.
 
 check1nbt TYPE REP ABS REPABS ABSREP PREPH (pi P_TACTICS) HYPSUCHTHAT (pi HYPS) :-
  pi x \ typ' x => check1nbt (TYPE '' x) (REP '' x) (ABS '' x) REPABS ABSREP PREPH (P_TACTICS x) (HYPSUCHTHAT, typ x) (HYPS x).
@@ -227,7 +227,7 @@ check1nbt TYPE REP ABS REPABS ABSREP PREPH (P,TACTICS) HYPSUCHTHAT HYPS :-
 
 check WHAT :-
  next_object WHAT C CONT,
- (C = stop, !, K = true ; check1 C H , check_hyps [] H, $print_constraints, K = (H => check CONT)),
+ (C = stop, !, K = true ; check1 C H , check_hyps [] H, print_constraints, K = (H => check CONT)),
  !, K.
 
 }
@@ -313,7 +313,7 @@ parse_axiom PST ST :- parseterm PST ST.
 parse_thm NAME (pi I) (pi O) :- pi x \ parse_thm NAME (I x) (O x).
 parse_thm _ (PST,TAC) (ST,(false,TAC)) :- !, parseterm PST ST.
 parse_thm NAME PST (ST,(true,[_])) :-
- (not (proves NAME _) ; $print "Error:" NAME already defined, fail),
+ (not (proves NAME _) ; print "Error:" NAME already defined, fail),
  parseterm PST ST.
 
 parse_nbt (pi I) (pi O) :- !, pi x \ parse_nbt (I x) (O x).
@@ -323,12 +323,12 @@ parse_nbt PP (P,(true,[_])) :- parseterm PP P.
 next_object [ C | NEXT ] CT CONTNEXT :-
   parse_obj C [ CT | CONT ], append CONT NEXT CONTNEXT.
 next_object [] C CONT :- 
- $print "Welcome to HOL extra-light",
+ print "Welcome to HOL extra-light",
  toplevel_loop [ C | CONT ].
 next_object toplevel C CONT :- toplevel_loop [ C | CONT ].
 
 read_cmd H :-
- $print "Enter a command or \"stop.\"",
+ print "Enter a command or \"stop.\"",
  flush std_out, $readterm std_in H,
  !.
 read_cmd H :- read_cmd H.
@@ -336,26 +336,26 @@ read_cmd H :- read_cmd H.
 toplevel_loop G :-
  read_cmd H,
  ( H = stop, !, G = [stop]
- ; parse_obj H PH, !, (append PH toplevel G ; $print "error", toplevel_loop G)
- ; $print "bad command", toplevel_loop G ).
+ ; parse_obj H PH, !, (append PH toplevel G ; print "error", toplevel_loop G)
+ ; print "bad command", toplevel_loop G ).
 
 callback_proved _ _ (false,_).
 callback_proved NAME G (true, [ TAC ]) :-
  canonical TAC CANONICALTAC,
  pptac PCANONICALTAC CANONICALTAC,
  ppterm PG G,
- $print (theorem NAME (PG , [ PCANONICALTAC ] )).
+ print (theorem NAME (PG , [ PCANONICALTAC ] )).
 
-end_of_proof (true, []) :- $print "proof completed".
+end_of_proof (true, []) :- print "proof completed".
 end_of_proof (false, []).
 
 next_tactic0 [ SEQ | OLD ] (true, [ _ | _ ]) ITAC :-
- $print,
+ print,
  list_iter_rev [ SEQ | OLD ] print_sequent,
  read_in_context SEQ ITAC BACKTRACK,
  BACKTRACK.
 next_tactic0 SEQS (true, CERT) ITAC :-
- $print "error",
+ print "error",
  next_tactic SEQS (true, CERT) ITAC.
 next_tactic0 SEQS (true_then_false, (_,INT_TACS,_)) ITAC :-
  next_tactic0 SEQS (true, INT_TACS) ITAC.
@@ -363,7 +363,7 @@ next_tactic0 SEQS (false, [ interactive | _ ]) ITAC :-
  next_tactic0 SEQS (true, [ _ ]) ITAC.
 next_tactic0 [ SEQ | OLD ] (false, [ TAC | _ ]) TAC.
 next_tactic0 _ (false, _) ITAC :-
- $print "aborted",
+ print "aborted",
  halt.
 
 next_tactic SEQS CERT TAC :- next_tactic0 SEQS CERT PTAC, parsetac PTAC TAC.
@@ -380,10 +380,10 @@ update_certificate (true_then_false, (SCRIPT,[ TAC | OTHER_TACS ],NON_INTERACTIV
    CERTIFICATE =
     (true_then_false, (SCRIPT,INTERACTIVE_TACS,NON_INTERACTIVE_TACS))
  ; CERTIFICATE = (false, NON_INTERACTIVE_TACS),
-   $print "INTERACTIVE SUBPROOF COMPLETED",
+   print "INTERACTIVE SUBPROOF COMPLETED",
    canonical SCRIPT CSCRIPT,
    pptac PSCRIPT CSCRIPT,
-   $print PSCRIPT).
+   print PSCRIPT).
 update_certificate (false, [ _ | OTHER_TACS ]) _ _ (false, OTHER_TACS).
 
 mk_script (bind A T) NEW NEW_TACS (bind A T2) :- !,
@@ -401,10 +401,10 @@ read_in_context (seq A B) TAC BACKTRACK :-
  (TAC = backtrack, !, BACKTRACK = (!, fail) ; BACKTRACK = true).
 
 print_sequent (seq Gamma G) :-
- $print,
- list_iter_rev Gamma (x \ sigma PX \ ppterm PX x, $print PX),
- $print "|------------------",
- ppterm PG G, $print PG.
+ print,
+ list_iter_rev Gamma (x \ sigma PX \ ppterm PX x, print PX),
+ print "|------------------",
+ ppterm PG G, print PG.
 print_sequent (bind A F) :- pi x \ print_sequent (F x).
 
 /* turns thenl into then */
@@ -633,7 +633,7 @@ deftac (repeat! TAC) SEQ (orelse! (then! TAC (repeat! (bind* TAC))) id).
 
 ppptac (pptac TAC) (pptac PTAC) :- ppptac TAC PTAC.
 deftac (pptac TAC) SEQ TAC :-
- $print "SEQ" SEQ ":=" TAC.
+ print "SEQ" SEQ ":=" TAC.
 
 ppptac (time TAC) (time PTAC) :- ppptac TAC PTAC.
 deftac (time TAC) SEQ XTAC :-
@@ -645,7 +645,7 @@ deftacl (time_after TAC B) SEQS TACL :-
  $gettimeofday A,
  D is A - B,
  mk_constant_list SEQS id TACL,
- $print "TIME SPENT " D "FOR" TAC.
+ print "TIME SPENT " D "FOR" TAC.
 
 /* For debugging only (?) For capturing metavariables */
 ppptac (inspect (seq Gamma F) TAC) (inspect (seq PGamma PF) PTAC) :-
@@ -961,7 +961,7 @@ deftac (sync N) (seq _ (exists '' _ ' _)) (then (applyth exists_i) (then (conv b
 ppptac (itaut N) (itaut N).
 deftac (itaut N) SEQ fail :- N =< 0, !.
 deftac (itaut N) SEQ TAC :-
- %$print (itaut N) SEQ,
+ %print (itaut N) SEQ,
  N1 is N - 1,
  N2 is N - 2,
  TAC =

--- a/tests/sources/holp/hc_interp.mod
+++ b/tests/sources/holp/hc_interp.mod
@@ -12,15 +12,15 @@ type   backchain   (list form) -> form -> o.
 type   try_clause  (list form) -> form -> form -> o.
 
 hc_interp Cs (some B)  :- !, hc_interp Cs (B T).
-hc_interp Cs (B and C) :- !, hc_interp Cs B, hc_interp Cs C.
-hc_interp Cs (B or C) :- !, (hc_interp Cs B ; hc_interp Cs C).
+hc_interp Cs (B `and C) :- !, hc_interp Cs B, hc_interp Cs C.
+hc_interp Cs (B `or C) :- !, (hc_interp Cs B ; hc_interp Cs C).
 hc_interp Cs A  :-  backchain Cs A.
 
 backchain Cs A :- memb D Cs, try_clause Cs D A.
 
-try_clause Cs (D1 and D2) A :- 
+try_clause Cs (D1 `and D2) A :- 
      !, (try_clause Cs D1 A ; try_clause Cs D2 A).
 try_clause Cs (all D) A :- !, try_clause Cs (D T) A. 
 try_clause Cs A A.
-try_clause Cs (G imp A) A :- hc_interp Cs G.
+try_clause Cs (G `imp A) A :- hc_interp Cs G.
 

--- a/tests/sources/holp/hc_syntax.mod
+++ b/tests/sources/holp/hc_syntax.mod
@@ -7,11 +7,11 @@
 module  hc_syntax.
 
 goal tru.
-goal (B and C) :- goal B, goal C.
-goal (B or C)  :- goal B, goal C.
+goal (B `and C) :- goal B, goal C.
+goal (B `or C)  :- goal B, goal C.
 goal (some C) :- pi X \ ((termp X) => (goal (C X))).
 goal A :- atom A.
 
 def_clause (all C)   :- pi X \ ((termp X) => (def_clause (C X))).
-def_clause (G imp A) :- atom A, goal G.
+def_clause (G `imp A) :- atom A, goal G.
 def_clause A :- atom A.

--- a/tests/sources/holp/hcinterp_examples.mod
+++ b/tests/sources/holp/hcinterp_examples.mod
@@ -12,9 +12,9 @@ accum_sig  logic_basic.
 type   prog  (list form) -> o.
 
 prog ((adj a b) :: (adj b c) :: (adj c (f c)) ::
-      (all X\ (all Y\ ((adj X Y) imp (path X Y))))  ::
-      (all X\ (all Y\ (all Z\ ( ((adj X Y) and (path Y Z)) 
-                                           imp (path X Z))))) :: nil).
+      (all X\ (all Y\ ((adj X Y) `imp (path X Y))))  ::
+      (all X\ (all Y\ (all Z\ ( ((adj X Y) `and (path Y Z)) 
+                                           `imp (path X Z))))) :: nil).
 
 pathfroma X :- prog Cs, hc_interp Cs (path a X).
 

--- a/tests/sources/holp/hcsyntax_examples.mod
+++ b/tests/sources/holp/hcsyntax_examples.mod
@@ -9,14 +9,14 @@ module  hcsyntax_examples.
 accumulate  hc_syntax, refl_syntax.
 
 /* some sample formulas */
-formula  1  (some x \ ((path a x) and (path x b))).
-formula  2  (some x \ ((path a x) imp (path x b))).
-formula  3  ((path a b) and (path b a)).
-formula  4  ((path a b) imp (path b a)).
+formula  1  (some x \ ((path a x) `and (path x b))).
+formula  2  (some x \ ((path a x) `imp (path x b))).
+formula  3  ((path a b) `and (path b a)).
+formula  4  ((path a b) `imp (path b a)).
 
-formula  5  ((path a b) imp (adj a b)).
-formula  6  (all x\ all y\ ((path x y) imp (adj x y))).
-formula  7  (all x\ all y\ (((path x y) imp (adj x y)) imp (adj x y))).
+formula  5  ((path a b) `imp (adj a b)).
+formula  6  (all x\ all y\ ((path x y) `imp (adj x y))).
+formula  7  (all x\ all y\ (((path x y) `imp (adj x y)) `imp (adj x y))).
 
 /* testing whether or not one of the formulas above is a goal or a clause */
 test_goal N :- formula N F, goal F. 

--- a/tests/sources/holp/logic_basic.sig
+++ b/tests/sources/holp/logic_basic.sig
@@ -11,14 +11,8 @@ accum_sig  logic_types.
 generalized quantifiers */
 type   perp    form.
 type   tru     form.
-type   and     form -> form -> form.
-type   or      form -> form -> form.
-type   imp     form -> form -> form.
+type   (`and)     form -> form -> form.
+type   (`or)      form -> form -> form.
+type   (`imp)     form -> form -> form.
 type   all     (term -> form) -> form.
 type   some    (term -> form) -> form.
-
-
-/* Some operator declarations for syntactic convenience */
-infixr  and   120.
-infixr  or    120.
-infixr  imp   110.

--- a/tests/sources/holp/main.mod
+++ b/tests/sources/holp/main.mod
@@ -16,13 +16,13 @@ main :- pathfroma X,
         test_defcl 4,
         test_defcl 5,
         test_defcl 6,
-        test 1 F1, F1 = some (x\ path a x imp tru), 
-        test 2 F2, F2 = all (x\ path a x imp tru),
-        test 3 F3, F3 = all (x\ path a x and path x a),
-        test 3 F31, F31 = all (x\ all (y\ path a x and path y a)),
-        test 3 F32, F32 = all (x\ all (y\ path a y and path x a)),
-        test 4 F4, F4 = all (x\ all (y\ path a x imp path a y)),
-        test 4 F5, F5 = all (x\ all (y\ path a y imp path a x)).
+        test 1 F1, F1 = some (x\ path a x `imp tru), 
+        test 2 F2, F2 = all (x\ path a x `imp tru),
+        test 3 F3, F3 = all (x\ path a x `and path x a),
+        test 3 F31, F31 = all (x\ all (y\ path a x `and path y a)),
+        test 3 F32, F32 = all (x\ all (y\ path a y `and path x a)),
+        test 4 F4, F4 = all (x\ all (y\ path a x `imp path a y)),
+        test 4 F5, F5 = all (x\ all (y\ path a y `imp path a x)).
 
 
 

--- a/tests/sources/holp/pnf.mod
+++ b/tests/sources/holp/pnf.mod
@@ -10,9 +10,9 @@ module  pnf.
 type  merge  (form -> form -> o).
 
 (prenex B B) :- (quant_free B), !. 
-(prenex (B and C) D) :- (prenex B U), (prenex C V), (merge (U and V) D).
-(prenex (B or C) D) :- (prenex B U), (prenex C V), (merge (U or V) D).
-(prenex (B imp C) D) :- (prenex B U), (prenex C V), (merge (U imp V) D).
+(prenex (B `and C) D) :- (prenex B U), (prenex C V), (merge (U `and V) D).
+(prenex (B `or C) D) :- (prenex B U), (prenex C V), (merge (U `or V) D).
+(prenex (B `imp C) D) :- (prenex B U), (prenex C V), (merge (U `imp V) D).
 (prenex (all B) (all D)) :- (pi X\ ((termp X) => (prenex (B X) (D X)))).
 
 (prenex (some B) (some D)) :- (pi X\ ((termp X) => (prenex (B X) (D X)))).
@@ -21,39 +21,39 @@ type  merge  (form -> form -> o).
 /* This predicate is for moving out quantifiers appearing at the head of the 
 immediate subformulas of a formula with a propositional connective as its 
 top-level symbol */
-(merge ((all B) and (all C)) (all D)) :-
-       (pi X\ ((termp X) => (merge ((B X) and (C X)) (D X)))).
-(merge ((all B) and C) (all D)) :- 
-       (pi X\ ((termp X) => (merge ((B X) and C) (D X)))).
-(merge (B and (all C)) (all D)) :- 
-       (pi X\ ((termp X) => (merge (B and (C X)) (D X)))).
+(merge ((all B) `and (all C)) (all D)) :-
+       (pi X\ ((termp X) => (merge ((B X) `and (C X)) (D X)))).
+(merge ((all B) `and C) (all D)) :- 
+       (pi X\ ((termp X) => (merge ((B X) `and C) (D X)))).
+(merge (B `and (all C)) (all D)) :- 
+       (pi X\ ((termp X) => (merge (B `and (C X)) (D X)))).
 
-(merge ((some B) and C) (some D)) :- 
-       (pi X\ ((termp X) => (merge ((B X) and C) (D X)))).
-(merge (B and (some C)) (some D)) :-
-       (pi X\ ((termp X) => (merge (B and (C X)) (D X)))).
+(merge ((some B) `and C) (some D)) :- 
+       (pi X\ ((termp X) => (merge ((B X) `and C) (D X)))).
+(merge (B `and (some C)) (some D)) :-
+       (pi X\ ((termp X) => (merge (B `and (C X)) (D X)))).
 
-(merge ((all B) or C) (all D)) :-
-       (pi X\ ((termp X) => (merge ((B X) or C) (D X)))).
-(merge (B or (all C)) (all D)) :-
-       (pi X\ ((termp X) => (merge (B or (C X)) (D X)))).
-(merge ((some B) or (some C)) (some D)) :-
-       (pi X\ ((termp X) => (merge ((B X) or (C X)) (D X)))).
-(merge ((some B) or C) (some D)):-
-       (pi X\ ((termp X) => (merge ((B X) or C) (D X)))).
-(merge (B or (some C)) (some D)) :-
-       (pi X\ ((termp X) => (merge (B or (C X)) (D X)))).
+(merge ((all B) `or C) (all D)) :-
+       (pi X\ ((termp X) => (merge ((B X) `or C) (D X)))).
+(merge (B `or (all C)) (all D)) :-
+       (pi X\ ((termp X) => (merge (B `or (C X)) (D X)))).
+(merge ((some B) `or (some C)) (some D)) :-
+       (pi X\ ((termp X) => (merge ((B X) `or (C X)) (D X)))).
+(merge ((some B) `or C) (some D)):-
+       (pi X\ ((termp X) => (merge ((B X) `or C) (D X)))).
+(merge (B `or (some C)) (some D)) :-
+       (pi X\ ((termp X) => (merge (B `or (C X)) (D X)))).
 
-(merge ((all B) imp (some C)) (some D)) :- 
-       (pi X\ ((termp X) => (merge ((B X) imp (C X)) (D X)))).
-(merge ((all B) imp C) (some D)) :- 
-       (pi X\ ((termp X) => (merge ((B X) imp C) (D X)))).
-(merge ((some B) imp C) (all D)) :-
-       (pi X\ ((termp X) => (merge ((B X) imp C) (D X)))).
-(merge (B imp (all C)) (all D)) :-
-       (pi X\ ((termp X) => (merge (B imp (C X)) (D X)))).
-(merge (B imp (some C)) (some D)) :-
-       (pi X\ ((termp X) => (merge (B imp (C X)) (D X)))).
+(merge ((all B) `imp (some C)) (some D)) :- 
+       (pi X\ ((termp X) => (merge ((B X) `imp (C X)) (D X)))).
+(merge ((all B) `imp C) (some D)) :- 
+       (pi X\ ((termp X) => (merge ((B X) `imp C) (D X)))).
+(merge ((some B) `imp C) (all D)) :-
+       (pi X\ ((termp X) => (merge ((B X) `imp C) (D X)))).
+(merge (B `imp (all C)) (all D)) :-
+       (pi X\ ((termp X) => (merge (B `imp (C X)) (D X)))).
+(merge (B `imp (some C)) (some D)) :-
+       (pi X\ ((termp X) => (merge (B `imp (C X)) (D X)))).
 
 (merge B B) :- (quant_free B).
 

--- a/tests/sources/holp/pnf_examples.mod
+++ b/tests/sources/holp/pnf_examples.mod
@@ -9,10 +9,10 @@ accumulate  refl_syntax, pnf.
 
 type  formula  int -> form -> o.
 
-formula 1  ((all (X \ (path a X))) imp tru).
-formula 2  ((some (X \ (path a X))) imp tru).
-formula 3  ((all (X \ (path a X))) and (all (Y \ (path Y a)))).
-formula 4  ((some (X \ (path a X))) imp ((all (Y \ (path a Y))))).
+formula 1  ((all (X \ (path a X))) `imp tru).
+formula 2  ((some (X \ (path a X))) `imp tru).
+formula 3  ((all (X \ (path a X))) `and (all (Y \ (path Y a)))).
+formula 4  ((some (X \ (path a X))) `imp ((all (Y \ (path a Y))))).
 
 (test N F) :- (formula N OF), (prenex OF F).
 

--- a/tests/sources/holp/refl_syntax.mod
+++ b/tests/sources/holp/refl_syntax.mod
@@ -25,7 +25,7 @@ atom (adj X Y) :- termp X, termp Y.
 quant_free perp.
 quant_free tru.
 quant_free A :- atom A.
-quant_free (B and C) :- quant_free B, quant_free C.
-quant_free (B or C) :- quant_free B, quant_free C.
-quant_free (B imp C) :- quant_free B, quant_free C.
+quant_free (B `and C) :- quant_free B, quant_free C.
+quant_free (B `or C) :- quant_free B, quant_free C.
+quant_free (B `imp C) :- quant_free B, quant_free C.
 

--- a/tests/sources/holp_legacy/README
+++ b/tests/sources/holp_legacy/README
@@ -1,0 +1,60 @@
+ *****************************************************************************
+ *                                                                           *
+ * The code in this directory is based on material in the paper              *
+ *                                                                           *
+ *     G. Nadathur and D. Miller, Higher-Order Logic Programming, in         *
+ *     Handbook of Logic in Artificial Intelligence and Logic                *
+ *     Programming, D. M. Gabbay, C. J. Hogger and J. A. Robinson (eds.),    *
+ *     Oxford University Press, January 1998, pages 499--590.                *
+ *                                                                           *
+ * The adaptation to Teyjus code is due to Gopalan Nadathur.                 *
+ *                                                                           *
+ *****************************************************************************
+	
+The important conceptual content of the code is the use of
+higher-order abstract syntax in representing quantification structure
+in formulas and of beta reduction, higher-order unification and the
+scoping primitives in probing this structure.
+
+The contents of particular files are as follows:
+
+lists.sig,               Interface and defining code for a collection
+lists.mod                of list manipulation predicates
+
+logic_types.sig          A file defining the kinds used in the 
+                         encoding of a first-order logic
+
+logic_basic.sig          A file defining the constructors used in 
+                         encoding the logical symbols
+
+logic_vocab.sig          A file encoding the nonlogical vocabulary 
+                         for a first-order logic
+
+hc_interp.sig            A interpreter for Horn clauses logic
+hc_interp.mod 
+
+hcinterp_examples.sig    Code for testing out the Horn clause logic
+hcinterp_examples.mod    interpreter
+
+refl_syntax.sig          Files defining the signature and clauses
+refl_syntax.mod          for recognizing quantifier free expressions
+                         in the logic
+
+hc_syntax.sig            Files defining the signature and clauses
+hc_syntax.mod            for recognizing goals and definite clauses
+                         in the Horn clause fragment of logic
+
+hcsyntax_examples.sig    Code for testing out the Horn clause logic
+hcsyntax_examples.mod    recognizers
+
+pnf.sig                  A prenex normal form transformer for 
+pnf.mod                  formulas
+
+pnf_examples.sig         Code for testing out the prenex-normal form 
+pnf_examples.mod         transformer
+
+script1,                 Scripts exhibiting the compilation and execution
+script2,                 of the code for the Horn clause interpreter, 
+script3                  formula recognizer and prenex normal form 
+                         transformer
+

--- a/tests/sources/holp_legacy/hc_interp.mod
+++ b/tests/sources/holp_legacy/hc_interp.mod
@@ -1,0 +1,26 @@
+/*
+ * An interpreter for the logic of Horn clauses. This code illustrates 
+ * the usefulness of beta reduction in realizing substitution. Also note
+ * the use of the logic variable in the third clause for try_clause.
+ */
+
+module  hc_interp.
+
+accumulate lists.
+
+type   backchain   (list form) -> form -> o.
+type   try_clause  (list form) -> form -> form -> o.
+
+hc_interp Cs (some B)  :- !, hc_interp Cs (B T).
+hc_interp Cs (B and C) :- !, hc_interp Cs B, hc_interp Cs C.
+hc_interp Cs (B or C) :- !, (hc_interp Cs B ; hc_interp Cs C).
+hc_interp Cs A  :-  backchain Cs A.
+
+backchain Cs A :- memb D Cs, try_clause Cs D A.
+
+try_clause Cs (D1 and D2) A :- 
+     !, (try_clause Cs D1 A ; try_clause Cs D2 A).
+try_clause Cs (all D) A :- !, try_clause Cs (D T) A. 
+try_clause Cs A A.
+try_clause Cs (G imp A) A :- hc_interp Cs G.
+

--- a/tests/sources/holp_legacy/hc_interp.sig
+++ b/tests/sources/holp_legacy/hc_interp.sig
@@ -1,0 +1,11 @@
+/* 
+ * Interface to code that implements an interpreter for Horn
+ * clause logic
+ */
+
+sig  hc_interp. 
+
+accum_sig  logic_types, logic_basic, logic_vocab.
+
+exportdef  hc_interp   (list form) -> form -> o.
+

--- a/tests/sources/holp_legacy/hc_syntax.mod
+++ b/tests/sources/holp_legacy/hc_syntax.mod
@@ -1,0 +1,17 @@
+/* 
+ * Predicates that recognize goal and clause structure in the logic of 
+ * Horn clauses. This code illustrates how recursion over abstraction 
+ * structure is programmed in Lambda Prolog
+ */
+
+module  hc_syntax.
+
+goal tru.
+goal (B and C) :- goal B, goal C.
+goal (B or C)  :- goal B, goal C.
+goal (some C) :- pi X \ ((termp X) => (goal (C X))).
+goal A :- atom A.
+
+def_clause (all C)   :- pi X \ ((termp X) => (def_clause (C X))).
+def_clause (G imp A) :- atom A, goal G.
+def_clause A :- atom A.

--- a/tests/sources/holp_legacy/hc_syntax.sig
+++ b/tests/sources/holp_legacy/hc_syntax.sig
@@ -1,0 +1,18 @@
+/*
+ * Interface to code for recognizing formula categories in Horn 
+ * clause logic
+ */
+
+sig  hc_syntax. 
+
+accum_sig  logic_types, logic_basic. 
+
+/* an `input' predicate---only its definition is used here */
+useonly     atom         form -> o.
+
+/* this predicate is used and its definition may be changed */
+type        termp        term -> o.
+
+/* `output' predicates---this module supplies their complete definition */
+exportdef   goal         form -> o.
+exportdef   def_clause   form -> o.

--- a/tests/sources/holp_legacy/hcinterp_examples.mod
+++ b/tests/sources/holp_legacy/hcinterp_examples.mod
@@ -1,0 +1,20 @@
+/*
+ * A harness for testing an interpreter for a logic programming 
+ * language based on Horn clauses
+ */
+
+module  hcinterp_examples.
+
+accumulate  hc_interp.
+
+accum_sig  logic_basic. 
+
+type   prog  (list form) -> o.
+
+prog ((adj a b) :: (adj b c) :: (adj c (f c)) ::
+      (all X\ (all Y\ ((adj X Y) imp (path X Y))))  ::
+      (all X\ (all Y\ (all Z\ ( ((adj X Y) and (path Y Z)) 
+                                           imp (path X Z))))) :: nil).
+
+pathfroma X :- prog Cs, hc_interp Cs (path a X).
+

--- a/tests/sources/holp_legacy/hcinterp_examples.sig
+++ b/tests/sources/holp_legacy/hcinterp_examples.sig
@@ -1,0 +1,13 @@
+/*
+ * Interface to a harness for testing an interpreter for
+ * Horn clause logic
+ */
+
+sig  hcinterp_examples.
+
+accum_sig  logic_types, logic_vocab.
+
+type  pathfroma  term -> o.
+
+
+

--- a/tests/sources/holp_legacy/hcsyntax_examples.mod
+++ b/tests/sources/holp_legacy/hcsyntax_examples.mod
@@ -1,0 +1,23 @@
+/*
+ * A testing harness for code that analyzes the structure of formula
+ * representation; the particular analysis involves recognizing 
+ * goals and program clauses in Horn clause logic
+ */
+
+module  hcsyntax_examples.
+
+accumulate  hc_syntax, refl_syntax.
+
+/* some sample formulas */
+formula  1  (some x \ ((path a x) and (path x b))).
+formula  2  (some x \ ((path a x) imp (path x b))).
+formula  3  ((path a b) and (path b a)).
+formula  4  ((path a b) imp (path b a)).
+
+formula  5  ((path a b) imp (adj a b)).
+formula  6  (all x\ all y\ ((path x y) imp (adj x y))).
+formula  7  (all x\ all y\ (((path x y) imp (adj x y)) imp (adj x y))).
+
+/* testing whether or not one of the formulas above is a goal or a clause */
+test_goal N :- formula N F, goal F. 
+test_defcl N :- formula N F, def_clause F.

--- a/tests/sources/holp_legacy/hcsyntax_examples.sig
+++ b/tests/sources/holp_legacy/hcsyntax_examples.sig
@@ -1,0 +1,15 @@
+/*
+ * Interface to a testing harness for code that checks if formulas satisfy
+ * the structure of goals or program clauses in Horn clause logic
+ */
+
+sig  hcsyntax_examples. 
+
+accum_sig  logic_types, logic_basic, logic_vocab.
+
+type formula int -> form -> o.
+
+type  test_goal, test_defcl  int -> o.
+
+
+

--- a/tests/sources/holp_legacy/lists.mod
+++ b/tests/sources/holp_legacy/lists.mod
@@ -1,0 +1,41 @@
+% Some simple operations on lists.
+
+module	lists.
+
+kind  pairty   type -> type -> type.
+
+type  pair     A -> B -> (pairty A B).
+
+type  id       (list A) -> (list A) -> o.
+type  memb     A -> (list A) -> o.
+type  member   A -> (list A) -> o.
+type  append   (list A) -> (list A) -> (list A) -> o.
+type  join     (list A) -> (list A) -> (list A) -> o.
+type  assoc    A -> B -> (list (pairty A B)) -> o.
+type  domain   (list (pairty A B)) -> (list A) -> o.
+type  range   (list (pairty A B)) -> (list B) -> o.
+
+id nil nil.
+id (X::L) (X::K) :- id L K.
+
+memb X (X::L).
+memb X (Y::L) :- memb X L.
+
+member X (X::L) :- !.
+member X (Y::L) :- member X L.
+
+append nil K K.
+append (X::L) K (X::M) :- append L K M.
+
+join nil K K.
+join (X::L) K M :- memb X K, !, join L K M.
+join (X::L) K (X::M) :- join L K M.
+
+assoc X Y (pair X Y::L).
+assoc X Y (P::L) :- assoc X Y L.
+
+domain nil nil.
+domain (pair X Y::Alist) (X::L) :- domain Alist L.
+
+range nil nil.
+range (pair X Y::Alist) (Y::L) :- range Alist L.

--- a/tests/sources/holp_legacy/lists.sig
+++ b/tests/sources/holp_legacy/lists.sig
@@ -1,0 +1,15 @@
+sig lists.
+
+kind  pairty   type -> type -> type.
+
+type  pair     A -> B -> (pairty A B).
+
+exportdef  id       (list A) -> (list A) -> o.
+exportdef  memb     A -> (list A) -> o.
+exportdef  member   A -> (list A) -> o.
+exportdef  append   (list A) -> (list A) -> (list A) -> o.
+exportdef  join     (list A) -> (list A) -> (list A) -> o.
+exportdef  assoc    A -> B -> (list (pairty A B)) -> o.
+exportdef  domain   (list (pairty A B)) -> (list A) -> o.
+exportdef  range   (list (pairty A B)) -> (list B) -> o.
+

--- a/tests/sources/holp_legacy/logic_basic.sig
+++ b/tests/sources/holp_legacy/logic_basic.sig
@@ -1,0 +1,24 @@
+/*
+ * This file defines encodings for the logical symbols in a 
+ * first-order logic. 
+ */
+
+sig  logic_basic.
+
+accum_sig  logic_types.
+
+/* Constants encoding the logical symbols; note the types of the 
+generalized quantifiers */
+type   perp    form.
+type   tru     form.
+type   and     form -> form -> form.
+type   or      form -> form -> form.
+type   imp     form -> form -> form.
+type   all     (term -> form) -> form.
+type   some    (term -> form) -> form.
+
+
+/* Some operator declarations for syntactic convenience */
+infixr  and   120.
+infixr  or    120.
+infixr  imp   110.

--- a/tests/sources/holp_legacy/logic_types.sig
+++ b/tests/sources/holp_legacy/logic_types.sig
@@ -1,0 +1,8 @@
+/* The basic categories in our encoding of first-order logic; the sort
+term is the type of terms and form is the type of formulas */
+
+sig logic_types.
+
+kind   term   type.
+kind   form   type.
+

--- a/tests/sources/holp_legacy/logic_vocab.sig
+++ b/tests/sources/holp_legacy/logic_vocab.sig
@@ -1,0 +1,19 @@
+/* 
+ * This file defines encodings for the nonlogical symbols in a
+ * first-order logic
+ */
+
+sig  logic_vocab.
+
+accum_sig  logic_types.
+
+/* The constants and function symbols */
+type   a      term.
+type   b      term.
+type   c      term.
+type   f      term -> term.
+
+/* The predicate symbols */
+type   path   term -> term -> form.
+type   adj    term -> term -> form.
+

--- a/tests/sources/holp_legacy/main.mod
+++ b/tests/sources/holp_legacy/main.mod
@@ -1,0 +1,28 @@
+module main.
+
+accumulate hcinterp_examples.
+accumulate hcsyntax_examples.
+accumulate pnf_examples.
+
+only_three :- not (pathfroma X, not (X = b), not (X = c), not (X = (f c))).
+
+main :- pathfroma X,
+        pathfroma b,
+        pathfroma c,
+        pathfroma (f c),
+        only_three,
+        test_goal 1,
+        test_goal 3,
+        test_defcl 4,
+        test_defcl 5,
+        test_defcl 6,
+        test 1 F1, F1 = some (x\ path a x imp tru), 
+        test 2 F2, F2 = all (x\ path a x imp tru),
+        test 3 F3, F3 = all (x\ path a x and path x a),
+        test 3 F31, F31 = all (x\ all (y\ path a x and path y a)),
+        test 3 F32, F32 = all (x\ all (y\ path a y and path x a)),
+        test 4 F4, F4 = all (x\ all (y\ path a x imp path a y)),
+        test 4 F5, F5 = all (x\ all (y\ path a y imp path a x)).
+
+
+

--- a/tests/sources/holp_legacy/main.sig
+++ b/tests/sources/holp_legacy/main.sig
@@ -1,0 +1,4 @@
+sig main.
+
+type main o.
+type only_three o.

--- a/tests/sources/holp_legacy/pnf.mod
+++ b/tests/sources/holp_legacy/pnf.mod
@@ -1,0 +1,59 @@
+/*
+ * Predicates for transforming formulas into prenex normal form 
+ * assuming classical logic equivalences. This is an example of 
+ * analyzing formula structure, including recursion over bindings
+ * and generating modified structure based on this analysis
+ */
+
+module  pnf.
+
+type  merge  (form -> form -> o).
+
+(prenex B B) :- (quant_free B), !. 
+(prenex (B and C) D) :- (prenex B U), (prenex C V), (merge (U and V) D).
+(prenex (B or C) D) :- (prenex B U), (prenex C V), (merge (U or V) D).
+(prenex (B imp C) D) :- (prenex B U), (prenex C V), (merge (U imp V) D).
+(prenex (all B) (all D)) :- (pi X\ ((termp X) => (prenex (B X) (D X)))).
+
+(prenex (some B) (some D)) :- (pi X\ ((termp X) => (prenex (B X) (D X)))).
+
+
+/* This predicate is for moving out quantifiers appearing at the head of the 
+immediate subformulas of a formula with a propositional connective as its 
+top-level symbol */
+(merge ((all B) and (all C)) (all D)) :-
+       (pi X\ ((termp X) => (merge ((B X) and (C X)) (D X)))).
+(merge ((all B) and C) (all D)) :- 
+       (pi X\ ((termp X) => (merge ((B X) and C) (D X)))).
+(merge (B and (all C)) (all D)) :- 
+       (pi X\ ((termp X) => (merge (B and (C X)) (D X)))).
+
+(merge ((some B) and C) (some D)) :- 
+       (pi X\ ((termp X) => (merge ((B X) and C) (D X)))).
+(merge (B and (some C)) (some D)) :-
+       (pi X\ ((termp X) => (merge (B and (C X)) (D X)))).
+
+(merge ((all B) or C) (all D)) :-
+       (pi X\ ((termp X) => (merge ((B X) or C) (D X)))).
+(merge (B or (all C)) (all D)) :-
+       (pi X\ ((termp X) => (merge (B or (C X)) (D X)))).
+(merge ((some B) or (some C)) (some D)) :-
+       (pi X\ ((termp X) => (merge ((B X) or (C X)) (D X)))).
+(merge ((some B) or C) (some D)):-
+       (pi X\ ((termp X) => (merge ((B X) or C) (D X)))).
+(merge (B or (some C)) (some D)) :-
+       (pi X\ ((termp X) => (merge (B or (C X)) (D X)))).
+
+(merge ((all B) imp (some C)) (some D)) :- 
+       (pi X\ ((termp X) => (merge ((B X) imp (C X)) (D X)))).
+(merge ((all B) imp C) (some D)) :- 
+       (pi X\ ((termp X) => (merge ((B X) imp C) (D X)))).
+(merge ((some B) imp C) (all D)) :-
+       (pi X\ ((termp X) => (merge ((B X) imp C) (D X)))).
+(merge (B imp (all C)) (all D)) :-
+       (pi X\ ((termp X) => (merge (B imp (C X)) (D X)))).
+(merge (B imp (some C)) (some D)) :-
+       (pi X\ ((termp X) => (merge (B imp (C X)) (D X)))).
+
+(merge B B) :- (quant_free B).
+

--- a/tests/sources/holp_legacy/pnf.sig
+++ b/tests/sources/holp_legacy/pnf.sig
@@ -1,0 +1,16 @@
+/* 
+ * Interface for code for transforming formulas into prenex normal form
+ */
+
+sig  pnf.
+
+accum_sig  logic_types, logic_basic.
+
+/* this predicate definition is used but not changed */
+useonly  quant_free   form -> o.
+
+/* this definition changes in this module */
+type  termp        term -> o.
+
+/* this definition is exported */
+exportdef  prenex     form -> form -> o.

--- a/tests/sources/holp_legacy/pnf_examples.mod
+++ b/tests/sources/holp_legacy/pnf_examples.mod
@@ -1,0 +1,18 @@
+/*
+ * A harness for testing the transformation of formulas to prenex
+ * normal form
+ */
+
+module  pnf_examples. 
+
+accumulate  refl_syntax, pnf.
+
+type  formula  int -> form -> o.
+
+formula 1  ((all (X \ (path a X))) imp tru).
+formula 2  ((some (X \ (path a X))) imp tru).
+formula 3  ((all (X \ (path a X))) and (all (Y \ (path Y a)))).
+formula 4  ((some (X \ (path a X))) imp ((all (Y \ (path a Y))))).
+
+(test N F) :- (formula N OF), (prenex OF F).
+

--- a/tests/sources/holp_legacy/pnf_examples.sig
+++ b/tests/sources/holp_legacy/pnf_examples.sig
@@ -1,0 +1,12 @@
+/*
+ * Interface for testing the prenex normal form transformer
+ */
+
+sig  pnf_examples.
+
+accum_sig  logic_types, logic_basic, logic_vocab.
+
+/* this predicate definition is used but not changed */
+exportdef  test  int -> form -> o.
+
+

--- a/tests/sources/holp_legacy/refl_syntax.mod
+++ b/tests/sources/holp_legacy/refl_syntax.mod
@@ -1,0 +1,31 @@
+/*
+ * Predicates for recognizing some categories of quantifier-free expressions
+ * in a given object logic
+ */
+ 
+module  refl_syntax.
+
+accum_sig  logic_types, logic_basic, logic_vocab.
+
+type  termp        term -> o.
+type  atom         form -> o.
+type  quant_free   form -> o.
+
+/* recognizer for terms */
+termp a.
+termp b.
+termp c.
+termp (f X) :- termp X.
+
+/* recognizer for atomic formulas */
+atom (path X Y) :- termp X, termp Y.
+atom (adj X Y) :- termp X, termp Y.
+
+/* recognizer for quantifier free formulas */
+quant_free perp.
+quant_free tru.
+quant_free A :- atom A.
+quant_free (B and C) :- quant_free B, quant_free C.
+quant_free (B or C) :- quant_free B, quant_free C.
+quant_free (B imp C) :- quant_free B, quant_free C.
+

--- a/tests/sources/holp_legacy/refl_syntax.sig
+++ b/tests/sources/holp_legacy/refl_syntax.sig
@@ -1,0 +1,22 @@
+/*
+ * Interface to code for recognizing some categories of quantifier-free 
+ * expressions in a given object logic
+ */
+
+sig  refl_syntax.
+
+accum_sig  logic_types, logic_basic, logic_vocab.
+
+/* recognizer for terms */
+type  termp        term -> o.
+
+/* Recognizers for atomic and quantifier free formulas; the exportdef 
+declaration signifies that the definitions of these predicates is fixed
+by this module */
+exportdef  atom        form -> o.
+exportdef  quant_free  form -> o.
+
+
+
+
+

--- a/tests/sources/ndprover/formulas.mod
+++ b/tests/sources/ndprover/formulas.mod
@@ -11,15 +11,15 @@ kind	xname		type.
 type	formula		xname -> bool -> o.
 
 formula bugs
- (((heated jar) and (forall X\ ((bug X) imp (animal X))) and
-   (forall X\ (forall Y\ (((heated Y) and (in X Y) and (animal X))
-                            imp (dead X)))) and
-   (forall Y\ ((forall X\ (((in X Y) and (bug X)) imp (dead X)))
-    imp (sterile Y))))
-  imp (sterile jar)).
+ (((heated jar) && (forall X\ ((bug X) ==> (animal X))) &&
+   (forall X\ (forall Y\ (((heated Y) && ((in X Y) && (animal X)))
+                            ==> (dead X)))) &&
+   (forall Y\ ((forall X\ (((in X Y) && (bug X)) ==> (dead X)))
+    ==> (sterile Y))))
+  ==> (sterile jar)).
 
 
-formula baffler (some X\ (forall Y\ ((p X) imp (p Y)))).
+formula baffler (some X\ (forall Y\ ((p X) ==> (p Y)))).
 
-formula cases1 (((q a) or (q b)) imp (some X\ (q X))).
+formula cases1 (((q a) || (q b)) ==> (some X\ (q X))).
 

--- a/tests/sources/ndprover/inter.mod
+++ b/tests/sources/ndprover/inter.mod
@@ -20,16 +20,16 @@ type    write           A -> o.
 type    process_input   (goal -> goal -> o) -> goal -> goal -> o.
 
 inter_top Name P OutGoal :- formula Name Formula,
-  inter (nil --> P of_type Formula) OutGoal.
+  inter (nil --> P `of_type Formula) OutGoal.
 
 
-inter (Gamma --> P of_type A) NewGoal :-
+inter (Gamma --> P `of_type A) NewGoal :-
   nl, print "Assumptions: ",
   nl, print_form_list Gamma 1,
   nl, print "Conclusion: ",
   nl, write A, nl,
   print "Enter tactic: ", read Tac, write Tac,
-  process_input Tac (Gamma --> P of_type A) NewGoal.
+  process_input Tac (Gamma --> P `of_type A) NewGoal.
 
 process_input backup _ _ :- !, fail.
 process_input quitg NewGoal NewGoal :- !.
@@ -40,7 +40,7 @@ process_input _ OldGoal NewGoal :-
   inter OldGoal NewGoal. 
 
 print_form_list nil N.
-print_form_list ((P of_type A)::Tail) N :-
+print_form_list ((P `of_type A)::Tail) N :-
   write N, print " ", write A, nl,
   (N1 is (N + 1)),
   print_form_list Tail N1.

--- a/tests/sources/ndprover/logic.sig
+++ b/tests/sources/ndprover/logic.sig
@@ -8,14 +8,10 @@ sig logic.
 kind    i       type.
 kind    bool    type.
 
-type    and     bool -> bool -> bool.
-type    or      bool -> bool -> bool.
-type    imp     bool -> bool -> bool.
+type    (&&)     bool -> bool -> bool.
+type    (||)      bool -> bool -> bool.
+type    (==>)     bool -> bool -> bool.
 type    neg     bool -> bool.
 type    forall  (i -> bool) -> bool.
 type	some    (i -> bool) -> bool.
 type    perp    bool.
-
-infixr  and 140.
-infixr  or  140.
-infixr  imp 130.

--- a/tests/sources/ndprover/ndtac.mod
+++ b/tests/sources/ndprover/ndtac.mod
@@ -14,8 +14,8 @@ accumulate listmanip.
 kind    judgment	type.
 kind    answer		type.
 
-type    of_type		proof_object -> bool -> judgment.
-type    -->		(list judgment) -> judgment -> goal.
+type    (`of_type)		proof_object -> bool -> judgment.
+type    (-->)		(list judgment) -> judgment -> goal.
 
 type	yes		answer.
 
@@ -38,83 +38,80 @@ type	and_i_tac	goal -> goal -> o.
 type	close_tacn	int -> goal -> goal -> o.
 type	close_tac	goal -> goal -> o.
 
-infix   of_type 120.
-infix   --> 110.
+close_tac (Gamma --> (P `of_type A)) truegoal :-
+  member (P `of_type A) Gamma.
 
-close_tac (Gamma --> (P of_type A)) truegoal :-
-  member (P of_type A) Gamma.
+close_tacn N (Gamma --> P `of_type A) truegoal :-
+  nth_item N (P `of_type A) Gamma.
 
-close_tacn N (Gamma --> P of_type A) truegoal :-
-  nth_item N (P of_type A) Gamma.
+and_i_tac (Gamma --> (and_i P1 P2) `of_type A && B)
+          (andgoal (Gamma --> P1 `of_type A) (Gamma --> P2 `of_type B)).
 
-and_i_tac (Gamma --> (and_i P1 P2) of_type A and B)
-          (andgoal (Gamma --> P1 of_type A) (Gamma --> P2 of_type B)).
+or_i1_tac (Gamma --> (or_i1 P) `of_type A || B)
+          (Gamma --> P `of_type A).
 
-or_i1_tac (Gamma --> (or_i1 P) of_type A or B)
-          (Gamma --> P of_type A).
+or_i2_tac (Gamma --> (or_i2 P) `of_type A || B)
+          (Gamma --> P `of_type B).
 
-or_i2_tac (Gamma --> (or_i2 P) of_type A or B)
-          (Gamma --> P of_type B).
+imp_i_tac (Gamma --> (imp_i P) `of_type A ==> B)
+          (allgoal PA\ (((PA `of_type A) :: Gamma) --> (P PA) `of_type B)).
 
-imp_i_tac (Gamma --> (imp_i P) of_type A imp B)
-          (allgoal PA\ (((PA of_type A) :: Gamma) --> (P PA) of_type B)).
+forall_i_tac (Gamma --> (forall_i P) `of_type forall A)
+             (allgoal T\ (Gamma --> (P T) `of_type (A T))).
 
-forall_i_tac (Gamma --> (forall_i P) of_type forall A)
-             (allgoal T\ (Gamma --> (P T) of_type (A T))).
+exists_i_tac (Gamma --> (exists_i T P) `of_type some A)
+             (Gamma --> P `of_type (A T)).
 
-exists_i_tac (Gamma --> (exists_i T P) of_type some A)
-             (Gamma --> P of_type (A T)).
-
-exists_i_query (Gamma --> (exists_i T P) of_type some A)
-               (Gamma --> P of_type (A T)) :-
+exists_i_query (Gamma --> (exists_i T P) `of_type some A)
+               (Gamma --> P `of_type (A T)) :-
   print "Enter substitution term: ", read T.
 
-and_e_tac N (Gamma --> PC of_type C)
-            ((((and_e1 P) of_type A) :: (((and_e2 P) of_type B) :: Gamma1)) 
-                     --> PC of_type C) :-
-  nth_item_and_rest N (P of_type A and B) Gamma Gamma1.
+and_e_tac N (Gamma --> PC `of_type C)
+            ((((and_e1 P) `of_type A) :: (((and_e2 P) `of_type B) :: Gamma1)) 
+                     --> PC `of_type C) :-
+  nth_item_and_rest N (P `of_type A && B) Gamma Gamma1.
 
-imp_e_tac N (Gamma --> PC of_type C)
-            (andgoal (Gamma1 --> PA of_type A)
-                     ((((imp_e PA P) of_type B)::Gamma1) --> PC of_type C)) :-
-  nth_item_and_rest N (P of_type A imp B) Gamma Gamma1.
+imp_e_tac N (Gamma --> PC `of_type C)
+            (andgoal (Gamma1 --> PA `of_type A)
+                     ((((imp_e PA P) `of_type B)::Gamma1) --> PC `of_type C)) :-
+  nth_item_and_rest N (P `of_type A ==> B) Gamma Gamma1.
 
-imp_e_retain N (Gamma --> PC of_type C)
-               (andgoal (Gamma --> PA of_type A)
-                        ((((imp_e PA P) of_type B) :: Gamma) 
-                                        --> PC of_type C)) :-
-  nth_item N (P of_type A imp B) Gamma.
+imp_e_retain N (Gamma --> PC `of_type C)
+               (andgoal (Gamma --> PA `of_type A)
+                        ((((imp_e PA P) `of_type B) :: Gamma) 
+                                        --> PC `of_type C)) :-
+  nth_item N (P `of_type A ==> B) Gamma.
 
-bchain_tac N (Gamma --> (imp_e PA P) of_type B)
-             (Gamma1 --> PA of_type A) :-
-  nth_item_and_rest N (P of_type A imp B) Gamma Gamma1.
+bchain_tac N (Gamma --> (imp_e PA P) `of_type B)
+             (Gamma1 --> PA `of_type A) :-
+  nth_item_and_rest N (P `of_type A ==> B) Gamma Gamma1.
 
-fchain_tac N (Gamma --> PC of_type C)
-             ((((imp_e PA P) of_type B)::Gamma2) --> PC of_type C) :-
-  nth_item_and_rest N (P of_type A imp B) Gamma Gamma1,
-  member_and_rest (PA of_type A) Gamma1 Gamma2.
+fchain_tac N (Gamma --> PC `of_type C)
+             ((((imp_e PA P) `of_type B)::Gamma2) --> PC `of_type C) :-
+  nth_item_and_rest N (P `of_type A ==> B) Gamma Gamma1,
+  member_and_rest (PA `of_type A) Gamma1 Gamma2.
 
-forall_e_tac N (Gamma --> PC of_type C)
-               ((((forall_e T P) of_type (A T)) :: Gamma1) --> PC of_type C) :-
-  nth_item_and_rest N (P of_type forall A) Gamma Gamma1.
+forall_e_tac N (Gamma --> PC `of_type C)
+               ((((forall_e T P) `of_type (A T)) :: Gamma1) --> PC `of_type C) :-
+  nth_item_and_rest N (P `of_type forall A) Gamma Gamma1.
 
-forall_e_query N (Gamma --> PC of_type C)
-                 ((((forall_e T P) of_type (A T))::Gamma1) --> PC of_type C) :-
+forall_e_query N (Gamma --> PC `of_type C)
+                 ((((forall_e T P) `of_type (A T))::Gamma1) --> PC `of_type C) :-
   print "Enter substitution term: ", read T,
   print "Remove hypothesis? ",
-  (read yes, nth_item_and_rest N (P of_type forall A) Gamma Gamma1;
-   Gamma1 = Gamma, nth_item N (P of_type forall A) Gamma).
+  (read yes, nth_item_and_rest N (P `of_type forall A) Gamma Gamma1;
+   Gamma1 = Gamma, nth_item N (P `of_type forall A) Gamma).
 
-or_e_tac N (Gamma --> (or_e P P1 P2) of_type C)
-          (andgoal (allgoal PA\ (((PA of_type A)::Gamma1) 
-                                          --> (P1 PA) of_type C))
-                   (allgoal PB\ (((PB of_type B)::Gamma1) 
-                                          --> (P2 PB) of_type C))) :-
-  nth_item_and_rest N (P of_type A or B) Gamma Gamma1.
+or_e_tac N (Gamma --> (or_e P P1 P2) `of_type C)
+          (andgoal (allgoal PA\ (((PA `of_type A)::Gamma1) 
+                                          --> (P1 PA) `of_type C))
+                   (allgoal PB\ (((PB `of_type B)::Gamma1) 
+                                          --> (P2 PB) `of_type C))) :-
+  nth_item_and_rest N (P `of_type A || B) Gamma Gamma1.
 
-exists_e_tac N (Gamma --> (exists_e P PC) of_type C)
+exists_e_tac N (Gamma --> (exists_e P PC) `of_type C)
                (allgoal T\ (allgoal PA\
-                 (((PA of_type (A T))::Gamma1) --> (PC T PA) of_type C))) :-
-  nth_item_and_rest N (P of_type some A) Gamma Gamma1.
+                 (((PA `of_type (A T))::Gamma1) --> (PC T PA) `of_type C))) :-
+  nth_item_and_rest N (P `of_type some A) Gamma Gamma1.
 
 

--- a/tests/sources/ndprover/ndtac.sig
+++ b/tests/sources/ndprover/ndtac.sig
@@ -12,8 +12,8 @@ accum_sig goaltypes, ndproofs, logic.
 kind    judgment	type.
 kind    answer		type.
 
-type    of_type		proof_object -> bool -> judgment.
-type    -->		(list judgment) -> judgment -> goal.
+type    (`of_type)		proof_object -> bool -> judgment.
+type    (-->)	     	(list judgment) -> judgment -> goal.
 
 type	yes		answer.
 
@@ -35,7 +35,3 @@ exportdef	or_i1_tac	goal -> goal -> o.
 exportdef	and_i_tac	goal -> goal -> o.
 exportdef	close_tacn	int -> goal -> goal -> o.
 exportdef	close_tac	goal -> goal -> o.
-
-infix   of_type 120.
-infix   --> 110.
-

--- a/tests/sources/ndprover_legacy/README
+++ b/tests/sources/ndprover_legacy/README
@@ -1,0 +1,70 @@
+ *****************************************************************************
+ *                                                                           *
+ * The code in this directory implements an interactive theorem prover       *
+ * based on a natural deduction calculus. The important ideas underlying the *
+ * code were explored by Amy Felty as part of her doctoral dissertation. A   *
+ * shorter description of the relevant ideas may be found in the paper       *
+ *                                                                           *
+ *     Specifying Theorem Provers in a Higher-Order Logic Programming        *
+ *     Language, by Amy Felty and Dale Miller, Springer Verlag LNCS 310,     *
+ *     pp 61 - 88, 1988.                                                     *
+ *                                                                           *
+ * To our knowledge, the present code dates back to a demonstration of a     *
+ * Lambda Prolog interpreter at a pre-conference workshop at CADE 9 by       *
+ * Amy Felty, Dale Miller and Gopalan Nadathur.                              *
+ *                                                                           *
+ * The adaptation to Teyjus code is due to Gopalan Nadathur.                 *
+ *                                                                           *
+ *****************************************************************************
+
+The code in this directory demonstrates many of the good features of Lambda 
+Prolog: lambda terms as a means for capturing the higher-order abstract 
+syntax of formulas and proofs, beta conversion as a means for realizing 
+substitution correctly, benefits of higher-order programming and the 
+support for search in logic programming as a natural basis for realizing 
+tactics and tacticals.
+
+The contents of particular files are as follows:
+
+listmanip.sig,   Some list manipulation utilities needed in the 
+listmanip.mod    implementation of tactics
+
+logic.sig        Defines kinds for expression categories and constants for 
+                 encoding the logical vocabulary of a first-order logic
+
+nonlogical.sig   Encodings for the nonlogical vocabulary of a first-order
+                 logic
+
+formulas.sig,    Illustrations of formula encodings; these encodings are 
+formulas.mod     also useful in theorem proving demonstrations
+
+ndproofs.sig     Encodings of proofs in the natural deduction calculus
+
+goaltypes.sig    Encodings for goals in a tactic and tactical style 
+                 theorem prover
+
+ndtac.sig,       Implementation of primitive tactics for a fragment of 
+ndtac.mod        first-order logic
+
+goalred.sig,     Code for simplifying goals based on the recognition of
+goalred.mod      trivially solved subparts
+
+tacticals.sig,   Implementation of some tacticals, i.e. methods for 
+tacticals.mod    combining atomic proof rules (realized through tactics)
+                 into larger (derived) rules
+
+inter.sig,       An interactive theorem prover based on the use of tactics 
+inter.mod        and tacticals. This is the main program in this directory
+
+script           Exhibition of a run of the system
+
+Running the code
+----------------
+
+The main file to compile and load is inter. The file script contains an 
+example session consisting of compiling, loading and executing the code 
+in inter. The file printfile contains a bottom-up listing of the files 
+in this directory and may be used in understanding the code. 
+
+Last edited on June 26, 1999 by Gopalan Nadathur
+

--- a/tests/sources/ndprover_legacy/formulas.mod
+++ b/tests/sources/ndprover_legacy/formulas.mod
@@ -1,0 +1,25 @@
+/*
+ * Encodings of some formulas in the object logic considered
+ */
+
+module formulas.
+
+accum_sig  logic, nonlogical.
+
+kind	xname		type.
+
+type	formula		xname -> bool -> o.
+
+formula bugs
+ (((heated jar) and (forall X\ ((bug X) imp (animal X))) and
+   (forall X\ (forall Y\ (((heated Y) and (in X Y) and (animal X))
+                            imp (dead X)))) and
+   (forall Y\ ((forall X\ (((in X Y) and (bug X)) imp (dead X)))
+    imp (sterile Y))))
+  imp (sterile jar)).
+
+
+formula baffler (some X\ (forall Y\ ((p X) imp (p Y)))).
+
+formula cases1 (((q a) or (q b)) imp (some X\ (q X))).
+

--- a/tests/sources/ndprover_legacy/formulas.sig
+++ b/tests/sources/ndprover_legacy/formulas.sig
@@ -1,0 +1,14 @@
+/*
+ * Interface to formula encodings
+ */
+
+sig  formulas. 
+
+accum_sig  logic, nonlogical. 
+
+kind  xname  type. 
+
+type  bugs, baffler, cases1  xname.
+
+type  formula  xname -> bool -> o. 
+      

--- a/tests/sources/ndprover_legacy/goalred.mod
+++ b/tests/sources/ndprover_legacy/goalred.mod
@@ -1,0 +1,20 @@
+/*
+ * Code for simplifying goals. Currently the only simplification is that
+ * of removing trivial goals (truegoal) from larger goal expressions.
+ */
+
+module goalred.
+
+accum_sig  goaltypes.
+
+type    goalreduce      goal -> goal -> o.
+
+goalreduce (andgoal truegoal Goal) OutGoal :-
+  !, goalreduce Goal OutGoal.
+
+goalreduce (andgoal Goal truegoal) OutGoal :-
+  !, goalreduce Goal OutGoal.
+
+goalreduce (allgoal T\ truegoal) truegoal :- !.
+
+goalreduce Goal Goal.

--- a/tests/sources/ndprover_legacy/goalred.sig
+++ b/tests/sources/ndprover_legacy/goalred.sig
@@ -1,0 +1,10 @@
+/*
+ * Interface to code for simplifying goals based on recognizing 
+ * ones that have trivial solutions
+ */
+
+sig  goalred.
+
+accum_sig   goaltypes. 
+
+exportdef    goalreduce      goal -> goal -> o.

--- a/tests/sources/ndprover_legacy/goaltypes.sig
+++ b/tests/sources/ndprover_legacy/goaltypes.sig
@@ -1,0 +1,14 @@
+/*
+ * Encodings for goals in a tactic and tactical style prover; the needed
+ * sort and constructors of this sort are identified here
+ */
+
+sig  goaltypes.
+
+kind    goal            type.
+
+type    truegoal        goal.
+type    andgoal         goal -> goal -> goal.
+type    allgoal         (A -> goal) -> goal.
+
+

--- a/tests/sources/ndprover_legacy/inter.mod
+++ b/tests/sources/ndprover_legacy/inter.mod
@@ -1,0 +1,51 @@
+/*
+ * Implementation of an interactive theorem prover based on the use of
+ * tactics and tacticals. This is the main program in this directory.
+ */
+
+module inter.
+
+accum_sig  logic, nonlogical, formulas, ndproofs, ndtac, tacticals.
+
+accumulate ndtac, tacticals, formulas.
+
+type	inter_top	xname -> proof_object -> goal -> o.
+type	inter		goal -> goal -> o.
+type	do		o -> goal -> goal -> o.
+type	quitg		goal -> goal -> o.
+type	backup		goal -> goal -> o.
+type	print_form_list	list judgment -> int -> o.
+type    nl              o.
+type    write           A -> o.
+type    process_input   (goal -> goal -> o) -> goal -> goal -> o.
+
+inter_top Name P OutGoal :- formula Name Formula,
+  inter (nil --> P of_type Formula) OutGoal.
+
+
+inter (Gamma --> P of_type A) NewGoal :-
+  nl, print "Assumptions: ",
+  nl, print_form_list Gamma 1,
+  nl, print "Conclusion: ",
+  nl, write A, nl,
+  print "Enter tactic: ", read Tac, write Tac,
+  process_input Tac (Gamma --> P of_type A) NewGoal.
+
+process_input backup _ _ :- !, fail.
+process_input quitg NewGoal NewGoal :- !.
+process_input (do G) OldGoal NewGoal :- G, inter OldGoal NewGoal.
+process_input Tac OldGoal NewGoal :-
+  Tac OldGoal MidGoal, maptac inter MidGoal NewGoal.
+process_input _ OldGoal NewGoal :- 
+  inter OldGoal NewGoal. 
+
+print_form_list nil N.
+print_form_list ((P of_type A)::Tail) N :-
+  write N, print " ", write A, nl,
+  (N1 is (N + 1)),
+  print_form_list Tail N1.
+
+write A :- term_to_string A Str, print Str.
+nl :- print "\n".
+
+main :- inter_top cases1 Proof Outgoal.

--- a/tests/sources/ndprover_legacy/inter.sig
+++ b/tests/sources/ndprover_legacy/inter.sig
@@ -1,0 +1,18 @@
+/*
+ * Interface to an implementation of an interactive theorem prover.
+ */
+
+sig  inter.
+
+accum_sig  logic, nonlogical, formulas, ndproofs, ndtac, tacticals.
+
+exportdef   inter_top	        xname -> proof_object -> goal -> o.
+exportdef   inter	        goal -> goal -> o.
+exportdef   do                  o -> goal -> goal -> o.
+exportdef   quitg	        goal -> goal -> o.
+exportdef   backup              goal -> goal -> o.
+exportdef   print_form_list	list judgment -> int -> o.
+exportdef   nl                  o.
+exportdef   write               A -> o.
+
+type main o.

--- a/tests/sources/ndprover_legacy/listmanip.mod
+++ b/tests/sources/ndprover_legacy/listmanip.mod
@@ -1,0 +1,43 @@
+/* File listmanip.sig. Various simple list manipulation programs
+needed for writing our theorem provers are defined here.  All of these
+programs are essentially first-order and correspond to code one would
+write in normal Prolog.  */
+
+module listmanip.
+
+type    member                  A -> (list A) -> o.
+type    member_and_rest         A -> (list A) -> (list A) -> o.
+type    nth_item                int -> A -> (list A) -> o.
+type    nth_item_and_rest       int -> A -> (list A) -> (list A) -> o.
+type    member_move_to_end      A -> (list A) -> (list A) -> o.
+type    add_to_end              A -> (list A) -> (list A) -> o.
+
+member X (X::L) :- !.
+member X (Y::L) :- member X L.
+
+member_and_rest A (A::Rest) Rest.
+member_and_rest A (B::Tail) (B::Rest) :-
+  member_and_rest A Tail Rest.
+
+nth_item 0 A List :- !, member A List.
+nth_item 1 A (A::Rest) :- !.
+nth_item N A (B::Tail) :-
+  (N1 is (N - 1)), nth_item N1 A Tail.
+
+nth_item_and_rest 0 A List Rest :- !,
+  member_and_rest A List Rest.
+nth_item_and_rest 1 A (A::Rest) Rest.
+nth_item_and_rest N A (B::Tail) (B::Rest) :-
+  (N1 is (N - 1)),
+  nth_item_and_rest N1 A Tail Rest.
+
+member_move_to_end A (A::Rest) NewList :-
+  add_to_end A Rest NewList.
+member_move_to_end A (B::Tail) (B::NewList) :-
+  member_move_to_end A Tail NewList.
+
+add_to_end A nil (A::nil).
+add_to_end A (Head::Tail) (Head::NewTail) :-
+  add_to_end A Tail NewTail.
+
+

--- a/tests/sources/ndprover_legacy/listmanip.sig
+++ b/tests/sources/ndprover_legacy/listmanip.sig
@@ -1,0 +1,12 @@
+/* File listmanip.sig. Signature file for list manipulating predicates
+used in the theorem prover */
+
+sig listmanip.
+
+exportdef    member                  A -> (list A) -> o.
+exportdef    member_and_rest         A -> (list A) -> (list A) -> o.
+exportdef    nth_item                int -> A -> (list A) -> o.
+exportdef    nth_item_and_rest       int -> A -> (list A) -> (list A) -> o.
+exportdef    member_move_to_end      A -> (list A) -> (list A) -> o.
+exportdef    add_to_end              A -> (list A) -> (list A) -> o.
+

--- a/tests/sources/ndprover_legacy/logic.sig
+++ b/tests/sources/ndprover_legacy/logic.sig
@@ -1,0 +1,21 @@
+/*
+ * Encodings for the basic categories of expressions and the logical 
+ * constants in a first order object logic
+ */
+
+sig logic.
+
+kind    i       type.
+kind    bool    type.
+
+type    and     bool -> bool -> bool.
+type    or      bool -> bool -> bool.
+type    imp     bool -> bool -> bool.
+type    neg     bool -> bool.
+type    forall  (i -> bool) -> bool.
+type	some    (i -> bool) -> bool.
+type    perp    bool.
+
+infixr  and 140.
+infixr  or  140.
+infixr  imp 130.

--- a/tests/sources/ndprover_legacy/ndproofs.sig
+++ b/tests/sources/ndprover_legacy/ndproofs.sig
@@ -1,0 +1,26 @@
+/*
+ * Encodings of proofs in the natural deduction calculus
+ */
+
+sig  ndproofs.
+
+accum_sig  logic.
+
+kind    proof_object	type.
+
+type    and_i           proof_object -> proof_object -> proof_object.
+type    or_i1           proof_object -> proof_object.
+type    or_i2           proof_object -> proof_object.
+type    imp_i           (proof_object -> proof_object) -> proof_object.
+type    forall_i        (i -> proof_object) -> proof_object.
+type    exists_i        i -> proof_object -> proof_object.
+type    and_e1          proof_object -> proof_object.
+type    and_e2          proof_object -> proof_object.
+type    imp_e           proof_object -> proof_object -> proof_object.
+type    forall_e        i -> proof_object -> proof_object.
+type    or_e            proof_object -> (proof_object -> proof_object) ->
+                         (proof_object -> proof_object) -> proof_object.
+type    exists_e        proof_object ->
+                         (i -> proof_object -> proof_object) ->
+                         proof_object.
+

--- a/tests/sources/ndprover_legacy/ndtac.mod
+++ b/tests/sources/ndprover_legacy/ndtac.mod
@@ -1,0 +1,120 @@
+/*
+ * Implementation of a collection of primitive tactics for a 
+ * fragment of first-order logic. The proof objects that are built to
+ * complement the use of the tactics here are in the form of natural
+ * deduction proofs.
+ */
+
+module ndtac.
+
+accum_sig goaltypes, ndproofs, logic.
+
+accumulate listmanip.
+
+kind    judgment	type.
+kind    answer		type.
+
+type    of_type		proof_object -> bool -> judgment.
+type    -->		(list judgment) -> judgment -> goal.
+
+type	yes		answer.
+
+type	exists_e_tac	int -> goal -> goal -> o.
+type	or_e_tac	int -> goal -> goal -> o.
+type	forall_e_query	int -> goal -> goal -> o.
+type	forall_e_tac	int -> goal -> goal -> o.
+type	fchain_tac	int -> goal -> goal -> o.
+type	bchain_tac	int -> goal -> goal -> o.
+type	imp_e_retain	int -> goal -> goal -> o.
+type	imp_e_tac	int -> goal -> goal -> o.
+type	and_e_tac	int -> goal -> goal -> o.
+type	exists_i_query	goal -> goal -> o.
+type	exists_i_tac	goal -> goal -> o.
+type	forall_i_tac	goal -> goal -> o.
+type	imp_i_tac	goal -> goal -> o.
+type	or_i2_tac	goal -> goal -> o.
+type	or_i1_tac	goal -> goal -> o.
+type	and_i_tac	goal -> goal -> o.
+type	close_tacn	int -> goal -> goal -> o.
+type	close_tac	goal -> goal -> o.
+
+infix   of_type 120.
+infix   --> 110.
+
+close_tac (Gamma --> (P of_type A)) truegoal :-
+  member (P of_type A) Gamma.
+
+close_tacn N (Gamma --> P of_type A) truegoal :-
+  nth_item N (P of_type A) Gamma.
+
+and_i_tac (Gamma --> (and_i P1 P2) of_type A and B)
+          (andgoal (Gamma --> P1 of_type A) (Gamma --> P2 of_type B)).
+
+or_i1_tac (Gamma --> (or_i1 P) of_type A or B)
+          (Gamma --> P of_type A).
+
+or_i2_tac (Gamma --> (or_i2 P) of_type A or B)
+          (Gamma --> P of_type B).
+
+imp_i_tac (Gamma --> (imp_i P) of_type A imp B)
+          (allgoal PA\ (((PA of_type A) :: Gamma) --> (P PA) of_type B)).
+
+forall_i_tac (Gamma --> (forall_i P) of_type forall A)
+             (allgoal T\ (Gamma --> (P T) of_type (A T))).
+
+exists_i_tac (Gamma --> (exists_i T P) of_type some A)
+             (Gamma --> P of_type (A T)).
+
+exists_i_query (Gamma --> (exists_i T P) of_type some A)
+               (Gamma --> P of_type (A T)) :-
+  print "Enter substitution term: ", read T.
+
+and_e_tac N (Gamma --> PC of_type C)
+            ((((and_e1 P) of_type A) :: (((and_e2 P) of_type B) :: Gamma1)) 
+                     --> PC of_type C) :-
+  nth_item_and_rest N (P of_type A and B) Gamma Gamma1.
+
+imp_e_tac N (Gamma --> PC of_type C)
+            (andgoal (Gamma1 --> PA of_type A)
+                     ((((imp_e PA P) of_type B)::Gamma1) --> PC of_type C)) :-
+  nth_item_and_rest N (P of_type A imp B) Gamma Gamma1.
+
+imp_e_retain N (Gamma --> PC of_type C)
+               (andgoal (Gamma --> PA of_type A)
+                        ((((imp_e PA P) of_type B) :: Gamma) 
+                                        --> PC of_type C)) :-
+  nth_item N (P of_type A imp B) Gamma.
+
+bchain_tac N (Gamma --> (imp_e PA P) of_type B)
+             (Gamma1 --> PA of_type A) :-
+  nth_item_and_rest N (P of_type A imp B) Gamma Gamma1.
+
+fchain_tac N (Gamma --> PC of_type C)
+             ((((imp_e PA P) of_type B)::Gamma2) --> PC of_type C) :-
+  nth_item_and_rest N (P of_type A imp B) Gamma Gamma1,
+  member_and_rest (PA of_type A) Gamma1 Gamma2.
+
+forall_e_tac N (Gamma --> PC of_type C)
+               ((((forall_e T P) of_type (A T)) :: Gamma1) --> PC of_type C) :-
+  nth_item_and_rest N (P of_type forall A) Gamma Gamma1.
+
+forall_e_query N (Gamma --> PC of_type C)
+                 ((((forall_e T P) of_type (A T))::Gamma1) --> PC of_type C) :-
+  print "Enter substitution term: ", read T,
+  print "Remove hypothesis? ",
+  (read yes, nth_item_and_rest N (P of_type forall A) Gamma Gamma1;
+   Gamma1 = Gamma, nth_item N (P of_type forall A) Gamma).
+
+or_e_tac N (Gamma --> (or_e P P1 P2) of_type C)
+          (andgoal (allgoal PA\ (((PA of_type A)::Gamma1) 
+                                          --> (P1 PA) of_type C))
+                   (allgoal PB\ (((PB of_type B)::Gamma1) 
+                                          --> (P2 PB) of_type C))) :-
+  nth_item_and_rest N (P of_type A or B) Gamma Gamma1.
+
+exists_e_tac N (Gamma --> (exists_e P PC) of_type C)
+               (allgoal T\ (allgoal PA\
+                 (((PA of_type (A T))::Gamma1) --> (PC T PA) of_type C))) :-
+  nth_item_and_rest N (P of_type some A) Gamma Gamma1.
+
+

--- a/tests/sources/ndprover_legacy/ndtac.sig
+++ b/tests/sources/ndprover_legacy/ndtac.sig
@@ -1,0 +1,41 @@
+/*
+ * Interface to the implementation of a set of primitive tactics
+ * for a fragment of first-order logic. Judgements pair formulas 
+ * with proofs. Basic goals represent a relationship between a list 
+ * of judgements and a judgement.
+ */
+
+sig  ndtac. 
+
+accum_sig goaltypes, ndproofs, logic.
+
+kind    judgment	type.
+kind    answer		type.
+
+type    of_type		proof_object -> bool -> judgment.
+type    -->		(list judgment) -> judgment -> goal.
+
+type	yes		answer.
+
+exportdef	exists_e_tac	int -> goal -> goal -> o.
+exportdef	or_e_tac	int -> goal -> goal -> o.
+exportdef	forall_e_query	int -> goal -> goal -> o.
+exportdef	forall_e_tac	int -> goal -> goal -> o.
+exportdef	fchain_tac	int -> goal -> goal -> o.
+exportdef	bchain_tac	int -> goal -> goal -> o.
+exportdef	imp_e_retain	int -> goal -> goal -> o.
+exportdef	imp_e_tac	int -> goal -> goal -> o.
+exportdef	and_e_tac	int -> goal -> goal -> o.
+exportdef	exists_i_query	goal -> goal -> o.
+exportdef	exists_i_tac	goal -> goal -> o.
+exportdef	forall_i_tac	goal -> goal -> o.
+exportdef	imp_i_tac	goal -> goal -> o.
+exportdef	or_i2_tac	goal -> goal -> o.
+exportdef	or_i1_tac	goal -> goal -> o.
+exportdef	and_i_tac	goal -> goal -> o.
+exportdef	close_tacn	int -> goal -> goal -> o.
+exportdef	close_tac	goal -> goal -> o.
+
+infix   of_type 120.
+infix   --> 110.
+

--- a/tests/sources/ndprover_legacy/nonlogical.sig
+++ b/tests/sources/ndprover_legacy/nonlogical.sig
@@ -1,0 +1,25 @@
+/*
+ * Encodings for some constants forming the nonlogical vocabulary of
+ * a first order (object) logic
+ */
+
+sig  nonlogical.
+
+accum_sig  logic.
+
+type    a               i.
+type    b               i.
+type	jar		i.
+
+
+type    p               i -> bool.
+type    q               i -> bool.
+type	sterile		i -> bool.
+type	dead		i -> bool.
+type	animal		i -> bool.
+type	bug		i -> bool.
+type	heated		i -> bool.
+
+type	in		i -> i -> bool.
+
+

--- a/tests/sources/ndprover_legacy/tacticals.mod
+++ b/tests/sources/ndprover_legacy/tacticals.mod
@@ -1,0 +1,58 @@
+/*
+ * Implementation of some tacticals, i.e. `programs' for combining 
+ * primitive tactics in a way that yields derived rules.
+ */
+
+module tacticals.
+
+accum_sig  goaltypes.
+
+accumulate  goalred.
+
+type    maptac          (goal -> goal -> o) -> goal -> goal -> o.
+type    then            (goal -> goal -> o)
+                          -> (goal -> goal -> o) -> goal -> goal -> o.
+type    orelse          (goal -> goal -> o)
+                          -> (goal -> goal -> o) -> goal -> goal -> o.
+type    idtac           goal -> goal -> o.
+type    repeattac       (goal -> goal -> o) -> goal -> goal -> o.
+type    try             (goal -> goal -> o) -> goal -> goal -> o.
+type    complete        (goal -> goal -> o) -> goal -> goal -> o.
+
+
+%  maptac will map a tactical over a compound goal structure.  This
+%  is useful since we only need to have primitive tactics work on
+%  primitive goals.
+maptac Tac truegoal truegoal.
+maptac Tac (andgoal InGoal1 InGoal2) OutGoal :-
+  maptac Tac InGoal1 OutGoal1,
+  maptac Tac InGoal2 OutGoal2,
+  goalreduce (andgoal OutGoal1 OutGoal2) OutGoal.
+maptac Tac (allgoal InGoal) OutGoal :-
+  pi T\ (maptac Tac (InGoal T) (OutGoal1 T)),
+  goalreduce (allgoal OutGoal1) OutGoal.
+maptac Tac InGoal OutGoal :-
+  Tac InGoal OutGoal.
+
+
+%  The next three clauses define three familar and basic tactics.
+then Tac1 Tac2 InGoal OutGoal :-
+  Tac1 InGoal MidGoal,
+  maptac Tac2 MidGoal OutGoal.
+
+orelse Tac1 Tac2 InGoal OutGoal :-
+  Tac1 InGoal OutGoal,!;
+  Tac2 InGoal OutGoal.
+
+idtac Goal Goal.
+
+
+% The next three clauses define certain other useful tacticals.
+repeattac Tac InGoal OutGoal :-
+  orelse (then Tac (repeattac Tac)) idtac InGoal OutGoal.
+
+try Tac InGoal OutGoal :-
+  orelse Tac idtac InGoal OutGoal.
+
+complete Tac InGoal truegoal :-
+  Tac InGoal truegoal.

--- a/tests/sources/ndprover_legacy/tacticals.sig
+++ b/tests/sources/ndprover_legacy/tacticals.sig
@@ -1,0 +1,18 @@
+/*
+ * Interface to the implementation of some tacticals, i.e. methods for 
+ * combining primitive tactics to produce derived rules 
+ */
+
+sig  tacticals. 
+
+accum_sig  goaltypes.
+
+exportdef    maptac          (goal -> goal -> o) -> goal -> goal -> o.
+exportdef    then            (goal -> goal -> o)
+                          -> (goal -> goal -> o) -> goal -> goal -> o.
+exportdef    orelse          (goal -> goal -> o)
+                          -> (goal -> goal -> o) -> goal -> goal -> o.
+exportdef    idtac           goal -> goal -> o.
+exportdef    repeattac       (goal -> goal -> o) -> goal -> goal -> o.
+exportdef    try             (goal -> goal -> o) -> goal -> goal -> o.
+exportdef    complete        (goal -> goal -> o) -> goal -> goal -> o.

--- a/tests/sources/notation.elpi
+++ b/tests/sources/notation.elpi
@@ -1,26 +1,26 @@
 module test.
-
+/*
 infixl x+,y+ 190.
 infixr x++ 191.
 prefixr z+ 191.
 postfixl w+ 190.
 infixl x* 200.
-
-X x+ D.
+*/
+X +x D.
 
 foo xx uu.
 
-z+ x w+.
+~z x ?w.
 
-x x* y x+ z x* w.
+x *x y +x z *x w.
 
-a x+ b x+ c x+ d x+ e.
-a x++ b x++ c x++ d x++ e.
+a +x b +x c +x d +x e.
+a ++x b ++x c ++x d ++x e.
 
 type a A.
 type d A.
-type (x+) A -> B -> C.
-type (y+) A -> B -> C.
+type (+x) A -> B -> C.
+type (+y) A -> B -> C.
 
-main :- print (a a x+ [b] y+ d), cd x+ d.
+main :- print (a a +x [b] +y d), cd +x d.
 

--- a/tests/sources/notation_error.elpi
+++ b/tests/sources/notation_error.elpi
@@ -1,0 +1,1 @@
+infix foo 1.

--- a/tests/sources/notation_legacy.elpi
+++ b/tests/sources/notation_legacy.elpi
@@ -1,0 +1,26 @@
+module test.
+
+infixl x+,y+ 190.
+infixr x++ 191.
+prefixr z+ 191.
+postfixl w+ 190.
+infixl x* 200.
+
+X x+ D.
+
+foo xx uu.
+
+z+ x w+.
+
+x x* y x+ z x* w.
+
+a x+ b x+ c x+ d x+ e.
+a x++ b x++ c x++ d x++ e.
+
+type a A.
+type d A.
+type (x+) A -> B -> C.
+type (y+) A -> B -> C.
+
+main :- print (a a x+ [b] y+ d), cd x+ d.
+

--- a/tests/sources/pcf/eval.mod
+++ b/tests/sources/pcf/eval.mod
@@ -12,7 +12,7 @@ type special       tm -> int -> list tm -> tm.
 type eval_special  tm -> list tm -> tm -> o.
 
 eval (fn M)   (fn M).
-eval (M `@ N)   V :- eval M Fun, eval N U, apply Fun U V.
+eval (M # N)   V :- eval M Fun, eval N U, apply Fun U V.
 eval (fixpt R) V :- eval (R (fixpt R)) V.
 eval (cond Cond Then Else) V :- 
   eval Cond Bool, if (Bool = truth) (eval Then V) (eval Else V).
@@ -50,9 +50,9 @@ apply (special Fun C Args) U (special Fun K (U::Args)) :- K is C - 1.
 
 %% List primitives
 
-eval_special car   ((cons `@ V `@ U)::nil) V.
-eval_special cdr   ((cons `@ V `@ U)::nil) U.
-eval_special cons  (U::V::nil) (cons `@ V `@ U).
+eval_special car   ((cons # V # U)::nil) V.
+eval_special cdr   ((cons # V # U)::nil) U.
+eval_special cons  (U::V::nil) (cons # V # U).
 eval_special nullp (U::nil) V :- if (U = empty) (V = truth) (V = false).
 eval_special consp (U::nil) V :- if (U = empty) (V = false) (V = truth).
 

--- a/tests/sources/pcf/eval_test.mod
+++ b/tests/sources/pcf/eval_test.mod
@@ -8,14 +8,14 @@ accumulate eval, examples.
 
 type eval_test   int -> tm -> o.
 
-eval_test 1 V :- prog "fib" Fib, eval (Fib `@ in 12) V.
+eval_test 1 V :- prog "fib" Fib, eval (Fib # in 12) V.
 eval_test 2 V :- prog "map" Map, prog "fib" Fib, 
-             eval (Map `@ Fib `@ (cons `@ in 3 `@ (cons `@ in 6 `@ empty))) V.
+             eval (Map # Fib # (cons # in 3 # (cons # in 6 # empty))) V.
 eval_test 3 V :- prog "app" App, 
-             eval (App `@ (cons `@ in 3 `@ empty) `@ (cons `@ in 5 `@ empty)) V.
+             eval (App # (cons # in 3 # empty) # (cons # in 5 # empty)) V.
 eval_test 4 V :- prog "mem" Mem, 
-             eval (Mem `@ (in 3) `@ (cons `@ in 5 `@ (cons `@ in 3 `@ empty))) V.
+             eval (Mem # (in 3) # (cons # in 5 # (cons # in 3 # empty))) V.
 eval_test 5 V :- prog "mem" Mem, 
-             eval (Mem `@ (in 4) `@ (cons `@ in 5 `@ (cons `@ in 3 `@ empty))) V.
+             eval (Mem # (in 4) # (cons # in 5 # (cons # in 3 # empty))) V.
 
 

--- a/tests/sources/pcf/examples.mod
+++ b/tests/sources/pcf/examples.mod
@@ -8,54 +8,54 @@ module examples.
 type prog    string -> tm -> o.
 
 prog "successor" 
-  (fn x\ plus `@ x `@ (in 1)).
+  (fn x\ plus # x # (in 1)).
 
 prog "onep" 
-  (fn w\ fn u\ fn v\ cond (equal `@ (in 1) `@ w) u v).
+  (fn w\ fn u\ fn v\ cond (equal # (in 1) # w) u v).
 
 prog "is_sym"
-  (fn f\ fn x\ fn y\ equal `@ (f `@ x `@ y) `@ (f `@ y `@ x)).
+  (fn f\ fn x\ fn y\ equal # (f # x # y) # (f # y # x)).
 
 prog "fib" 
-  (fixpt fib\ fn n\ cond (zerop `@ n) (in 0) 
-                     (cond (equal `@ n `@ (in 1)) (in 1) 
-                           (plus `@ (fib `@ (minus `@ n `@ (in 1))) `@ 
-                                   (fib `@ (minus `@ n `@ (in 2)))))).
+  (fixpt fib\ fn n\ cond (zerop # n) (in 0) 
+                     (cond (equal # n # (in 1)) (in 1) 
+                           (plus # (fib # (minus # n # (in 1))) # 
+                                   (fib # (minus # n # (in 2)))))).
 
 prog "map" 
   (fixpt map\ fn f\ fn l\ 
-     cond (nullp `@ l) empty 
-          (cons `@ (f `@ (car `@ l)) `@ (map `@ f `@ (cdr `@ l)))).
+     cond (nullp # l) empty 
+          (cons # (f # (car # l)) # (map # f # (cdr # l)))).
 
 prog "mem" 
   (fixpt mem\ fn x\ fn l\ 
-    cond (nullp `@ l) false 
-         (cond (and `@ (consp `@ l) `@ (equal `@ (car `@ l) `@ x)) 
-                truth (mem `@ x `@ (cdr `@ l)))).
+    cond (nullp # l) false 
+         (cond (and # (consp # l) # (equal # (car # l) # x)) 
+                truth (mem # x # (cdr # l)))).
 
 prog "fact" 
   (fixpt f\ fn n\ fn m\
-    cond (equal `@ n `@ (in 0)) m
-         (f `@ (minus `@ n `@ (in 1)) `@ (times `@ n `@ m))).
+    cond (equal # n # (in 0)) m
+         (f # (minus # n # (in 1)) # (times # n # m))).
 
 prog "app"
   (fixpt app\ fn l\ fn k\
-    (cond (nullp `@ l) k (cons `@ (car `@ l) `@ (app `@ (cdr `@ l) `@ k)))).
+    (cond (nullp # l) k (cons # (car # l) # (app # (cdr # l) # k)))).
 
 prog "gcd" 
   (fixpt f\ fn x\ fn y\ 
-    cond (equal `@ (in 1) `@ x) (in 1)
-         (cond (greater `@ y `@ x) (f `@ y `@ x)
-               (cond (equal `@ x `@ y) x (f `@ (minus `@ x `@ y) `@ y)))).
+    cond (equal # (in 1) # x) (in 1)
+         (cond (greater # y # x) (f # y # x)
+               (cond (equal # x # y) x (f # (minus # x # y) # y)))).
 
-prog "ex1"   (cons `@ (in 1) `@ (in 2)).
-prog "ex2"   (plus `@ empty `@ (in 1)).
+prog "ex1"   (cons # (in 1) # (in 2)).
+prog "ex2"   (plus # empty # (in 1)).
 prog "ex3"   (cond truth (in 3) empty).
 prog "ex4"   (fn x\ fn x\x).
 prog "ex5"   (cond truth (in 3) (in 5)).
-prog "ex6"   ((fn x\x) `@ (fn y\y)).
+prog "ex6"   ((fn x\x) # (fn y\y)).
 prog "i"     (fn x\ x).
 prog "k"     (fn x\ fn y\x).
-prog "s"     (fn x\ fn y\ fn z\ (x `@ z) `@ (y `@ z)).
-prog "comp"  (fn f\ fn g\ fn x\ f `@ (g `@ x)).
+prog "s"     (fn x\ fn y\ fn z\ (x # z) # (y # z)).
+prog "comp"  (fn f\ fn g\ fn x\ f # (g # x)).
 

--- a/tests/sources/pcf/monoinfer.mod
+++ b/tests/sources/pcf/monoinfer.mod
@@ -9,7 +9,7 @@ accum_sig  pcf, monotypes.
 
 type prim, infer      tm -> ty -> o.
 
-infer (M `@ N) B        :- infer M (A --> B), infer N A.
+infer (M # N) B        :- infer M (A --> B), infer N A.
 infer (fn M) (A --> B) :- pi x\ infer x A => infer (M x) B.
 infer (fixpt M) A      :- pi x\ infer x A => infer (M x) A.
 infer (cond C T E) A   :- infer C bool, infer T A, infer E A.

--- a/tests/sources/pcf/monotypes.sig
+++ b/tests/sources/pcf/monotypes.sig
@@ -9,8 +9,7 @@ sig monotypes.
 
 kind   ty    type.              % constructor for mono types
 
-type   -->   ty -> ty -> ty.    % arrow type constructor
-infixr -->   5.
+type   (-->)   ty -> ty -> ty.    % arrow type constructor
 
 type lst     ty -> ty.          % list type constructor
 type num     ty.                % integer type

--- a/tests/sources/pcf/pcf.mod
+++ b/tests/sources/pcf/pcf.mod
@@ -8,18 +8,18 @@ accumulate eval_test, mono_test, poly_test, tr_test, examples.
 
 type main o.
 
-main :- eval_test 1 V1, !,
-        eval_test 2 V2, !,
-        eval_test 3 V3, !,
-        V1 = in 144, 
-        V2 = (cons `@ in 2 `@(cons `@ in 8 `@ empty)),
-        V3 = (cons `@ in 3 `@(cons `@ in 5 `@ empty)),
-        mono_test "onep" Ty1, !,
-        mono_test "is_sym" Ty2, !,
-        mono_test "fib" Ty3, !,
-        poly_test "successor" Ty4, !,
-        poly_test "onep" Ty5, !,
-        poly_test "is_sym" Ty6, !,
-        tr_test "successor", !,
-        tr_test "onep", !,
-        tr_test "is_sym".
+main :- % std.spy(eval_test 1 V1), !,
+        % std.spy(eval_test 2 V2), !,
+        % std.spy(eval_test 3 V3), !,
+        % V1 = in 144, 
+        % V2 = (cons # in 2 # (cons # in 8 # empty)),
+        % V3 = (cons # in 3 # (cons # in 5 # empty)),
+        std.spy(mono_test "onep" Ty1), !,
+        std.spy(mono_test "is_sym" Ty2), !,
+        std.spy(mono_test "fib" Ty3), !,
+        std.spy(poly_test "successor" Ty4), !,
+        std.spy(poly_test "onep" Ty5), !,
+        std.spy(poly_test "is_sym" Ty6), !,
+        std.spy(tr_test "successor"), !,
+        std.spy(tr_test "onep"), !,
+        std.spy(tr_test "is_sym").

--- a/tests/sources/pcf/pcf.sig
+++ b/tests/sources/pcf/pcf.sig
@@ -9,8 +9,7 @@ kind   tm   type.
 
 type   fn   (tm -> tm) -> tm.       % abstraction constructor
 
-type   `@    tm -> tm -> tm.         % application constructor
-infixl `@    6.
+type   (#)    tm -> tm -> tm.         % application constructor
 
 type fixpt (tm -> tm) -> tm.        % fixed point constructor for recursion
 type cond  tm -> tm -> tm -> tm.    % conditional

--- a/tests/sources/pcf/polyinfer.mod
+++ b/tests/sources/pcf/polyinfer.mod
@@ -66,12 +66,12 @@ type  poly_inst   poly -> ty -> list (pair tm ty) -> list eq -> poly -> o.
 
 tyinfer Term Poly :- typeof (pr Term topvar :: nil) nil Poly.
 
-typeof (pr (M `@ N) A ::S) Eqs (all P) :- !,
+typeof (pr (M # N) A ::S) Eqs (all P) :- !,
   pi c\ tvar c => typeof (pr M (c --> A) :: pr N c :: S) Eqs (P c). 
 
 typeof (pr (fn M) A :: S) Eqs  (all d\ all e\ P d e) :- !,
   pi d\ tvar d => pi e\ tvar e => pi x\ tybind x d => 
-   typeof (pr (M x) e :: S) ((A === d --> e) :: Eqs) (P d e).
+   typeof (pr (M x) e :: S) ((A === (d --> e)) :: Eqs) (P d e).
 
 typeof (pr (fixpt M) A :: S) Eqs  (all P) :- !,
   pi d\ tvar d => pi x\ tybind x d => 

--- a/tests/sources/pcf/refl_syntax.mod
+++ b/tests/sources/pcf/refl_syntax.mod
@@ -10,7 +10,7 @@ accum_sig   pcf.
 type   term      tm -> o.
 
 term (fn R) :- pi X\ ((term X) => (term (R X))).
-term (M `@ N) :- term M, term N.
+term (M # N) :- term M, term N.
 term (fixpt R) :- pi X\((term X) => (term (R X))).
 term (cond M N P) :- term M, term N, term P.
 

--- a/tests/sources/pcf/tailrec.mod
+++ b/tests/sources/pcf/tailrec.mod
@@ -20,6 +20,6 @@ trfn (fn R) :- pi X\ ((term X) => (trfn (R X))).
 trfn R :- trbody R.
 
 trbody (cond M N P) :- term M, trbody N, trbody P.
-trbody (M `@ N) :- !, trbody M, term N.
+trbody (M # N) :- !, trbody M, term N.
 trbody M :- headrec M; term M.
 

--- a/tests/sources/pcf/unifytypes.mod
+++ b/tests/sources/pcf/unifytypes.mod
@@ -15,8 +15,7 @@ type  tvar  ty -> o.
 
 % Representation of disagreement pairs
 kind  eq       type.             
-type  ===       ty -> ty -> eq.
-infix ===       4.
+type  (===)       ty -> ty -> eq.
 
 
 % subst_ty is a predicate such that (subst_ty V T Ty1 Ty2) is true if
@@ -58,7 +57,7 @@ type  unify       list eq -> ty -> ty -> o.
 
 unify nil In In.
 unify ((A === A) :: Eqs) In Out :- !, unify Eqs In Out.
-unify ((A --> Ax === B --> Bx) :: Eqs) In Out :-
+unify (((A --> Ax) === (B --> Bx)) :: Eqs) In Out :-
   unify ((A === B) :: (Ax === Bx) :: Eqs) In Out.
 unify ((lst A === lst B) :: Eqs) In Out :- unify ((A === B) :: Eqs) In Out.
 unify ((A === B) :: Eqs) In Out :-

--- a/tests/sources/pcf/unifytypes.sig
+++ b/tests/sources/pcf/unifytypes.sig
@@ -14,8 +14,7 @@ type  tvar  ty -> o.
 
 % Representation of disagreement pairs
 kind  eq       type.             
-type  ===       ty -> ty -> eq.
-infix ===       4.
+type  (===)       ty -> ty -> eq.
 
 % (unify Eqs In Out) is true if solving the equations represented by 
 % Eqs results in In being instantiated to Out 

--- a/tests/sources/pcf_legacy/README
+++ b/tests/sources/pcf_legacy/README
@@ -1,0 +1,66 @@
+ *****************************************************************************
+ *                                                                           *
+ *   The code in this directory is due primarily to Dale Miller. Gopalan     *
+ *   Nadathur is responsible for some additions, debugging and               *
+ *   reorganization.                                                         *
+ *                                                                           *
+ *****************************************************************************
+
+The important conceptual content of the code in this directory is in
+the use of higher-order abstract syntax in representing and manipulating 
+programs and types in a simple functional programming language referred 
+to as PCF here. In particular, the code brings out the value of beta 
+reduction, unification and scoping primitives in carrying out operations 
+on HOAS representations. Another interesting facet of the code is that 
+it illustrates both a shallow and a deep embedding of types in the 
+context of implementing type inference.
+
+The relevant files are the following:
+
+pcf.sig                 Defines the kinds and constants used in encoding
+                        the functional programming language.
+
+monotypes.sig           Defines the kinds and constants used in the 
+                        (shallow) encoding of types.
+
+polytypes.sig           Augments monotypes.sig to realize a deep embedding
+                        of types.
+
+examples.sig,           Illustrates the use of the declarations in pcf.sig
+examples.mod            in representing programs.
+
+refl_syntax.mod,        Implement a recognizer for terms representing
+refl_syntax.sig         well-formed programs.
+
+eval.mod,               Implement a call-by-value evaluator for the 
+eval.sig,               functional programming language; meta-level beta 
+eval_test.mod,          reduction is used to realize substitution. The
+eval_test.sig           eval_test files provide a testing harness.
+
+monoinfer.mod,          Implement type inference for PCF. The shallow
+monoinfer.sig,          embedding of types is used; there is no explicit 
+mono_test.mod,          type quantification, type variables are realized 
+mono_test.sig           through meta variables and meta-language unification
+                        can be exploited. The mono_test files realize a
+                        testing harness.
+
+unifytypes.mod,         Implement unification for types in a situation 
+unifytypes.sig          where type variables are represented by specially
+                        marked constants; useful when the deep embedding 
+                        of types is used.
+
+polyinfer.mod,          Implement type inference for PCF using the deep 
+polyinfer.sig,          embedding of types. The poly_test files realize
+poly_test.mod,          a testing harness.
+poly_test.sig
+
+
+tailrec.mod,            Implement a recognizer for tail recursive programs.
+tailrec.sig,            The tr_test files realize a testing harness.
+tr_test.mod,
+tr_test.sig
+
+script1,                Depict the execution of the code in this directory.
+script2,                In particular, these scripts show the execution of
+script3,                the evaluator, type inference using the shallow and
+script4                 the deep embedding, and the tail recursion tester.

--- a/tests/sources/pcf_legacy/control.mod
+++ b/tests/sources/pcf_legacy/control.mod
@@ -1,0 +1,30 @@
+module control.
+
+type if          o -> o -> o -> o.
+type once        o -> o.
+
+
+% Relates three formulas if the corresponding condition holds:
+% ``if Cond Then Else'' attempts to prove Then if the condition Cond
+% success; otherwise it attempts Else.  Notice the use of !.
+
+if Cond Then Else :- Cond, !, Then.
+if Cond Then Else :- Else.
+
+% Attempts to prove its argument and if it succeeds, backtracking is
+% disallowed by using !.
+
+once P :- P, !.
+
+type announce o -> o.
+
+announce G :-
+  print ">> ", term_to_string G String, print String, print "\n", fail.
+
+
+type spi o -> o.
+
+spi G :-
+  (print ">Entering ", term_to_string G Str,  print Str,  print "\n", G,
+   print ">Success  ", term_to_string G Strx, print Strx, print "\n";
+   print ">Leaving  ", term_to_string G Str,  print Str,  print "\n", fail).

--- a/tests/sources/pcf_legacy/control.sig
+++ b/tests/sources/pcf_legacy/control.sig
@@ -1,0 +1,10 @@
+/*
+ * Some special control predicates of general utility
+ */
+
+sig control.
+
+exportdef announce    o -> o.                % for displaying goals
+exportdef spi         o -> o.                % display entry and exit from goal
+exportdef if          o -> o -> o -> o.      % if then else
+exportdef once        o -> o.                % once only predicate

--- a/tests/sources/pcf_legacy/eval.mod
+++ b/tests/sources/pcf_legacy/eval.mod
@@ -1,0 +1,72 @@
+/*
+ * A call-by-value interpreter for PCF
+ */
+
+module eval.
+
+accumulate control.       % for control predicates used in the code
+
+type eval          tm -> tm -> o.
+type apply         tm -> tm -> tm -> o.
+type special       tm -> int -> list tm -> tm.
+type eval_special  tm -> list tm -> tm -> o.
+
+eval (fn M)   (fn M).
+eval (M `@ N)   V :- eval M Fun, eval N U, apply Fun U V.
+eval (fixpt R) V :- eval (R (fixpt R)) V.
+eval (cond Cond Then Else) V :- 
+  eval Cond Bool, if (Bool = truth) (eval Then V) (eval Else V).
+eval (in N)    (in N).
+eval truth     truth.
+eval false     false.
+eval empty     empty.
+
+% The value of the special built-in functions is given as a 
+% special construction: it contains the arity and the arguments 
+% already supplied (which starts out as empty).
+
+eval and     (special and     2 nil).
+eval car     (special car     1 nil).
+eval cdr     (special cdr     1 nil).
+eval cons    (special cons    2 nil).
+eval consp   (special consp   1 nil).
+eval equal   (special equal   2 nil).
+eval greater (special greater 2 nil).
+eval minus   (special minus   2 nil).
+eval nullp   (special nullp   1 nil).
+eval plus    (special plus    2 nil).
+eval times   (special times   2 nil).
+eval zerop   (special zerop   1 nil).
+
+% apply describes how to apply a fnbda abstract or a special to
+% arguments.
+
+apply (fn R) U V :- eval (R U) V.
+apply (special Fun 1 Args) U V :- !, eval_special Fun (U::Args) V.
+apply (special Fun C Args) U (special Fun K (U::Args)) :- K is C - 1.
+
+% Links between the built-in functions and their actual meaning
+% is given in the following lines.
+
+%% List primitives
+
+eval_special car   ((cons `@ V `@ U)::nil) V.
+eval_special cdr   ((cons `@ V `@ U)::nil) U.
+eval_special cons  (U::V::nil) (cons `@ V `@ U).
+eval_special nullp (U::nil) V :- if (U = empty) (V = truth) (V = false).
+eval_special consp (U::nil) V :- if (U = empty) (V = false) (V = truth).
+
+% Boolean primitives
+eval_special and (B2::B1::nil) V :-
+  if (B1 = false) (V = false) (if (B2 = false) (V = false) (V = truth)).
+eval_special or  (B2::B1::nil) V :-
+  if (B1 = truth) (V = truth) (if (B2 = truth) (V = truth) (V = false)).
+
+% Integer primitives
+eval_special minus ((in N)::(in M)::nil) (in V) :- V is M - N.
+eval_special plus  ((in N)::(in M)::nil) (in V) :- V is M + N.
+eval_special times ((in N)::(in M)::nil) (in V) :- V is M * N.
+eval_special zerop ((in N)::nil) V :- if (N = 0) (V = truth) (V = false).
+eval_special equal (B2::B1::nil) V :- if (B1 = B2) (V = truth) (V = false).
+eval_special greater ((in N)::(in M)::nil) V :- 
+  if (M > N) (V = truth) (V = false).

--- a/tests/sources/pcf_legacy/eval.sig
+++ b/tests/sources/pcf_legacy/eval.sig
@@ -1,0 +1,11 @@
+/*
+ * Interface to the call-by-value interpreter for PCF
+ */
+
+sig eval.
+
+accum_sig  pcf.
+
+%type special       tm -> int -> list tm -> tm.
+
+type eval          tm -> tm -> o.

--- a/tests/sources/pcf_legacy/eval_test.mod
+++ b/tests/sources/pcf_legacy/eval_test.mod
@@ -1,0 +1,21 @@
+/*
+ * A testing harness for the call-by-value evaluator for PCF
+ */
+
+module eval_test.
+
+accumulate eval, examples.
+
+type eval_test   int -> tm -> o.
+
+eval_test 1 V :- prog "fib" Fib, eval (Fib `@ in 12) V.
+eval_test 2 V :- prog "map" Map, prog "fib" Fib, 
+             eval (Map `@ Fib `@ (cons `@ in 3 `@ (cons `@ in 6 `@ empty))) V.
+eval_test 3 V :- prog "app" App, 
+             eval (App `@ (cons `@ in 3 `@ empty) `@ (cons `@ in 5 `@ empty)) V.
+eval_test 4 V :- prog "mem" Mem, 
+             eval (Mem `@ (in 3) `@ (cons `@ in 5 `@ (cons `@ in 3 `@ empty))) V.
+eval_test 5 V :- prog "mem" Mem, 
+             eval (Mem `@ (in 4) `@ (cons `@ in 5 `@ (cons `@ in 3 `@ empty))) V.
+
+

--- a/tests/sources/pcf_legacy/eval_test.sig
+++ b/tests/sources/pcf_legacy/eval_test.sig
@@ -1,0 +1,10 @@
+/* 
+ * Interface to the testing harness for the call-by-value interpreter
+ */
+
+sig eval_test.
+
+accum_sig eval.
+
+exportdef  eval_test   int -> tm -> o.
+

--- a/tests/sources/pcf_legacy/examples.mod
+++ b/tests/sources/pcf_legacy/examples.mod
@@ -1,0 +1,61 @@
+/*
+ * Illustration of encodings of programs in the simple functional 
+ * programming language
+ */
+
+module examples.
+
+type prog    string -> tm -> o.
+
+prog "successor" 
+  (fn x\ plus `@ x `@ (in 1)).
+
+prog "onep" 
+  (fn w\ fn u\ fn v\ cond (equal `@ (in 1) `@ w) u v).
+
+prog "is_sym"
+  (fn f\ fn x\ fn y\ equal `@ (f `@ x `@ y) `@ (f `@ y `@ x)).
+
+prog "fib" 
+  (fixpt fib\ fn n\ cond (zerop `@ n) (in 0) 
+                     (cond (equal `@ n `@ (in 1)) (in 1) 
+                           (plus `@ (fib `@ (minus `@ n `@ (in 1))) `@ 
+                                   (fib `@ (minus `@ n `@ (in 2)))))).
+
+prog "map" 
+  (fixpt map\ fn f\ fn l\ 
+     cond (nullp `@ l) empty 
+          (cons `@ (f `@ (car `@ l)) `@ (map `@ f `@ (cdr `@ l)))).
+
+prog "mem" 
+  (fixpt mem\ fn x\ fn l\ 
+    cond (nullp `@ l) false 
+         (cond (and `@ (consp `@ l) `@ (equal `@ (car `@ l) `@ x)) 
+                truth (mem `@ x `@ (cdr `@ l)))).
+
+prog "fact" 
+  (fixpt f\ fn n\ fn m\
+    cond (equal `@ n `@ (in 0)) m
+         (f `@ (minus `@ n `@ (in 1)) `@ (times `@ n `@ m))).
+
+prog "app"
+  (fixpt app\ fn l\ fn k\
+    (cond (nullp `@ l) k (cons `@ (car `@ l) `@ (app `@ (cdr `@ l) `@ k)))).
+
+prog "gcd" 
+  (fixpt f\ fn x\ fn y\ 
+    cond (equal `@ (in 1) `@ x) (in 1)
+         (cond (greater `@ y `@ x) (f `@ y `@ x)
+               (cond (equal `@ x `@ y) x (f `@ (minus `@ x `@ y) `@ y)))).
+
+prog "ex1"   (cons `@ (in 1) `@ (in 2)).
+prog "ex2"   (plus `@ empty `@ (in 1)).
+prog "ex3"   (cond truth (in 3) empty).
+prog "ex4"   (fn x\ fn x\x).
+prog "ex5"   (cond truth (in 3) (in 5)).
+prog "ex6"   ((fn x\x) `@ (fn y\y)).
+prog "i"     (fn x\ x).
+prog "k"     (fn x\ fn y\x).
+prog "s"     (fn x\ fn y\ fn z\ (x `@ z) `@ (y `@ z)).
+prog "comp"  (fn f\ fn g\ fn x\ f `@ (g `@ x)).
+

--- a/tests/sources/pcf_legacy/examples.sig
+++ b/tests/sources/pcf_legacy/examples.sig
@@ -1,0 +1,10 @@
+/* 
+ * Interface to a collection of terms illustrating the encoding of
+ * programs in a simple functional programming language
+ */
+
+sig examples.
+
+accum_sig   pcf.
+
+exportdef prog     string -> tm -> o.

--- a/tests/sources/pcf_legacy/mono_test.mod
+++ b/tests/sources/pcf_legacy/mono_test.mod
@@ -1,0 +1,12 @@
+/* 
+ * A testing harness for code that infers monotypes for programs in
+ * the simple functional programming language
+ */
+
+module mono_test.
+
+accumulate monoinfer, examples.
+
+type mono_test   string -> ty -> o.
+
+mono_test String Type :- prog String Term, infer Term Type.

--- a/tests/sources/pcf_legacy/mono_test.sig
+++ b/tests/sources/pcf_legacy/mono_test.sig
@@ -1,0 +1,10 @@
+/*
+ * Interface for testing code that infers monomorphic types for
+ * programs in the simple functional programming language
+ */
+
+sig  mono_test.
+
+accum_sig monoinfer, monotypes.
+
+type  mono_test  string -> ty -> o.

--- a/tests/sources/pcf_legacy/monoinfer.mod
+++ b/tests/sources/pcf_legacy/monoinfer.mod
@@ -1,0 +1,42 @@
+/*
+ * Code for inferring monotypes for programs in the simple 
+ * functional programming language
+ */
+
+module monoinfer.
+
+accum_sig  pcf, monotypes.
+
+type prim, infer      tm -> ty -> o.
+
+infer (M `@ N) B        :- infer M (A --> B), infer N A.
+infer (fn M) (A --> B) :- pi x\ infer x A => infer (M x) B.
+infer (fixpt M) A      :- pi x\ infer x A => infer (M x) A.
+infer (cond C T E) A   :- infer C bool, infer T A, infer E A.
+infer T A              :- prim T A.
+
+% Primitive for lists.
+
+prim car    ((lst A) --> A).
+prim cdr    ((lst A) --> (lst A) ).
+prim empty  (lst A).
+prim cons   (A --> (lst A) --> (lst A) ).
+prim nullp  ((lst A) --> bool).
+prim consp  ((lst A) --> bool).
+
+% Primitives for booleans.
+
+prim equal  (A --> A --> bool).
+prim and    (bool --> bool --> bool).
+prim or     (bool --> bool --> bool).
+prim truth   bool.
+prim false   bool.
+
+% Primitives for integers
+
+prim times    (num --> num --> num).
+prim plus     (num --> num --> num).
+prim minus    (num --> num --> num).
+prim zerop    (num --> bool).
+prim greater  (num --> num --> bool).
+prim (in N)    num.

--- a/tests/sources/pcf_legacy/monoinfer.sig
+++ b/tests/sources/pcf_legacy/monoinfer.sig
@@ -1,0 +1,10 @@
+/* 
+ * Interface to code for inferring monotypes for programs
+ * in the simple functional programming language
+ */
+
+sig  monoinfer.
+
+accum_sig  pcf, monotypes.
+
+type  infer  tm -> ty -> o.

--- a/tests/sources/pcf_legacy/monotypes.sig
+++ b/tests/sources/pcf_legacy/monotypes.sig
@@ -1,0 +1,17 @@
+/*
+ *  Encoding of types. Polymorphism is not explicitly represented in
+ *  types in this encoding; some aspects of polymorphism can be 
+ *  captured through logic variables in the meta-logic. This encoding 
+ *  is in a sense a shallow encoding.
+ */
+
+sig monotypes.
+
+kind   ty    type.              % constructor for mono types
+
+type   -->   ty -> ty -> ty.    % arrow type constructor
+infixr -->   5.
+
+type lst     ty -> ty.          % list type constructor
+type num     ty.                % integer type
+type bool    ty.                % boolean type

--- a/tests/sources/pcf_legacy/pcf.mod
+++ b/tests/sources/pcf_legacy/pcf.mod
@@ -1,0 +1,25 @@
+/* combines script1 to script4.
+ */
+
+module pcf.
+
+
+accumulate eval_test, mono_test, poly_test, tr_test, examples.
+
+type main o.
+
+main :- eval_test 1 V1, !,
+        eval_test 2 V2, !,
+        eval_test 3 V3, !,
+        V1 = in 144, 
+        V2 = (cons `@ in 2 `@(cons `@ in 8 `@ empty)),
+        V3 = (cons `@ in 3 `@(cons `@ in 5 `@ empty)),
+        mono_test "onep" Ty1, !,
+        mono_test "is_sym" Ty2, !,
+        mono_test "fib" Ty3, !,
+        poly_test "successor" Ty4, !,
+        poly_test "onep" Ty5, !,
+        poly_test "is_sym" Ty6, !,
+        tr_test "successor", !,
+        tr_test "onep", !,
+        tr_test "is_sym".

--- a/tests/sources/pcf_legacy/pcf.sig
+++ b/tests/sources/pcf_legacy/pcf.sig
@@ -1,0 +1,24 @@
+/*
+ * The sorts and constants needed for encoding the terms in a simple 
+ * functional programming language PCF
+ */
+
+sig pcf.
+
+kind   tm   type.
+
+type   fn   (tm -> tm) -> tm.       % abstraction constructor
+
+type   `@    tm -> tm -> tm.         % application constructor
+infixl `@    6.
+
+type fixpt (tm -> tm) -> tm.        % fixed point constructor for recursion
+type cond  tm -> tm -> tm -> tm.    % conditional
+type in    int -> tm.               % constructor for embedding integers
+
+type and, or, false, truth,                      % boolean functions
+     car, cdr, cons, nullp, consp, empty,        % lists functions
+     equal, greater, zerop, minus, plus, times   % integer functions
+     tm.
+
+type main o.

--- a/tests/sources/pcf_legacy/poly_test.mod
+++ b/tests/sources/pcf_legacy/poly_test.mod
@@ -1,0 +1,12 @@
+/*
+ *  A testing harness for the code that infers polytypes for programs
+ *  in the simple functional programming language.
+ */
+
+module poly_test.
+
+accumulate polyinfer, examples. 
+
+type poly_test  string -> poly -> o.
+
+poly_test String Ty :- prog String T, polyinfer T Ty.

--- a/tests/sources/pcf_legacy/poly_test.sig
+++ b/tests/sources/pcf_legacy/poly_test.sig
@@ -1,0 +1,11 @@
+/*
+ * Interface for testing code that infers polytypes for programs 
+ * in the simple functional programming language
+ */
+
+sig  poly_test.
+
+accum_sig polyinfer, polytypes.
+
+type  poly_test  string -> poly -> o.
+

--- a/tests/sources/pcf_legacy/polyinfer.mod
+++ b/tests/sources/pcf_legacy/polyinfer.mod
@@ -1,0 +1,100 @@
+/*
+ * Code for inferring polytypes for programs in the simple functional
+ * programming language
+ */
+
+module polyinfer.
+
+accum_sig  polytypes, pcf, unifytypes.
+
+accumulate  unifytypes.
+
+% Predicate for distinguishing constants representing type variables
+type   tvar    ty -> o.
+
+
+% Variable representing the initial type of a term
+type   topvar  ty.
+
+tvar topvar.
+
+
+% Predicate for removing vacuous quantifications in poly types.
+type  rem_vac   poly -> poly -> o.
+
+rem_vac (c Ty) (c Ty).
+rem_vac (all x\P) Q     :- !, rem_vac P Q.
+rem_vac (all P) (all Q) :- pi x\ rem_vac (P x) (Q x).
+
+
+% Polytypes of primitives in the programming language
+type prim_poly    tm -> poly -> o.
+
+prim_poly car      (all A\ c ((lst A) --> A)).
+prim_poly cdr      (all A\ c ((lst A) --> (lst A))).
+prim_poly empty    (all A\ c (lst A)).
+prim_poly cons     (all A\ c (A --> (lst A) --> (lst A))).
+prim_poly nullp    (all A\ c ((lst A) --> bool)).
+prim_poly consp    (all A\ c ((lst A) --> bool)).
+  
+prim_poly equal    (all A\ c (A --> A --> bool)).
+prim_poly and      (c (bool --> bool --> bool)).
+prim_poly or       (c (bool --> bool --> bool)).
+prim_poly truth    (c bool).
+prim_poly false    (c bool).
+
+prim_poly times    (c (num --> num --> num)).
+prim_poly plus     (c (num --> num --> num)).
+prim_poly minus    (c (num --> num --> num)).
+prim_poly zerop    (c (num --> bool)).
+prim_poly greater  (c (num --> num --> bool)).
+prim_poly (in N)   (c  num).
+
+
+% Representing typing judgements; these are essentially term, type pairs
+kind pair    type -> type -> type.     
+type pr      A -> B -> pair A B.
+
+
+% Inferring a poly type for a term. The main work is done in typeof that
+% generates typing judgements and constraints between these, and invokes
+% type unification to solve the constraints.
+type  tybind      tm -> ty -> o.
+type  tyinfer     tm -> poly -> o.
+type  typeof      list (pair tm ty) -> list eq -> poly -> o.
+type  poly_inst   poly -> ty -> list (pair tm ty) -> list eq -> poly -> o.
+
+tyinfer Term Poly :- typeof (pr Term topvar :: nil) nil Poly.
+
+typeof (pr (M `@ N) A ::S) Eqs (all P) :- !,
+  pi c\ tvar c => typeof (pr M (c --> A) :: pr N c :: S) Eqs (P c). 
+
+typeof (pr (fn M) A :: S) Eqs  (all d\ all e\ P d e) :- !,
+  pi d\ tvar d => pi e\ tvar e => pi x\ tybind x d => 
+   typeof (pr (M x) e :: S) ((A === d --> e) :: Eqs) (P d e).
+
+typeof (pr (fixpt M) A :: S) Eqs  (all P) :- !,
+  pi d\ tvar d => pi x\ tybind x d => 
+   typeof (pr (M x) d :: S) ((A === d) :: Eqs) (P d).
+
+typeof (pr (cond Cond Then Else) A :: S) Eqs P :- !, 
+  typeof (pr Cond bool :: pr Then A :: pr Else A :: S) Eqs P.
+
+typeof (pr C B :: S) Eqs Poly :-
+  prim_poly C Ty, !, poly_inst Ty B S Eqs Poly.
+
+typeof (pr X B :: S) Eqs Poly :-
+  tybind X A, typeof S ((A === B) :: Eqs) Poly.
+
+typeof nil Eqs (c Ty) :-  unify Eqs topvar Ty.
+
+poly_inst (c Ty)    B S Eqs Poly :- typeof S ((Ty === B) :: Eqs) Poly.
+poly_inst (all Ty) B S Eqs (all Poly) :- 
+    pi x\ tvar x => poly_inst (Ty x) B S Eqs (Poly x).
+
+
+% The main predicate. Infer a poly type first and then prune 
+% vacuous quantifications
+type  polyinfer  tm -> poly -> o.
+
+polyinfer Tm Ty :- tyinfer Tm PreTy, rem_vac PreTy Ty.

--- a/tests/sources/pcf_legacy/polyinfer.sig
+++ b/tests/sources/pcf_legacy/polyinfer.sig
@@ -1,0 +1,11 @@
+/* 
+ * Interface to code for inferring polytypes for programs
+ * in the simple functional programming language
+ */
+
+sig  polyinfer.
+
+accum_sig  pcf, polytypes. 
+
+type  polyinfer  tm -> poly -> o.
+

--- a/tests/sources/pcf_legacy/polytypes.sig
+++ b/tests/sources/pcf_legacy/polytypes.sig
@@ -1,0 +1,19 @@
+/*
+ * Representing polytypes. Uses monotypes as the base, reflecting these
+ * into the encoding through a special constructor and adding 
+ * quantification. No type variables are assumed to appear in types at
+ * this level.
+ */
+
+sig  polytypes.
+
+accum_sig  monotypes.
+
+kind   poly    type.                
+
+type   all     (ty -> poly) -> poly.
+type   c       ty -> poly.
+
+
+
+

--- a/tests/sources/pcf_legacy/refl_syntax.mod
+++ b/tests/sources/pcf_legacy/refl_syntax.mod
@@ -1,0 +1,35 @@
+/*
+ * Code for recognizing the terms representing valid programs in the
+ * simple functional programming language that is considered here
+ */
+
+module refl_syntax.
+
+accum_sig   pcf.
+
+type   term      tm -> o.
+
+term (fn R) :- pi X\ ((term X) => (term (R X))).
+term (M `@ N) :- term M, term N.
+term (fixpt R) :- pi X\((term X) => (term (R X))).
+term (cond M N P) :- term M, term N, term P.
+
+term (in X).
+
+term and.
+term or.
+term false.
+term truth.
+term car.
+term cdr.
+term cons.
+term nullp.
+term consp.
+term empty.
+term equal.
+term greater.
+term zerop.
+term minus.
+term plus.
+term times.
+

--- a/tests/sources/pcf_legacy/refl_syntax.sig
+++ b/tests/sources/pcf_legacy/refl_syntax.sig
@@ -1,0 +1,10 @@
+/*
+ * Interface to a recognizer of valid program terms
+ */
+
+sig  refl_syntax. 
+
+accum_sig  pcf.
+
+/* the definition of this predicate may need to be dynamically extended */
+type   term      tm -> o.

--- a/tests/sources/pcf_legacy/tailrec.mod
+++ b/tests/sources/pcf_legacy/tailrec.mod
@@ -1,0 +1,25 @@
+/*
+ * Recognizing tail recursive functions of arbitrary arguments. 
+ * This code illustrates the use of Lambda Prolog scoping devices in
+ * realizing recursion over binding structure
+ */
+
+module  tailrec.
+
+accumulate refl_syntax.
+
+type  tailrec  tm -> o.
+type  trfn     tm -> o.
+type  headrec  tm -> o.
+type  trbody   tm -> o.
+
+tailrec (fixpt M) :- !, pi F\ ((headrec F) => (trfn (M F))).
+tailrec M.
+
+trfn (fn R) :- pi X\ ((term X) => (trfn (R X))).
+trfn R :- trbody R.
+
+trbody (cond M N P) :- term M, trbody N, trbody P.
+trbody (M `@ N) :- !, trbody M, term N.
+trbody M :- headrec M; term M.
+

--- a/tests/sources/pcf_legacy/tailrec.sig
+++ b/tests/sources/pcf_legacy/tailrec.sig
@@ -1,0 +1,13 @@
+/*
+ * Interface to code for recognizing tail recursiveness of arbitrary 
+ * arity functions
+ */
+
+sig  tailrec.
+
+accum_sig  pcf.
+
+type  term  tm -> o.
+
+exportdef  tailrec  tm -> o.
+

--- a/tests/sources/pcf_legacy/tr_test.mod
+++ b/tests/sources/pcf_legacy/tr_test.mod
@@ -1,0 +1,12 @@
+/*
+ *  A testing harness for the code that checks for tail recursiveness
+ *  of programs in the simple functional programming language.
+ */
+
+module tr_test.
+
+accumulate tailrec, examples. 
+
+type tr_test  string -> o.
+
+tr_test String :- prog String T, tailrec T.

--- a/tests/sources/pcf_legacy/tr_test.sig
+++ b/tests/sources/pcf_legacy/tr_test.sig
@@ -1,0 +1,10 @@
+/*
+ * Interface for testing code that checks for tail recursiveness 
+ * of programs in the simple functional programming language
+ */
+
+sig  tr_test.
+
+accum_sig tailrec.
+
+type  tr_test  string -> o.

--- a/tests/sources/pcf_legacy/unifytypes.mod
+++ b/tests/sources/pcf_legacy/unifytypes.mod
@@ -1,0 +1,73 @@
+/*
+ * Code for unifying types. Types are assumed to be represented like
+ * monotypes, i.e. without explicit quantification, with one exception:
+ * variables are not represented by meta variables but, rather, by 
+ * special constants of which the predicate tvar is true.
+ */
+
+module unifytypes.
+
+accum_sig   monotypes.
+
+accumulate  control.
+
+type  tvar  ty -> o.
+
+% Representation of disagreement pairs
+kind  eq       type.             
+type  ===       ty -> ty -> eq.
+infix ===       4.
+
+
+% subst_ty is a predicate such that (subst_ty V T Ty1 Ty2) is true if
+% replacing all occurrences of V in type Ty1 by T produces the type
+% Ty2; V is assumed to be (a special constant representing) a variable.
+type subst_ty   ty -> ty -> ty -> ty -> o.
+
+subst_ty V T Var S  :- tvar Var, if (V = Var) (S = T) (S = Var).
+subst_ty V T num num.
+subst_ty V T bool bool.
+subst_ty V T (lst A) (lst B) :- subst_ty V T A B.
+subst_ty V T (A --> B) (Ax --> Bx) :- subst_ty V T A Ax,  subst_ty V T B Bx.
+
+
+% Transforming an equation through a substitution
+type subst_eq   ty -> ty ->      eq ->      eq -> o.
+
+subst_eq  V T (A === B) (Ax === Bx) :- subst_ty V T A Ax, subst_ty V T B Bx.
+
+% Transforming a set of equations through a substitution
+type subst_eqs  ty -> ty -> list eq -> list eq -> o.
+
+subst_eqs V T nil nil.
+subst_eqs V T (Eq :: Eqs) (Eq' :: Eqs') :- 
+    subst_eq V T Eq Eq', subst_eqs V T Eqs Eqs'.
+
+% Checking if (a constant representing) a variable has occurrences 
+% in a type
+type free_occ  ty -> ty -> o.
+
+free_occ V V         :- tvar V.
+free_occ V (A --> B) :- free_occ V A; free_occ V B.
+free_occ V (lst A)   :- free_occ V A.
+
+
+% The main unification predicate; (unify Eqs In Out) is true if solving
+% the equations represented by Eqs results in In being instantiated to Out
+type  unify       list eq -> ty -> ty -> o.
+
+unify nil In In.
+unify ((A === A) :: Eqs) In Out :- !, unify Eqs In Out.
+unify ((A --> Ax === B --> Bx) :: Eqs) In Out :-
+  unify ((A === B) :: (Ax === Bx) :: Eqs) In Out.
+unify ((lst A === lst B) :: Eqs) In Out :- unify ((A === B) :: Eqs) In Out.
+unify ((A === B) :: Eqs) In Out :-
+  tvar A, !, not (free_occ A B),
+  subst_eqs A B Eqs Eqsx,
+  subst_ty    A B In  Mid,
+  unify Eqsx Mid Out.
+unify ((B === A) :: Eqs) In Out :- 
+  tvar A, !, not (free_occ A B),
+  subst_eqs A B Eqs Eqsx,
+  subst_ty    A B In  Mid,
+  unify Eqsx Mid Out.

--- a/tests/sources/pcf_legacy/unifytypes.sig
+++ b/tests/sources/pcf_legacy/unifytypes.sig
@@ -1,0 +1,23 @@
+/*
+ * Interface to code for unifying types. Types are assumed to be 
+ * represented like monotypes, i.e. without explicit quantification, 
+ * with one exception: variables are not represented by meta variables 
+ * but, rather, by special constants of which the predicate tvar is true.
+ */
+
+sig  unifytypes.
+
+accum_sig  monotypes.
+
+% predicate for encoding type variables
+type  tvar  ty -> o.
+
+% Representation of disagreement pairs
+kind  eq       type.             
+type  ===       ty -> ty -> eq.
+infix ===       4.
+
+% (unify Eqs In Out) is true if solving the equations represented by 
+% Eqs results in In being instantiated to Out 
+type  unify       list eq -> ty -> ty -> o.
+

--- a/tests/sources/printer.elpi
+++ b/tests/sources/printer.elpi
@@ -1,0 +1,8 @@
+main :-
+  print (p X :- q X, r x),
+  print (X is f Y mod r X),
+  print (X is f Y + r X * g A),
+  print (X is (f Y + r X) * g A),
+  print (X is f Y ^ r X ^ g A),
+  print (X || A && B ==> G),
+  print [f X, g Y, (a , b), a + b].

--- a/tests/sources/progs/eval.mod
+++ b/tests/sources/progs/eval.mod
@@ -10,7 +10,7 @@ eval  (cond X Y Z) V  :-
                 (eval X truth, eval Y V ; eval Z V), !.
 eval  (fix F) V               :-  
                 eval (F (fix F))  V, !.
-eval  (&& X Y) V   :-  
+eval  (X && Y) V   :-  
                 (eval X truth, eval Y truth, V = truth ;
                              V = false), !.
 eval  (plus X Y) (c V) :-  

--- a/tests/sources/progs/fp_vocab.sig
+++ b/tests/sources/progs/fp_vocab.sig
@@ -18,7 +18,7 @@ type   c       int -> tm.
 % encodings for booleans of the object language
 type   truth   tm.
 type   false   tm.
-type   &&      tm -> tm -> tm.
+type   (&&)      tm -> tm -> tm.
 
 % encodings for arithmetic functions of the object language
 type   plus    tm -> tm -> tm.

--- a/tests/sources/progs/refl_syntax.mod
+++ b/tests/sources/progs/refl_syntax.mod
@@ -18,7 +18,7 @@ term (c X).
 term null.
 term (cons Hd Tl) :- term Hd, term Tl.
 
-term (&& M N) :- term M, term N.
+term (M && N) :- term M, term N.
 term (plus M N) :- term M, term N.
 term (minus M N) :- term M, term N.
 term (times M N) :- term M, term N.

--- a/tests/sources/progs/terms.mod
+++ b/tests/sources/progs/terms.mod
@@ -8,7 +8,7 @@ trm trfact1 (fix F \ (abs N\ (abs M\
                    (app (app F (minus N (c 1))) (times N M)))))).
 
 trm trfact2 (fix F \ (abs P \ 
-             (cond (&& (prp P) (eq (fst P) (c 0))) (snd P)
+             (cond ((prp P) && (eq (fst P) (c 0))) (snd P)
                    (cond (prp P) (app F (pr (minus (fst P) (c 1))
                                             (times (fst P) (snd P))))
                           err)))).

--- a/tests/sources/sepcomp_perf.ml
+++ b/tests/sources/sepcomp_perf.ml
@@ -33,5 +33,5 @@ let () =
   let us = cc ~elpi ~flags 1 us in
   let ex = cc ~elpi ~flags 2 ex in
   let p = Compile.assemble ~elpi (us :: list_init 0 50000 (fun _ -> ex)) in
-  let q = Compile.query p (Parse.goal_from_stream (Ast.Loc.initial "g") (Stream.of_string "main")) in
+  let q = Compile.query p (Parse.goal_from ~elpi ~loc:(Ast.Loc.initial "g") (Lexing.from_string "main")) in
   exec q

--- a/tests/sources/sepcomp_template.ml
+++ b/tests/sources/sepcomp_template.ml
@@ -5,12 +5,12 @@ let init () =
 
 let cc ~elpi ~flags i u =
   Compile.unit ~elpi ~flags
-    (Parse.program_from_stream ~elpi (Ast.Loc.initial (Printf.sprintf "<u%d>" i))
-      (Stream.of_string u))
+    (Parse.program_from ~elpi ~loc:(Ast.Loc.initial (Printf.sprintf "<u%d>" i))
+      (Lexing.from_string u))
 
 let link ~elpi us =
   let p = Compile.assemble ~elpi us in
-  let q = Compile.query p (Parse.goal_from_stream (Ast.Loc.initial "g") (Stream.of_string "main")) in
+  let q = Compile.query p (Parse.goal_from ~elpi ~loc:(Ast.Loc.initial "g") (Lexing.from_string "main")) in
   q
 
 let check q =

--- a/tests/sources/w.elpi
+++ b/tests/sources/w.elpi
@@ -14,6 +14,7 @@ type lam (term -> term) -> term.
 type let term -> ty -> (term -> term) -> term.
 
 kind tye type.
+% elpi:skip 2
 infixr ==> 50.
 infixl # 60.
 type (==>) tye -> tye -> tye.

--- a/tests/sources/w_legacy.elpi
+++ b/tests/sources/w_legacy.elpi
@@ -1,0 +1,126 @@
+filter [] _ [].
+filter [X|XS] P [X|YS] :- P X, !, filter XS P YS.
+filter [_|XS] P YS :- filter XS P YS.
+
+mem [X|_] X :- !.
+mem [_|XS] X :- mem XS X.
+
+if G T _ :- G, !, T.
+if _ _ E :- E.
+
+kind term type.
+type app term -> term -> term.
+type lam (term -> term) -> term.
+type let term -> ty -> (term -> term) -> term.
+
+kind tye type.
+infixr ==> 50.
+infixl # 60.
+type (==>) tye -> tye -> tye.
+type (#) tye -> tye -> tye.
+
+kind ty type.
+type all (tye -> ty) -> ty.
+type mono tye -> ty.
+
+type one term.
+type plus term.
+type size term.
+type empty term.
+type comma term.
+
+type integer tye.
+type list tye.
+type pair tye.
+
+% constants
+w one    (mono integer).
+w plus   (mono (integer ==> integer ==> integer)).
+w size   (all x\ mono (list # x ==> integer)).
+w empty  (all x\ mono (list # x)).
+w comma  (all x\ all y\ mono (x ==> y ==> (pair # x # y))).
+
+pred w i:term, o:ty.
+
+w (app F X) (mono R) :-
+  w F (mono (A ==> R)),
+  w X (mono A).
+
+w (lam F) (mono (A ==> R)) :-
+  pi x\ w x (mono A) => w (F x) (mono R).
+
+w (let F FP B) (mono TC) :-
+  w F (mono FT),
+  declare_constraint (overbar (mono FT) FP) [],
+  pi x\ w x FP => w (B x) (mono TC).
+
+w X (mono T) :- w X (all Poly), specialize (all Poly) T.
+
+w X TY :- print "Error: " X "cannot have type" TY.
+
+pred specialize i:ty, o:tye.
+
+specialize (all F) T :- specialize (F FRESH_) T.
+specialize (mono X) X.
+
+pred overbar i:ty, o:ty.
+
+constraint w overbar {
+
+rule \ (G ?- overbar T T1)
+     | (generalize G T POLYT) <=> (T1 = POLYT).
+
+rule \ (G ?- overbar T _) <=> (print "overbar" G "|-" T "failed", halt).
+
+generalize G (mono T) ALL :-
+  free-ty (mono T) [] VT,
+  free-gamma G [] VG,
+  filter VT (x\ not(mem VG x)) Q,
+  quantify Q T ALL.
+
+free-ty (mono X) L L1 :- free X L L1.
+free-ty (all F) L L1 :- pi x\ free-ty (F x) L L1.
+
+free-gamma [] L L.
+free-gamma [w _ T|X] L L2 :- free-ty T L L1, free-gamma X L1 L2.
+
+free (A # B) L L2 :- free A L L1, free B L1 L2.
+free (A ==> B) L L2 :- free A L L1, free B L1 L2.
+free (uvar X _) L L1 :- if (mem L X) (L1 = L) (L1 = [X|L]).
+free X L L.
+
+copy-ty (mono X1) (mono X2) :- copy X1 X2.
+copy-ty (all F1) (all F2) :- pi x\ copy x x => copy-ty (F1 x) (F2 x).
+
+copy (A ==> B) (A1 ==> B1) :- copy A A1, copy B B1.
+copy (A # B) (A1 # B1) :- copy A A1, copy B B1.
+copy X X.
+
+quantify [] X (mono X1) :- copy X X1.
+quantify [X|XS] T (all x\ T2 x) :-
+  quantify XS T T1,
+  pi x\ copy (uvar X _) x => copy-ty T1 (T2 x).
+
+}
+
+main :-
+  print "Test 1",
+  P = let (lam x\x) T_ (id\ app (app plus (app id one))
+                                  (app size (app id empty))),
+  print "Typing" P,
+  w P TP,
+  print "OK" P "has type" TP,
+  print "",
+  print "Test 2",
+  X = lam (x\
+        let (lam y\ app (app comma x) y) Y_ (mk\
+          app (app comma (app mk one)) (app mk x))),
+  print "Typing" X,
+  w X XT,
+  print "OK" X "has type" XT,
+  print "",
+  print "Test 3",
+  Q = lam (id\ app (app plus (app id one))
+                                  (app size (app id empty))),
+  print "Typing" Q,
+  w Q TQ. % should print error

--- a/tests/suite/correctness_HO.ml
+++ b/tests/suite/correctness_HO.ml
@@ -127,6 +127,12 @@ let () = declare "notation"
   ~description:"extensible syntax"
   ()
 
+let () = declare "notation_legacy"
+  ~source_elpi:"notation_legacy.elpi"
+  ~legacy_parser:true
+  ~description:"extensible syntax"
+  ()
+
 let () = declare "pnf"
   ~source_elpi:"pnf.elpi"
   ~description:"some HO programming"
@@ -148,6 +154,23 @@ let () = declare "holp"
   ~description:"HOL programming"
   ()
 
+  let () = declare "holp_legacy"
+  ~source_elpi:"holp_legacy/main.mod"
+  ~source_teyjus:"holp_legacy/main.mod"
+  ~deps_teyjus:[
+    "holp_legacy/hcinterp_examples.mod";
+    "holp_legacy/hc_syntax.mod";
+    "holp_legacy/pnf_examples.mod";
+    "holp_legacy/hc_interp.mod";
+    "holp_legacy/lists.mod";
+    "holp_legacy/pnf.mod";
+    "holp_legacy/hcsyntax_examples.mod";
+    "holp_legacy/refl_syntax.mod";
+  ]
+  ~legacy_parser:true
+  ~description:"HOL programming"
+  ()
+
 let () = declare "ndprover"
   ~source_elpi:"ndprover/inter.mod"
   ~source_teyjus:"ndprover/inter.mod"
@@ -162,6 +185,20 @@ let () = declare "ndprover"
   ~description:"Natural deduction prover"
   ()
 
+  let () = declare "ndprover_legacy"
+  ~source_elpi:"ndprover_legacy/inter.mod"
+  ~source_teyjus:"ndprover_legacy/inter.mod"
+  ~deps_teyjus:[
+    "ndprover_legacy/formulas.mod";
+    "ndprover_legacy/ndtac.mod";
+    "ndprover_legacy/goalred.mod";
+    "ndprover_legacy/listmanip.mod";
+    "ndprover_legacy/tacticals.mod";
+  ]
+  ~input:"ndprover.stdin"
+  ~description:"Natural deduction prover"
+  ~legacy_parser:true
+  ()
 
 let () = declare "pcf"
   ~source_elpi:"pcf/pcf.mod"
@@ -181,6 +218,27 @@ let () = declare "pcf"
     "pcf/tr_test.mod";
   ]
   ~description:"type inference for PCF"
+  ()
+
+let () = declare "pcf_legacy"
+  ~source_elpi:"pcf_legacy/pcf.mod"
+  ~source_teyjus:"pcf_legacy/pcf.mod"
+  ~deps_teyjus:[
+    "pcf_legacy/control.mod";
+    "pcf_legacy/monoinfer.mod";
+    "pcf_legacy/poly_test.mod";
+    "pcf_legacy/unifytypes.mod";
+    "pcf_legacy/eval.mod";
+    "pcf_legacy/mono_test.mod";
+    "pcf_legacy/refl_syntax.mod";
+    "pcf_legacy/eval_test.mod";
+    "pcf_legacy/tailrec.mod";
+    "pcf_legacy/examples.mod";
+    "pcf_legacy/polyinfer.mod";
+    "pcf_legacy/tr_test.mod";
+  ]
+  ~description:"type inference for PCF"
+  ~legacy_parser:true
   ()
 
 let () = declare "progs"

--- a/tests/suite/elpi_specific.ml
+++ b/tests/suite/elpi_specific.ml
@@ -159,7 +159,7 @@ let () = declare "elpi_only_llam"
 
 let () = declare "hollight"
   ~source_elpi:"hollight.elpi"
-  ~description:"hollinght implementation"
+  ~description:"hollight implementation"
   ~expectation:Test.Failure (* needs advanced modes *)
   ()
 let () = declare "hollight_legacy"
@@ -261,4 +261,25 @@ let () = declare "variadic_declare_constraints"
   ~source_elpi:"variadic_declare_constraints.elpi"
   ~description:"declare_constraint takes keys of different types"
   ~expectation:Test.Success
+  ()
+
+let () = declare "notation_error"
+  ~source_elpi:"notation_error.elpi"
+  ~description:"infix declaration error"
+  ~expectation:Test.(FailureOutput (Str.regexp "not supported by this parser"))
+  ()
+
+let () = declare "printer"
+  ~source_elpi:"printer.elpi"
+  ~description:"printing infix"
+  ~typecheck:false
+  ~expectation:Test.(SuccessOutput (Str.regexp_string (
+    Str.global_replace (Str.regexp_string "\r") "" {|p X0 :- q X0 , r x
+X0 is f X1 mod r X0
+X0 is f X1 + r X0 * g X2
+X0 is (f X1 + r X0) * g X2
+X0 is f X1 ^ r X0 ^ g X2
+X0 || X2 && X3 ==> X4
+[f X0, g X1, (a , b), a + b]
+|})))
   ()

--- a/tests/suite/elpi_specific.ml
+++ b/tests/suite/elpi_specific.ml
@@ -160,7 +160,7 @@ let () = declare "elpi_only_llam"
 let () = declare "hollight"
   ~source_elpi:"hollight.elpi"
   ~description:"hollight implementation"
-  ~expectation:Test.Failure (* needs advanced modes *)
+  ~expectation:Test.(FailureOutput (Str.regexp "line 231")) (* needs advanced modes *)
   ()
 let () = declare "hollight_legacy"
   ~source_elpi:"hollight_legacy.elpi"

--- a/tests/suite/elpi_specific.ml
+++ b/tests/suite/elpi_specific.ml
@@ -106,6 +106,11 @@ let () = declare "w"
   ~source_elpi:"w.elpi"
   ~description:"ELPI example at MLWS"
   ()
+let () = declare "w_legacy"
+  ~source_elpi:"w_legacy.elpi"
+  ~legacy_parser:true
+  ~description:"ELPI example at MLWS"
+  ()
 let () = declare "uvar_keyword"
   ~source_elpi:"uvar_chr.elpi"
   ~description:"uvar kwd status at the meta level"
@@ -156,6 +161,12 @@ let () = declare "hollight"
   ~source_elpi:"hollight.elpi"
   ~description:"hollinght implementation"
   ~expectation:Test.Failure (* needs advanced modes *)
+  ()
+let () = declare "hollight_legacy"
+  ~source_elpi:"hollight_legacy.elpi"
+  ~description:"hollight implementation"
+  ~expectation:Test.Failure (* needs advanced modes *)
+  ~legacy_parser:true
   ()
 
 let () = declare "asclause"

--- a/tests/suite/suite.ml
+++ b/tests/suite/suite.ml
@@ -298,6 +298,7 @@ let match_rex rex input_line =
     done
   with End_of_file -> () end;
   let s = Buffer.contents b in
+  let s = Str.global_replace (Str.regexp_string "\r") "" s in
   try ignore(Str.search_forward rex s 0); true
   with Not_found -> false
 

--- a/tests/suite/suite.ml
+++ b/tests/suite/suite.ml
@@ -27,6 +27,7 @@ type t = {
   expectation : expectation;
   outside_llam : bool;
   trace : string list;
+  legacy_parser : bool;
 }
 
 let tests = ref []
@@ -37,6 +38,7 @@ let declare
     ?(typecheck=true) ?input ?(expectation=Success)
     ?(outside_llam=false)
     ?(trace=Off)
+    ?(legacy_parser=false)
     ~category
     ()
 =
@@ -59,6 +61,7 @@ let declare
     expectation;
     category;
     outside_llam;
+    legacy_parser;
     trace = (match trace with Off -> [] | On l -> "-trace-on" :: l)
   } :: !tests
 
@@ -157,6 +160,10 @@ let open_file_w name =
 let open_log ~executable { Test.name; _ } =
   begin try Unix.mkdir logdir 0o770 with Unix.Unix_error _ -> () end;
   let name = logdir^"/"^Filename.basename executable^"+"^name^".log" in
+  open_file_w name, name
+
+let open_dummy_log () =
+  let name = Filename.temp_file "elpi" "txt" in
   open_file_w name, name
 
 let write (fd,_) s = ignore(Unix.write_substring fd s 0 (String.length s))
@@ -282,13 +289,17 @@ let read_time input_line =
   with End_of_file -> !time
 
 let match_rex rex input_line =
-  let b = ref false in
-  try while true do
+  let b = Buffer.create 100 in
+  begin try
+    while true do
     let l = input_line () in
-    try ignore(Str.search_forward rex l 0); b := true
-    with Not_found -> ()
-  done; !b
-  with End_of_file -> !b
+    Buffer.add_string b l;
+    Buffer.add_string b "\n";
+    done
+  with End_of_file -> () end;
+  let s = Buffer.contents b in
+  try ignore(Str.search_forward rex s 0); true
+  with Not_found -> false
 
 let read_tctime input_line =
   let time = ref 0.0 in
@@ -300,9 +311,20 @@ let read_tctime input_line =
   done; !time
   with End_of_file -> !time
 
+let legacy_parser_available executable =
+  let log = Util.open_dummy_log () in
+  let env = Unix.environment () in
+  match
+    Util.exec ~executable ~timeout:1.0 ~env ~log ~args:["-legacy-parser-available"] ()
+  with
+  | Util.Exit(0,_,_) -> true
+  | _ -> false
+
 let () = Runner.declare
-  ~applicable:begin fun ~executable { Test.source_elpi; _ } ->
-    if is_elpi executable && source_elpi <> None then Runner.Can_run_it
+  ~applicable:begin fun ~executable { Test.source_elpi; legacy_parser; _ } ->
+    if is_elpi executable && source_elpi <> None && 
+      (not legacy_parser || legacy_parser_available executable)
+      then Runner.Can_run_it
     else Runner.Not_for_me
   end
   ~run:begin fun ~executable ~timetool ~timeout ~env ~sources test ->
@@ -315,12 +337,15 @@ let () = Runner.declare
     Util.write log (Printf.sprintf "executable: %s\n" executable);
     let executable_stuff = Filename.dirname executable ^ "/../lib/elpi/" in
 
-    let { Test.expectation; input; outside_llam ; typecheck; trace; _ } = test in
+    let { Test.expectation; input; outside_llam ; typecheck; trace; legacy_parser; _ } = test in
     let input = Util.option_map (fun x -> sources^x) input in
     let args = ["-test";"-I";executable_stuff;"-I";sources;source] @ trace in
     let args =
       if typecheck then args
       else "-no-tc" :: args in
+    let args =
+      if not legacy_parser then args
+      else "-legacy-parser" :: args in
     let args =
       if outside_llam then "-delay-problems-outside-pattern-fragment"::args
       else args in

--- a/tests/suite/suite.mli
+++ b/tests/suite/suite.mli
@@ -24,6 +24,7 @@ val declare :
   ?expectation:expectation -> 
   ?outside_llam:bool ->
   ?trace:trace ->
+  ?legacy_parser:bool ->
   category:string ->
   unit -> unit
 
@@ -41,6 +42,7 @@ type t = {
   expectation : expectation;
   outside_llam : bool;
   trace: string list;
+  legacy_parser : bool;
 }
 
 val get : catskip:string list -> (name:string -> bool) -> t list

--- a/tests/test.real.ml
+++ b/tests/test.real.ml
@@ -207,8 +207,10 @@ let info =
     |> List.map (fun (cat,ts) -> [ `I(cat,String.concat ", " ts) ])
     |> List.concat in
   let man = [`Blocks [`S "KNOWN TESTS" ; `Blocks tests ] ] in
-  Term.info ~doc ~exits:Term.default_exits ~man "test" 
+  (Term.info ~doc ~exits:Term.default_exits ~man "test") [@ warning "-A"]
+  (* ocaml >= 4.08 | Cmd.info ~doc ~exits:Cmd.Exit.defaults ~man "test" *)
 ;;
 
 let () =
-  Term.exit @@ Term.eval (Term.(const main $ src $ plot $ timeout $ runners $ namef $ catskip $ mem $ seed), info)
+  (Term.exit @@ Term.eval (Term.(const main $ src $ plot $ timeout $ runners $ namef $ catskip $ mem $ seed),info)) [@ warning "-A"]
+  (* ocaml >= 4.08 | exit @@ Cmd.eval (Cmd.v info Term.(const main $ src $ plot $ timeout $ runners $ namef $ catskip $ mem $ seed)) *)


### PR DESCRIPTION
TODO:
- [x] documentation, see _log/elpi+notation_error.log
- [x] apply camlp5 patch here, camlp5 8.x
- [x] test coq-elpi (heavy user of quotations)
- [x] lexer: `% elpi:skip 3` to skip 3 lines, so that one can say
  ```
   % elpi:skip 1
   infix ==> 120.
   ```
   and have it work with both Elpi and Teyjus (when the mixfix is compatible with the new parser)