### PR TITLE
[compiler] flatten commas AST

### DIFF
--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -158,8 +158,9 @@ let mkApp loc = function
   | [] -> anomaly ~loc "empty application"
   | x::_ -> raise (NotInProlog(loc,"syntax error: the head of an application must be a constant or a variable, got: " ^ best_effort_pp x.it))
 
-let mkAppF loc (cloc, c) = function
+let rec mkAppF loc (cloc, c) = function
   | [] -> anomaly ~loc "empty application"
+  | { loc; it = App({it=Const ","; loc=cloc}, tl1)} ::tl when c="," -> mkAppF loc (cloc, ",") (tl1@tl)
   | args -> { loc; it = App( { it = Const c; loc = cloc },args) }
 
 


### PR DESCRIPTION
The term: `p :- (true, true), (true,true).` produces the ast:
```
  (app
    [const :-, const p, 
     app [const ,, app [const ,, const true, const true], const true, const true]]), 
```
Note that we have the subterm `app [COMMA, app [COMMA, true, true], true, true]`
With this PR the compiler flattens the term and produces instead:
```
 (app
    [const :-, const p, 
     app [const ,, const true, const true, const true, const true]), 
```
The same subterm is now: `app [COMMA, true, true, true, true]`
