### PR TITLE
[test/suite.ml] small fix in displaying source path

### DIFF
--- a/tests/suite/suite.ml
+++ b/tests/suite/suite.ml
@@ -390,7 +390,7 @@ let () = Runner.declare
 
     let { Test.expectation; input; outside_llam ; trace; _ } = test in
     let input = Util.option_map (fun x -> sources^x) input in
-    let args = ["-test";"-I";executable_stuff;"-I";sources;source] @ trace in
+    let args = ["-test";"-I";executable_stuff;"-I";sources^source] @ trace in
     let args =
       if outside_llam then "-delay-problems-outside-pattern-fragment"::args
       else args in


### PR DESCRIPTION
BEFORE:
```
executable: path/_build/install/default/bin/elpi
args: -test -I path/_build/install/default/bin/../lib/elpi/ -I path/tests/sources/ io_colon.elpi
```

AFTER:
```
executable: path/_build/install/default/bin/elpi
args: -test -I path/_build/install/default/bin/../lib/elpi/ -I path/tests/sources/io_colon.elpi
```

Note the absence of space before io_colon.elpi