### PR TITLE
Open Gramlib in legacy parser

### DIFF
--- a/src/legacy_parser/parser.ml
+++ b/src/legacy_parser/parser.ml
@@ -9,6 +9,7 @@ module Loc = U.Loc
 open Elpi_parser.Ast
 open Elpi_parser.Parser_config
 open Term
+open Gramlib
 
 module Str = Re.Str
 


### PR DESCRIPTION
This is needed to bring `Ploc` into scope.
