### PR TITLE
dt filter out uvar in input mode with rigid arg

### DIFF
--- a/src/runtime/discrimination_tree.mli
+++ b/src/runtime/discrimination_tree.mli
@@ -41,6 +41,9 @@ val mkOutputMode : cell
 *)
 val mkListTailVariable : cell
 
+(** unique identifier for uvar constructor *)
+val mkUvarVariable : cell
+
 (** This is used for capped lists.
 
   If the length of the maximal list in the rules of a predicate is N, then any
@@ -127,4 +130,5 @@ module Internal: sig
   val isListTailVariable : cell -> bool
   val isListTailVariableUnif : cell -> bool
   val isPathEnd : cell -> bool
+  val isUvarVariable : cell -> bool
 end

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -2585,11 +2585,11 @@ let arg_to_trie_path ~safe ~depth ~is_goal args arg_depths args_depths_ar mode m
     else
       let path_depth = path_depth - 1 in 
       match deref_head ~depth t with 
-      | Const k when k == Global_symbols.uvarc -> Path.emit path mkVariable; update_current_min_depth path_depth
+      | Const k when k == Global_symbols.uvarc -> Path.emit path mkUvarVariable; update_current_min_depth path_depth
       | Const k when safe -> Path.emit path @@ mkConstant ~safe ~data:k ~arity:0; update_current_min_depth path_depth
       | Const k -> Path.emit path @@ mkConstant ~safe ~data:k ~arity:0; update_current_min_depth path_depth
       | CData d -> Path.emit path @@ mkPrimitive d; update_current_min_depth path_depth
-      | App (k,_,_) when k == Global_symbols.uvarc -> Path.emit path @@ mkVariable; update_current_min_depth path_depth
+      | App (k,_,_) when k == Global_symbols.uvarc -> Path.emit path @@ mkUvarVariable; update_current_min_depth path_depth
       | App (k,a,_) when k == Global_symbols.asc -> main ~safe ~depth a (path_depth+1)
       | Lam _ -> Path.emit path mkAny; update_current_min_depth path_depth (* loose indexing to enable eta *)
       | Arg _ | UVar _ | AppArg _ | AppUVar _ | Discard -> Path.emit path @@ mkVariable; update_current_min_depth path_depth

--- a/tests/sources/dt_var3.elpi
+++ b/tests/sources/dt_var3.elpi
@@ -1,0 +1,7 @@
+:index(20)
+pred f i:int.
+f uvar :- print "uvar".
+f X :- var X, print "X".
+f 1 :- print "Y".
+
+main :- f 1.

--- a/tests/suite/correctness_FO.ml
+++ b/tests/suite/correctness_FO.ml
@@ -142,6 +142,13 @@ let () = declare "dt_var2"
   ~expectation:(SuccessOutput (Str.regexp "dev:disc-tree:candidates = 3"))
   ()
 
+let () = declare "dt_var3"
+  ~source_elpi:"dt_var3.elpi"
+  ~description:"discrimination_tree indexing flex"
+    ~trace:(On["tty";"stdout";"-trace-at";"1";"9999";"-trace-only";"dev:disc-tree:candidates"])
+  ~expectation:(SuccessOutput (Str.regexp "dev:disc-tree:candidates = 2"))
+  ()
+
 let () = declare "dt_multiparam1"
   ~source_elpi:"dt_multiparam1.elpi"
   ~description:"discrimination_tree indexing multi argument"


### PR DESCRIPTION
I have tested this change on all the project thanks to this change, where I put DTree
in all predicate with high indexing depth.

To perform the same test apply the following diff.
```diff
diff --git a/src/compiler/compiler.ml b/src/compiler/compiler.ml
index 983da7c7..e134e47e 100644
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -512,13 +512,13 @@ end = struct (* {{{ *)
       | Index(i,index_type) :: rest ->
          let it =
            match index_type with
-           | None -> None
-           | Some "Map" -> Some Map
-           | Some "Hash" -> Some HashMap
+           | None -> Some DiscriminationTree
+           | Some "Map" -> Some DiscriminationTree
+           | Some "Hash" -> Some DiscriminationTree
            | Some "DTree" -> Some DiscriminationTree
            | Some s -> error ~loc ("unknown indexing directive " ^ s ^ ". Valid ones are: Map, Hash, DTree.") in
          begin match r with
-           | None -> aux_tatt (Some (Structured.Index(i,it))) f rest
+           | None -> aux_tatt (Some (Structured.Index(List.init 100 (fun _ -> 100),it))) f rest
            | Some (Structured.Index _) -> duplicate_err "index"
            | Some _ -> error ~loc "external predicates cannot be indexed"
          end
diff --git a/src/runtime/runtime.ml b/src/runtime/runtime.ml
index 471bed38..6f14124c 100644
--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -2629,7 +2629,7 @@ let arg_to_trie_path ~safe ~depth ~is_goal args arg_depths args_depths_ar mode m
       make_sub_path arg_hd arg_tl arg_depth_hd arg_depth_tl Output []
     | arg_hd :: arg_tl, arg_depth_hd :: arg_depth_tl, mode_hd :: mode_tl ->
       make_sub_path arg_hd arg_tl arg_depth_hd arg_depth_tl (get_arg_mode mode_hd) mode_tl 
-    | _, _ :: _,_ -> anomaly "Invalid Index length" in
+    | _, _ :: _,_ -> () in
   begin
     if args == [] then emit_mode is_goal mkOutputMode
     else aux ~safe ~depth is_goal args (if is_goal then Array.to_list args_depths_ar else arg_depths) mode
```
