### PR TITLE
improve separate compilation API performance

### DIFF
--- a/elpi.opam
+++ b/elpi.opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "subst"] {dev}
   [make "config" "LEGACY_PARSER=1"] {elpi-option-legacy-parser:installed}
   ["dune" "build" "-p" name "-j" jobs]
-  [make "tests" "DUNE_OPTS=-p %{name}%" "SKIP=performance_HO" "SKIP+=performance_FO"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
+  [make "tests" "DUNE_OPTS=-p %{name}%" "SKIP=performance_HO" "SKIP+=performance_FO" "SKIP+=elpi_api_performance"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
 ]
 
 depends: [

--- a/src/compiler.ml
+++ b/src/compiler.ml
@@ -435,7 +435,7 @@ type program = {
   toplevel_macros : macro_declaration;
 }
 and pbody = {
-  types : typ list C.Map.t; (* TODO: use a map : symbol -> types to speed up merge types *)
+  types : typ list C.Map.t;
   type_abbrevs : type_abbrev_declaration C.Map.t;
   modes : (mode * Loc.t) C.Map.t;
   body : block list;

--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -2484,7 +2484,7 @@ let add_clauses ~depth clauses p =
   let p = List.fold_left (add1clause ~depth) p clauses in
   p
 
-let make_index ~depth ~indexing p =
+let make_index ~depth ~indexing ~clauses_rev:p =
   let m = C.Map.fold (fun predicate (mode, indexing) m ->
     match indexing with
     | Hash args ->
@@ -2502,7 +2502,6 @@ let make_index ~depth ~indexing p =
         flex_arg_clauses = [];
         arg_idx = Ptmap.empty;
       }) m) indexing Ptmap.empty in
-  let p = List.rev p in
   { index = add_clauses ~depth p m; src = [] }
 
 let add_clauses ~depth clauses clauses_src { index; src } =
@@ -2617,7 +2616,7 @@ end (* }}} *)
 open Indexing
 
 (* Used to pass the program to the CHR runtime *)
