### PR TITLE
Run dune build and check in modified files

### DIFF
--- a/src/trace_atd.ts
+++ b/src/trace_atd.ts
@@ -1059,7 +1059,7 @@ function _atd_write_option<T>(write_elt: (x: T, context: any) => any):
   return write_option
 }
 
-function _atd_write_nullable<T>(write_elt: (x: T | null, context: any) => any):
+function _atd_write_nullable<T>(write_elt: (x: T, context: any) => any):
   (x: T | null, context: any) => any {
   function write_option(x: T | null, context: any): any {
     if (x === null)


### PR DESCRIPTION
After running `dune build`, the workspace isn't clean. Fix this by running `dune build` and commiting.