### PR TITLE
unification: fix simplification step

### DIFF
--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -1795,7 +1795,7 @@ let rec unif argsdepth matching depth adepth a bdepth b e =
       e.(i) <- v;
       [%spy "user:assign" ~rid (fun fmt () -> ppterm depth [] ~argsdepth empty_env fmt (e.(i))) ()];
       let bdepth, b =
-        match deref_uv ~from:argsdepth ~to_:(bdepth+depth) args v with
+        match deref_uv ~from:argsdepth ~to_:(adepth+depth) args v with
         | UVar(r,from,args) when args > 0 -> adepth, AppUVar(r,from,C.mkinterval (from) args 0)
         | _ -> bdepth, b
       in

--- a/tests/sources/bug-256.elpi
+++ b/tests/sources/bug-256.elpi
@@ -1,0 +1,6 @@
+pred u o:(int -> int).
+u (y\y).
+
+main :-
+  pi x\ u (y\ X x y),
+  std.assert! (X 1 2 = 2) "bug".

--- a/tests/sources/bug-256.elpi
+++ b/tests/sources/bug-256.elpi
@@ -2,5 +2,17 @@ pred u o:(int -> int).
 u (y\y).
 
 main :-
-  pi x\ u (y\ X x y),
-  std.assert! (X 1 2 = 2) "bug".
+  print "-----------",
+  t1,
+  print "-----------",
+  t2,
+  t3,
+  true.
+
+t1 :- pi x\ u (y\ X x y), std.assert! (X 1 2 = 2) "bug".
+
+t2 :-
+  (pi X\ p ( a\f (X a))) => pi x y\ p ( a\f (g x y a)). 
+
+t3 :-
+  (pi X\ q ( a\b\c\d\f (X a))) => pi x y\ q ( a\b\c\d\f (g x y a)). 

--- a/tests/sources/llam.elpi
+++ b/tests/sources/llam.elpi
@@ -1,3 +1,4 @@
+pred spy i:prop.
 spy X :-  counter "run" N, print N "test " X, 
   not(not(X)).
 
@@ -19,6 +20,8 @@ prune_arg (r F).
 prune_arg2 (r (x\F x)).
 prune_arg3 (r (x\y\F y x)).
 
+type whatever A.
+
 main :-
   test (eq\F\        pi x\ pi y\ eq (F y x) x)             (a\b\b),
   test (eq\F\   not (pi x\ pi y\ eq (F x) y))              whatever,
@@ -27,9 +30,9 @@ main :-
   test (eq\F\   not (pi x\ pi y\ sigma R\ R = x, eq (F R) y))              whatever,
   test (eq\F\        pi x\ pi y\ sigma R\ R = x, eq (F y x) (r (w\h w R))) (a\b\r (x\h x b)),
   spy (pi dummy\ clause (x\y\x)),
-  (pi dummy\ clause1 (x\y\F y x), F = a\b\b),
-  (pi dummy\ clause2 (x\y\x,x)),
-  (clause3 (x\y\G y x) => pi dummy\ clause3 (x\y\x)), (G = a\b\b),
+  spy (pi dummy\ clause1 (x\y\F y x), F = a\b\b),
+  spy (pi dummy\ clause2 (x\y\x , x)),
+  spy (clause3 (x\y\G y x) => pi dummy\ clause3 (x\y\x)), (G = a\b\b),
   test (eq\F\        sigma H\pi x\ pi y\ eq (F y) (r (H y x)), H x x = x, H x y = x)   (a\r a),
 
   % this is hard because F<H but is applied to y that H can see, so H is restricted to the

--- a/tests/sources/trace_w.json
+++ b/tests/sources/trace_w.json
@@ -410,7 +410,7 @@
 {"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, character 3232:"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, character 3232:","(bind [] _ A0 (mono A1)) :- (copy A0 A1)."]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--539 [] ==> uvar frozen--539 []"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign:simplify","payload" : ["X13 := c0 \\\nX15 c0"]}
+{"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign:simplify:heap","payload" : ["X13 := c0 \\\nX15 c0"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X15^1 := mono X16^1"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["62"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--539 [] ==> uvar frozen--539 []) X16^1"]}

--- a/tests/suite/correctness_HO.ml
+++ b/tests/suite/correctness_HO.ml
@@ -348,3 +348,10 @@ let () = declare "chr_with_hypotheses"
   ~typecheck:true
   ~expectation:Success
   ()
+
+let () = declare "bug-256"
+  ~source_elpi:"bug-256.elpi"
+  ~description:"move/unif"
+  ~typecheck:true
+  ~expectation:Success
+  ()


### PR DESCRIPTION
The simplification step turns `X c0 c1` (that is `UVar(r,0,2)`) into `Y^2` via `X := a\b\Y^2`.
In #256 the query `pi x\ u (y\ X x y)` goes against `u (x\x)`. The simplification step was eating both arguments generating
`X := a\  b\ Y^1 a `. Now it instead generates `X := a\ Y^1`, so that we have `u (y\ Y^1 y) = u (y\y)` so `Y := x\x` and hence `X := a\b\b` that is correct.

The old code was confusing locally bound variables and pi generated ones in the simplification step that seems wrong.
By doing so, the old code was always eating all arguments, the 2 in `UVar(r,0,2)`, and the rest of the unification code was assuming that, after the simplification step, the term was either `UVar(_,_,0)` or `AppUVar`. The current patch restores that "a posteriori", but we should pre compute it or fix make_lambdas.

`deref_uv` was also doing some confusion in the (back then untested) case in which and UVar is simplified without eating all arguments, fixed in #260.

In short the old code was trying to keep into the fast fragment terms that don't belong. The new code calls full pattern fragment unification in a few more cases. Perf wise I see no visible effect.
