### PR TITLE
[test.real] command_exist

### DIFF
--- a/tests/test.real.ml
+++ b/tests/test.real.ml
@@ -138,7 +138,9 @@ let print_csv plot results =
           end
       | None -> ());
   close_out oc;
-  if Sys.command "which lua5.1 &>/dev/null" = 0 && Sys.command "which gnuplot &> /dev/null" = 0 then begin
+  let command_exists cmd =
+    Sys.command ("command -v " ^ cmd ^ " 2> /dev/null || exit 1 ") = 0 in
+  if command_exists "lua5.1" && command_exists "gnuplot" then begin
     ignore(Sys.command (plot ^ " data.csv"));
     ignore(Sys.command "gnuplot data.csv.plot")
   end


### PR DESCRIPTION
Running the command `make tests ONLY=IO_COLON`
gives this:
![image](https://github.com/user-attachments/assets/59016bfe-67c3-47c1-9cb8-fbadd0c5dfc8)

Note the message ``elpi/usr/bin/env: `lua5.1`...`` displayed after the execution of the test

I suppose the problem come from Sys.command in combination with `&> /dev/null`.

This PR aims to hide the message