### PR TITLE
Make comma optional in predicate declarations

### DIFF
--- a/src/parser/error_messages.txt
+++ b/src/parser/error_messages.txt
@@ -421,13 +421,13 @@ Unexpected ')'.
 
 program: PRED VDASH
 program: PRED AFTER VDASH
-program: PRED AFTER IO COLON AFTER CONJ VDASH
-program: PRED AFTER IO VDASH
-program: PRED AFTER IO COLON VDASH
-program: PRED AFTER IO COLON AFTER RPAREN
+program: PRED AFTER IO_COLON AFTER CONJ VDASH
+program: PRED AFTER IO_COLON VDASH
+program: PRED AFTER IO_COLON AFTER RPAREN
 
 Predicate declaration expected. Examples:
 pred append i:list A, i:list A, o:list A.
+pred append i:list A i:list A o:list A.
 pred map i:list A, i:(A -> B -> prop), o:list B.
 
 program: EXPORTDEF AFTER LPAREN USE_SIG

--- a/src/parser/grammar.mly
+++ b/src/parser/grammar.mly
@@ -154,7 +154,7 @@ chr_rule:
 
 pred:
 | attributes = attributes; PRED;
-  c = constant; args = separated_list(CONJ,pred_item) { 
+  c = constant; args = separated_list(option(CONJ),pred_item) {
    let name = c in
    { Mode.loc=loc $sloc; name; args = List.map fst args },
    { Type.loc=loc $sloc; attributes; name;
@@ -162,9 +162,9 @@ pred:
        mkApp (loc $loc(c)) [mkCon "->";t;ty]) args (mkCon "prop") }
  }
 pred_item:
-| io = i_o; COLON; ty = type_term { (io,ty) }
-i_o:
-| io = IO { 
+| io = i_o_colon; ty = type_term { (io,ty) }
+i_o_colon:
+| io = IO_COLON { 
     if io = 'i' then true
     else if io = 'o' then false
     else assert false
@@ -199,6 +199,12 @@ kind_term:
 mode:
 | MODE; LPAREN; c = constant; l = nonempty_list(i_o); RPAREN {
     { Mode.name = c; args = l; loc = loc $sloc } 
+}
+i_o:
+| io = IO { 
+    if io = 'i' then true
+    else if io = 'o' then false
+    else assert false
 }
 
 macro:

--- a/src/parser/lexer.mll.in
+++ b/src/parser/lexer.mll.in
@@ -130,6 +130,7 @@ and token = parse
 | "}" { RCURLY }
 | "|" { PIPE }
 | "{{" { skip lexbuf 2; quoted 2 lexbuf }
+| (("i" | "o") as s) (' ' | '\t')* ':' { IO_COLON s }
 | ("i" | "o") as s { IO s }
 | "shorten" { SHORTEN }
 | "accumulate" { ACCUMULATE }

--- a/src/parser/test_lexer.ml
+++ b/src/parser/test_lexer.ml
@@ -40,6 +40,7 @@ type t = Tokens.token =
   | LBRACKET
   | KIND
   | IS
+  | IO_COLON of (char)
   | IO of (char)
   | INTEGER of ( int )
   | INDEX
@@ -189,3 +190,8 @@ a|}                                   [T(CONSTANT "b", 2, 1, 2);T(CONSTANT "c", 
   test  ":name"                       [T(COLON,1,0,1); T(NAME,1,0,5)];
   test  "@foo"                        [T(CONSTANT "@foo",1,0,4)];
   test  "a && b"                       [T(CONSTANT "a",1,0,1);T(FAMILY_AND "&&",1,0,4);T(CONSTANT "b",1,0,6)];
+  (*    01234567890123456789012345 *)
+  test  "i:"                          [T(IO_COLON 'i', 1, 0, 2)];
+  test  "o:"                          [T(IO_COLON 'o', 1, 0, 2)];
+  test  "i"                           [T(IO 'i', 1, 0, 1)];
+  test  "o"                           [T(IO 'o', 1, 0, 1)];

--- a/src/parser/tokens.mly
+++ b/src/parser/tokens.mly
@@ -18,6 +18,7 @@
 %token PIPE
 %token AS
 %token IS
+%token <char> IO_COLON
 %token <char> IO
 %token ARROW
 %token DARROW


### PR DESCRIPTION
This is a bit hackish as it modifies the lexer but I think it's ok.

If we decide to go for it, I should add tests and doc.