-let orig_prolog_program = Fork.new_local (make_index ~depth:0 ~indexing:C.Map.empty [])
+let orig_prolog_program = Fork.new_local (make_index ~depth:0 ~indexing:C.Map.empty ~clauses_rev:[])
 
 (******************************************************************************
   Dynamic Prolog program

--- a/src/runtime.mli
+++ b/src/runtime.mli
@@ -64,7 +64,7 @@ val subst: depth:int -> term list -> term -> term
 val make_index :
   depth:int ->
   indexing:(mode * indexing) Constants.Map.t ->
-  (constant * clause) list ->
+  clauses_rev:(constant * clause) list ->
     prolog_prog
 
 (* The projection from the internal notion of constraints in the API one *)

--- a/tests/sources/dune
+++ b/tests/sources/dune
@@ -5,4 +5,7 @@
 (executable (name sepcomp4) (modules sepcomp4) (libraries sepcomp))
 (executable (name sepcomp5) (modules sepcomp5) (libraries sepcomp))
 (executable (name sepcomp6) (modules sepcomp6) (libraries sepcomp))
-(executable (name sepcomp_perf) (modules sepcomp_perf) (libraries sepcomp))
+(executable (name sepcomp_perf1) (modules sepcomp_perf1) (libraries sepcomp))
+(executable (name sepcomp_perf2) (modules sepcomp_perf2) (libraries sepcomp))
+(executable (name sepcomp_perf3) (modules sepcomp_perf3) (libraries sepcomp))
+(executable (name sepcomp_perf4) (modules sepcomp_perf4) (libraries sepcomp))

--- a/tests/sources/sepcomp_perf1.ml
+++ b/tests/sources/sepcomp_perf1.ml
@@ -32,7 +32,11 @@ let () =
   let flags = Compile.default_flags in
   let us = cc ~elpi ~flags 1 us in
   let ex = cc ~elpi ~flags 2 ex in
-  let exs = list_init 0 50000 (fun _ -> ex) in
-  let p = Compile.assemble ~elpi (us :: exs) in
+  let p = Compile.assemble ~elpi [us] in
+  let exs = list_init 0 2000 (fun _ -> ex) in
+  let rec extend i p =
+    if i = 0 then p
+    else extend (i-1) (Compile.extend ~base:p exs) in
+  let p = extend 5 p in
   let q = Compile.query p (Parse.goal_from ~elpi ~loc:(Ast.Loc.initial "g") (Lexing.from_string "main")) in
   exec q

--- a/tests/sources/sepcomp_perf1.ml
+++ b/tests/sources/sepcomp_perf1.ml
@@ -32,6 +32,7 @@ let () =
   let flags = Compile.default_flags in
   let us = cc ~elpi ~flags 1 us in
   let ex = cc ~elpi ~flags 2 ex in
-  let p = Compile.assemble ~elpi (us :: list_init 0 50000 (fun _ -> ex)) in
+  let exs = list_init 0 50000 (fun _ -> ex) in
+  let p = Compile.assemble ~elpi (us :: exs) in
   let q = Compile.query p (Parse.goal_from ~elpi ~loc:(Ast.Loc.initial "g") (Lexing.from_string "main")) in
   exec q

--- a/tests/sources/sepcomp_perf2.ml
+++ b/tests/sources/sepcomp_perf2.ml
@@ -1,0 +1,39 @@
+let us = {|
+
+main :- p0, p1, p2, p3, p4, p5, p6, p7, p8, p9.
+
+|}
+
+let ex = {|
+
+p0 :- print "ok".
+p1 :- print "ok".
+p2 :- print "ok".
+p3 :- print "ok".
+p4 :- print "ok".
+p5 :- print "ok".
+p6 :- print "ok".
+p7 :- print "ok".
+p8 :- print "ok".
+p9 :- print "ok".
+
+|}
+
+open Elpi.API
+
+(* XXX 4.06: List.init *)
+let rec list_init i n f =
+  if i >= n then [] else
+  f i :: list_init (i+1) n f
+
+let () =
+  let open Sepcomp.Sepcomp_template in
+  let elpi = init () in
+  let flags = Compile.default_flags in
+  let us = cc ~elpi ~flags 1 us in
+  let ex = cc ~elpi ~flags 2 ex in
+  let p = Compile.assemble ~elpi [us] in
+  let exs = list_init 0 50000 (fun _ -> ex) in
+  let p = Compile.extend ~base:p exs in
+  let q = Compile.query p (Parse.goal_from ~elpi ~loc:(Ast.Loc.initial "g") (Lexing.from_string "main")) in
+  exec q

--- a/tests/sources/sepcomp_perf2.ml
+++ b/tests/sources/sepcomp_perf2.ml
@@ -33,7 +33,10 @@ let () =
   let us = cc ~elpi ~flags 1 us in
   let ex = cc ~elpi ~flags 2 ex in
   let p = Compile.assemble ~elpi [us] in
-  let exs = list_init 0 50000 (fun _ -> ex) in
-  let p = Compile.extend ~base:p exs in
+  let exs = list_init 0 5 (fun _ -> ex) in
+  let rec extend i p =
+    if i = 0 then p
+    else extend (i-1) (Compile.extend ~base:p exs) in
+  let p = extend 2000 p in
   let q = Compile.query p (Parse.goal_from ~elpi ~loc:(Ast.Loc.initial "g") (Lexing.from_string "main")) in
   exec q

--- a/tests/sources/sepcomp_perf3.ml
+++ b/tests/sources/sepcomp_perf3.ml
@@ -1,0 +1,40 @@
+let us = {|
+
+main :- p0, p1, p2, p3, p4, p5, p6, p7, p8, p9.
+
+|}
+
+let ex = {|
+
+p0 :- print "ok".
+p1 :- print "ok".
+p2 :- print "ok".
+p3 :- print "ok".
+p4 :- print "ok".
+p5 :- print "ok".
+p6 :- print "ok".
+p7 :- print "ok".
+p8 :- print "ok".
+p9 :- print "ok".
+
+|}
+
+open Elpi.API
+
+(* XXX 4.06: List.init *)
+let rec list_init i n f =
+  if i >= n then [] else
+  f i :: list_init (i+1) n f
+
+let () =
+  let open Sepcomp.Sepcomp_template in
+  let elpi = init () in
+  let flags = Compile.default_flags in
+  let us = cc ~elpi ~flags 1 us in
+  let ex = cc ~elpi ~flags 2 ex in
+  let p = Compile.assemble ~elpi [us] in
+  let exs = list_init 0 50000 (fun _ -> ex) in
+  let p = Compile.extend ~base:p exs in
+  let p = Compile.extend ~base:p exs in
+  let q = Compile.query p (Parse.goal_from ~elpi ~loc:(Ast.Loc.initial "g") (Lexing.from_string "main")) in
+  exec q

--- a/tests/sources/sepcomp_perf3.ml
+++ b/tests/sources/sepcomp_perf3.ml
@@ -34,7 +34,9 @@ let () =
   let ex = cc ~elpi ~flags 2 ex in
   let p = Compile.assemble ~elpi [us] in
   let exs = list_init 0 50000 (fun _ -> ex) in
-  let p = Compile.extend ~base:p exs in
-  let p = Compile.extend ~base:p exs in
+  let rec extend i p =
+    if i = 0 then p
+    else extend (i-1) (Compile.extend ~base:p exs) in
+  let p = extend 1 p in
   let q = Compile.query p (Parse.goal_from ~elpi ~loc:(Ast.Loc.initial "g") (Lexing.from_string "main")) in
   exec q

--- a/tests/sources/sepcomp_perf4.ml
+++ b/tests/sources/sepcomp_perf4.ml
@@ -1,0 +1,41 @@
+let us = {|
+
+main :- p0, p1, p2, p3, p4, p5, p6, p7, p8, p9.
+
+|}
+
+let ex = {|
+
+p0 :- print "ok".
+p1 :- print "ok".
+p2 :- print "ok".
+p3 :- print "ok".
+p4 :- print "ok".
+p5 :- print "ok".
+p6 :- print "ok".
+p7 :- print "ok".
+p8 :- print "ok".
+p9 :- print "ok".
+
+|}
+
+open Elpi.API
+
+(* XXX 4.06: List.init *)
+let rec list_init i n f =
+  if i >= n then [] else
+  f i :: list_init (i+1) n f
+
+let () =
+  let open Sepcomp.Sepcomp_template in
+  let elpi = init () in
+  let flags = Compile.default_flags in
+  let us = cc ~elpi ~flags 1 us in
+  let ex = cc ~elpi ~flags 2 ex in
+  let p = Compile.assemble ~elpi [us] in
+  let exs = list_init 0 50000 (fun _ -> ex) in
+  let p = Compile.extend ~base:p exs in
+  let p = Compile.extend ~base:p exs in
+  let p = Compile.extend ~base:p exs in
+  let q = Compile.query p (Parse.goal_from ~elpi ~loc:(Ast.Loc.initial "g") (Lexing.from_string "main")) in
+  exec q

--- a/tests/sources/sepcomp_perf4.ml
+++ b/tests/sources/sepcomp_perf4.ml
@@ -34,8 +34,9 @@ let () =
   let ex = cc ~elpi ~flags 2 ex in
   let p = Compile.assemble ~elpi [us] in
   let exs = list_init 0 50000 (fun _ -> ex) in
-  let p = Compile.extend ~base:p exs in
-  let p = Compile.extend ~base:p exs in
-  let p = Compile.extend ~base:p exs in
+  let rec extend i p =
+    if i = 0 then p
+    else extend (i-1) (Compile.extend ~base:p exs) in
+  let p = extend 2 p in
   let q = Compile.query p (Parse.goal_from ~elpi ~loc:(Ast.Loc.initial "g") (Lexing.from_string "main")) in
   exec q

--- a/tests/suite/elpi_api.ml
+++ b/tests/suite/elpi_api.ml
@@ -42,10 +42,3 @@ let () = declare "sepcomp6"
   ~expectation:Test.(SuccessOutput (Str.regexp "ok"))
   ()
 
-
-let () = declare "sepcomp_perf"
-  ~source_dune:"sepcomp_perf.ml"
-  ~after:"sepcomp_perf"
-  ~description:"separate compilation perf"
-  ~expectation:Test.Success
-  ()

--- a/tests/suite/elpi_api_performance.ml
+++ b/tests/suite/elpi_api_performance.ml
@@ -1,0 +1,34 @@
+(* elpi: embedded lambda prolog interpreter                                  *)
+(* license: GNU Lesser General Public License Version 2.1 or later           *)
+(* ------------------------------------------------------------------------- *)
+open Suite
+
+let declare = Test.declare ~category:(Filename.(chop_extension (basename __FILE__)))
+
+let () = declare "sepcomp_perf1"
+  ~source_dune:"sepcomp_perf1.ml"
+  ~after:"sepcomp_perf1"
+  ~description:"separate compilation perf"
+  ~expectation:Test.Success
+  ()
+
+let () = declare "sepcomp_perf2"
+  ~source_dune:"sepcomp_perf2.ml"
+  ~after:"sepcomp_perf2"
+  ~description:"separate compilation linker perf"
+  ~expectation:Test.Success
+  ()
+
+let () = declare "sepcomp_perf3"
+  ~source_dune:"sepcomp_perf3.ml"
+  ~after:"sepcomp_perf3"
+  ~description:"separate compilation linker perf"
+  ~expectation:Test.Success
+  ()
+
+let () = declare "sepcomp_perf4"
+  ~source_dune:"sepcomp_perf4.ml"
+  ~after:"sepcomp_perf4"
+  ~description:"separate compilation linker perf"
+  ~expectation:Test.Success
+  ()


### PR DESCRIPTION
todo:
- [x] why spill run on the whole program (and not just the new part)?
- [x] merge_types is quadratic 
- [ ] why insertion on the whole list, and not per-predicate?
- [x] why clauses are kept in regular order is we typically append to them? (keep them in rev order)