### PR TITLE
avoid infinite loop when calling rev with flex term

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
   - Add `choose`, `min`, `max`, `fold` and `partition` methods to OCaml sets
   - Add `fold` method to OCaml maps
 
+- Stdlib:
+  - Fix first argument of `std.rev` is in input
+
 - Runtime:
   - Fix discrimination tree retrieval
 

--- a/src/builtin.elpi
+++ b/src/builtin.elpi
@@ -592,6 +592,8 @@ length []    0.
 
 pred rev i:list A, o:list A.
 rev L RL  :- rev.aux L []  RL.
+
+pred rev.aux i:list A, i:list A, o:list A.
 rev.aux [X|XS] ACC R :- rev.aux XS [X|ACC] R.
 rev.aux [] L L.
 

--- a/src/builtin_stdlib.elpi
+++ b/src/builtin_stdlib.elpi
@@ -69,6 +69,8 @@ length []    0.
 
 pred rev i:list A, o:list A.
 rev L RL  :- rev.aux L []  RL.
+
+pred rev.aux i:list A, i:list A, o:list A.
 rev.aux [X|XS] ACC R :- rev.aux XS [X|ACC] R.
 rev.aux [] L L.
 

--- a/tests/sources/trace_findall.elab.json
+++ b/tests/sources/trace_findall.elab.json
@@ -89,9 +89,9 @@
                     "File",
                     {
                       "filename": "builtin_stdlib.elpi",
-                      "line": 287,
+                      "line": 289,
                       "column": 0,
-                      "character": 9518
+                      "character": 9562
                     }
                   ]
                 }
@@ -117,9 +117,9 @@
                   "File",
                   {
                     "filename": "builtin_stdlib.elpi",
-                    "line": 287,
+                    "line": 289,
                     "column": 0,
-                    "character": 9518
+                    "character": 9562
                   }
                 ]
               }
@@ -442,9 +442,9 @@
                   "File",
                   {
                     "filename": "builtin_stdlib.elpi",
-                    "line": 287,
+                    "line": 289,
                     "column": 0,
-                    "character": 9518
+                    "character": 9562
                   }
                 ]
               }

--- a/tests/sources/trace_findall.json
+++ b/tests/sources/trace_findall.json
@@ -10,8 +10,8 @@
 {"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["std.findall","std.findall (p _) X0"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin_stdlib.elpi\", line 287, column 0, character 9518:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin_stdlib.elpi\", line 287, column 0, character 9518:","(std.findall A0 A1) :- (findall_solutions A0 A1)."]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin_stdlib.elpi\", line 289, column 0, character 9562:"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin_stdlib.elpi\", line 289, column 0, character 9562:","(std.findall A0 A1) :- (findall_solutions A0 A1)."]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := p _"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := X0"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["7"]}


### PR DESCRIPTION
before:
```prolog
main :-
  std.rev A B. % Here infinite loop
```
now: when $1^{st}$ arg of `std.rev` is flex, modes correctly prevents the loop