### PR TITLE
elpi.opam: depend on OCaml 4.08

### DIFF
--- a/elpi.opam
+++ b/elpi.opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.07.0" }
+  "ocaml" {>= "4.08.0" }
   "stdlib-shims"
   "ppxlib" {>= "0.12.0" }
   "menhir" {>= "20211230" }


### PR DESCRIPTION
(Seems) needed to match the changelogs in https://github.com/LPCIC/elpi/releases, assuming those are correct — haven't checked.