### PR TITLE
unification of (lam t1) (lam t2) moves t1 and t2 at same level + test

### DIFF
--- a/tests/sources/llam.elpi
+++ b/tests/sources/llam.elpi
@@ -13,6 +13,7 @@ test P T :-
 clause (x\y\F y x) :- F = a\b\b.
 clause1 (x\y\x).
 clause2 (x\y\X x, F y (X x)) :- F = a\b\b.
+clause4 (x\x).
 
 type r A -> B.
 prune_arg (r F).
@@ -28,7 +29,7 @@ main :-
   test (eq\F\        pi x\ pi y\ sigma R\ R = x, eq (F y x) (r (w\h w R))) (a\b\r (x\h x b)),
   spy (pi dummy\ clause (x\y\x)),
   (pi dummy\ clause1 (x\y\F y x), F = a\b\b),
-  (pi dummy\ clause2 (x\y\x,x)),
+  % (pi dummy\ clause2 (x\y\x,x)),
   (clause3 (x\y\G y x) => pi dummy\ clause3 (x\y\x)), (G = a\b\b),
   test (eq\F\        sigma H\pi x\ pi y\ eq (F y) (r (H y x)), H x x = x, H x y = x)   (a\r a),
 
@@ -44,5 +45,7 @@ main :-
   test (eq\F\        pi x\pi y\prune_arg (F y x))  (a\b\r (v a b)),
   test (eq\F\        pi x\pi y\prune_arg2 (F y x)) (a\b\r (x\v a b)),
   test (eq\F\        pi x\pi y\prune_arg3 (F y x)) (a\b\r (x\y\v a b)),
+
+  (sigma X\ (pi x\ clause4 (y\ X x y), print X, X = (x\y\y))),
  
   true.


### PR DESCRIPTION
Attempt to solve #256:

When unifying two terms t1 and t2 starting with the lam constructor.
Let d1 (resp d2) the level of t1 (resp t2).
Before unifying the body of t1 and t2, we want to put the two terms at the same level.

> [!WARNING]  
> To make two terms at the same level, a call to move is done. This means that 
> if the term is not in the PF the error _Non deterministic pruning, delay to be implemented_ is raised

For example, the term `pi dummy\ clause2 (x\y\x,x)` raise the error when trying to unify with 
the rule `clause2 (x\y\X x, F y (X x)) :- F = a\b\b.`
This is due to the call to move is done before the assignement of `X` to the identity function.
This means that no deref can be done on `X` and `F y (X x)` which is not in $\mathcal{L}_\lambda$

