### PR TITLE
Hide unsafe code from the optimiser

### DIFF
--- a/elpi.opam
+++ b/elpi.opam
@@ -25,8 +25,8 @@ depends: [
   "cmdliner" {with-test}
   "dune" {>= "2.8.0"}
   "conf-time" {with-test}
-  "atdgen" {>= "2.9.1"}
-  "atdts" {>= "2.9.1"}
+  "atdgen" {>= "2.9.1" & < "2.10.0"}
+  "atdts" {>= "2.9.1" & < "2.10.0"}
 ]
 depopts: [
   "elpi-option-legacy-parser"

--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -2842,7 +2842,7 @@ and alternative = {
   clauses : clause list;
   next : alternative;
 }
-let noalts : alternative = Obj.magic 0
+let noalts : alternative = Obj.magic (Sys.opaque_identity 0)
 
 (******************************************************************************
   Constraint propagation


### PR DESCRIPTION
The type definition for `alternatives` is a record, so a clever compiler (such as Flambda 2) can assume that values of this type can never be equal to `0`. This translates all `alts == noalts` checks into trivial `false` constants, eventually breaking down with a segfault when `noalts` is actually passed.
My proposed fix is the minimal one: hide the constant `0` from the compiler, so it can't optimise away.
The real fix is to use a variant definition. Example:
```ocaml
and alternative =
| Noalts
| Alts of {
  cutto_alts : alternative;
  program : prolog_prog;
  adepth : int;
  agoal_hd : constant;
  ogoal_arg : term;
  ogoal_args : term list;
  agid : UUID.t; [@trace]
  goals : goal list;
  stack : frame;
  trail : T.trail;
  state : State.t;
  clauses : clause list;
  next : alternative;
}
```
It's exactly the same runtime representation as the current one, but type-safe.
