### PR TITLE
[typeabbrev] type `dl (dl A)` where `dl` is typeabbrev is no more "looping"

### DIFF
--- a/tests/sources/typeabbrv13.elpi
+++ b/tests/sources/typeabbrv13.elpi
@@ -1,0 +1,6 @@
+typeabbrev (dl A) (list A).
+
+pred p i:dl (dl A).
+
+main.
+

--- a/tests/sources/typeabbrv14.elpi
+++ b/tests/sources/typeabbrv14.elpi
@@ -1,0 +1,6 @@
+typeabbrev (dl A) (dl A).
+
+pred p i:dl (dl A).
+
+main.
+

--- a/tests/suite/correctness_FO.ml
+++ b/tests/suite/correctness_FO.ml
@@ -99,6 +99,17 @@ let () = declare "typeabbrv12"
   ~description:"type abbreviations and error messages"
   ()
 
+let () = declare "typeabbrv13"
+  ~source_elpi:"typeabbrv13.elpi"
+  ~description:"type abbreviations"
+  ()
+
+let () = declare "typeabbrv14"
+  ~source_elpi:"typeabbrv14.elpi"
+  ~description:"type abbreviations"
+  ~expectation:(FailureOutput (Str.regexp "SYMBOL.*uses the undefined dl constant"))
+  ()
+
 let () = declare "conj2"
   ~source_elpi:"conj2.elpi"
   ~description:"parsing and evaluation of & (binary conj)"


### PR DESCRIPTION
```prolog
typeabbrev (dl A) (list A).
pred p i:dl (dl A).
```
`dl (dl A)` is no more considered as an invalid (looping) type.

A typeabbrev can be created only if all of the constants in it have already been declared before it.
Recursive typeabbrev (like `typeabbrev dl dl` are still forbidden)