### PR TITLE
Performing a retroactive check on a rule that uses local clause loading and catchall

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -1772,8 +1772,9 @@ end = struct
       | Const b -> min_depth <= b && b < depth
       | _ -> false
     in
-    let is_unif_var = function
+    let rec is_unif_var = function
       | AppUVar _ | UVar (_, _, _) | Discard | Arg (_, _)|AppArg (_, _) -> true
+      | App (h,x,xs) when h == Global_symbols.asc -> is_unif_var x && List.for_all is_unif_var xs
       | Nil|Const _|Lam _|App (_, _, _)|Cons (_, _)|Builtin (_, _)|CData _ -> false
     in
     (* Builds a query for the predicate p with args args *)

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -1670,10 +1670,15 @@ end = struct
     let t  = todbl (depth,ctx) t in
     (!symb, !amap), t
 
-  let check_mut_excl state symbols pred_info cl cl_st p amap =
+  let check_mut_excl state symbols ~loc pred_info cl cl_st oc p amap : pred_info C.Map.t =
     let pp_global_predicate fmt p =
       let f = SymbolMap.global_name state symbols p in
       Format.fprintf fmt "predicate %a" F.pp f in
+
+    let preds_w_eigen_var_no_cut = ref C.Map.empty in
+    let add_pred_w_eigen_var_no_cut pred loc =
+      preds_w_eigen_var_no_cut := C.Map.add pred loc !preds_w_eigen_var_no_cut 
+    in
 
     let get_fresh_loc =
       let n = ref 0 in
@@ -1690,7 +1695,15 @@ end = struct
       | Some { overlap = Forbidden _ } -> false
       | _ -> true 
     in
-    let modes x = match get_opt x with Some {mode} -> mode | None -> [] in
+    let get_info x = match get_opt x with 
+      | Some {mode; overlap} -> 
+        let indexed_args = 
+          match overlap with 
+          | Forbidden d -> Discrimination_tree.user_upper_bound_depth d 
+          | Allowed -> [] 
+        in
+        mode, indexed_args 
+      | None -> [], [] in
     let get_overlapping (_, pred_info) c query = 
       match pred_info with
       | { overlap = Allowed } -> []
@@ -1710,19 +1723,30 @@ end = struct
       | Cons (a, b) -> Cons ((to_heap ~depth) a, (to_heap ~depth) b)
     in
 
-    (* Takes the list of rules overlapping with the clause cl *)
-    let overlapping_error ~loc ~is_local pred overlaps (cl_st,depth : term * int) = 
+    let pretty_term ~depth = 
+      let pp_ctx = ({ uv_names = ref (IntMap.empty,0); table = SymbolMap.compile symbols }) in
+      R.Pp.uppterm ~pp_ctx depth [] ~argsdepth:0 [||] in
+
+    let error_overlapping ~loc ~is_local pred overlaps (cl_st,depth : term * int) = 
       let local = if is_local then "local " else "" in
       let to_str fmt x =
         match x.overlap_loc with
         | None -> Format.fprintf fmt "- anonymous clause" 
         | Some loc -> Format.fprintf fmt "- rule at %a" Loc.pp loc in
-      let pretty = R.Pp.uppterm ~pp_ctx:({ uv_names = ref (IntMap.empty,0); table = SymbolMap.compile symbols }) depth [] ~argsdepth:0 [||] in
       error ~loc (Format.asprintf "@[<v 0>Mutual exclusion violated for rules of %a.@,This %srule overlaps with:@ %a@]@ @[This may break the determinacy of the predicate. To solve the problem, add a cut in its body.@]@ @[Offending clause is@ @[<hov 2>%a@]@] @]" pp_global_predicate pred local
-        (pplist to_str " ") overlaps pretty cl_st) 
+        (pplist to_str " ") overlaps (pretty_term ~depth) cl_st) 
+    in
+
+    let error_overlapping_eigen_variables ~loc pred (cl_st,depth : term * int) = 
+      error ~loc (Format.asprintf "@[<v 0>Mutual exclusion violated for rules of %a.@,This rule (displayed below) does not respects the principles of mutual exclution@]@ @[Principles: there is a cut in the body of the local clause and/or all indexed input arguments are eigenvariables@] @[To solve the problem, add a cut in its body.@]@ @[Offending clause is@ @[<hov 2>%a@]@] @]" pp_global_predicate pred
+        (pretty_term ~depth) cl_st) 
     in
 
     (* check if the term has a rigid occurence of a bound variable *)
+    (* 
+    (* We prefere to use a simpler version of has_rigid_occurrence which is
+       there is the function is_eigen_variable below: that is, the term is
+       exactly a name. This is to simplify the check when a catchall is loaded *)
     let has_rigid_occurence ~depth (t:term) = 
       (* Format.eprintf "Computing has rigid of %a from depth %d@." pp_term t depth; *)
       let rec aux = function
@@ -1743,32 +1767,48 @@ end = struct
       let b = aux t in
       (* Format.eprintf "Bool is %b@." b; *)
       b
+    in *)
+    let is_eigen_variable ~depth = function
+      | Const b -> 0 <= b && b < depth
+      | _ -> false
     in
-
+    let is_unif_var = function
+      | AppUVar _ | UVar (_, _, _) | Discard | Arg (_, _)|AppArg (_, _) -> true
+      | Nil|Const _|Lam _|App (_, _, _)|Cons (_, _)|Builtin (_, _)|CData _ -> false
+    in
     (* Builds a query for the predicate p with args args *)
+    (* returns 
+      - if all the input terms are eigen_variables (or if the predicate has no inputs)
+      - if all the input terms are unification variables
+      - the query
+    *)
     let hd_query ~loc ~depth p args =
-      let mode = modes p in
-      let rig_occ = ref false in
+      let mode, indexed_args = get_info p in
+      (* all inputs are exactely an eigen_variable *)
+      let rig_occ = ref true in
       let has_input = ref false in
-      let has_rigid_occurence m t =
+      let is_catchall = ref true in
+      let update_bools m t =
         has_input := !has_input || m;
-        rig_occ := !rig_occ || (has_rigid_occurence ~depth t) in
-      let rec mkpats args mode =
-        match args, mode with
-        | [], [] -> []
-        | a::args, (Mode.Fo Input | Ho(Input,_)) :: mode -> 
-          has_rigid_occurence true a;
-          a :: mkpats args mode
-        | _::args, _ :: mode -> mkDiscard :: mkpats args mode
-        | _::args, [] -> error ~loc @@
+        rig_occ := !rig_occ && (is_eigen_variable ~depth t);
+        is_catchall := !is_catchall && is_unif_var t
+      in
+      let rec mkpats indexed_args args mode =
+        match indexed_args, args, mode with
+        | _, [], [] -> []
+        | i::is, a::args, (Mode.Fo Input | Ho(Input,_)) :: mode when i > 0 -> 
+          update_bools true a;
+          a :: mkpats is args mode
+        | (([] as is) | (_::is)), _::args, _ :: mode -> mkDiscard :: mkpats is args mode
+        | _, _::args, [] -> error ~loc @@
           Format.asprintf "@[<hov 2>args/mode mismatch: Building query for %a: %s@]" pp_global_predicate p (String.concat " " (List.map  show_term args) ^ " != " ^ Mode.show_hos mode)
         | _ -> assert false
       in
-      (not !has_input || !rig_occ), R.mkAppL p @@ mkpats args mode 
+      (not !has_input || !rig_occ), (not !has_input || !is_catchall), R.mkAppL p @@ mkpats indexed_args args mode 
     in
 
     (* Returns if the clause has a bang *)
-    let check_overlaps ~is_local ~loc ~depth (cl:clause) h (cl_overlap:overlap_clause option) p args (index : int * pred_info) amap =
+    let check_overlaps ~is_local ~loc ~depth (cl:clause) h (cl_overlap:overlap_clause option) p args (index : int * pred_info) =
       match cl_overlap with
         | None -> ()
         | Some cl_overlap ->
@@ -1781,14 +1821,24 @@ end = struct
               if not x.has_cut then (x::filter_overlaps hb xs)
               else filter_overlaps hb xs
           in
-          let rig_occ, hd = hd_query ~loc ~depth p args in
-          (* Format.eprintf "Is_local:%b -- Has bang? %b -- rig_occ:%b@." is_local hb rig_occ; *)
-          if is_local && not cl_overlap.has_cut &&  not rig_occ then
-            overlapping_error ~is_local ~loc p [{ overlap_loc = None; timestamp =[]; has_cut = false}] h;
+          let all_input_eigen_vars, all_input_catchall, hd = hd_query ~loc ~depth p args in
+          (* Format.eprintf "Is_local:%b -- Has bang? %b -- rig_occ:%b -- is_chatchall:%b@." is_local cl_overlap.has_cut has_input_w_eigen_var is_catchall; *)
+          if is_local && not cl_overlap.has_cut && not all_input_eigen_vars then (
+            error_overlapping_eigen_variables ~loc p h);
+          if not is_local && all_input_catchall then
+            (* We check if there is a local clause for p loading a local clause without cut, if this is the case,
+               we throw an error, the catchall make $p$ non functional *)
+            (match get_opt p with
+            | None | Some {has_local_without_cut = None} -> ()
+            | Some {has_local_without_cut = (Some _) as loc1} ->
+              error_overlapping ~is_local ~loc p [{ overlap_loc = loc1; timestamp =[]; has_cut = false }] h);
+          if is_local && not cl_overlap.has_cut && all_input_eigen_vars then
+            (* Here we have a local clause with all input vars being eigenvars + the has no cut in the body, we add the info to the pred *)
+            add_pred_w_eigen_var_no_cut p loc;
           if not is_local || (is_local && not cl_overlap.has_cut) then
             let all_overlapping = get_overlapping index p hd in
             let overlapping =  filter_overlaps cl_overlap.has_cut all_overlapping in
-            if overlapping <> [] then overlapping_error ~loc ~is_local p overlapping h
+            if overlapping <> [] then error_overlapping ~loc ~is_local p overlapping h
     in
 
     (* Inspect the a local premise. If a local clause is found
@@ -1816,7 +1866,7 @@ end = struct
             begin try
               let fresh_loc = get_fresh_loc loc in
               let (p,cl), _, morelcs =
-                try R.CompileTime.clausify1 ~tail_cut:(ik = ImplBang) ~loc:fresh_loc ~modes ~nargs:(F.Map.cardinal amap) ~depth h
+                try R.CompileTime.clausify1 ~tail_cut:(ik = ImplBang) ~loc:fresh_loc ~modes:(fun x -> fst (get_info x)) ~nargs:(F.Map.cardinal amap) ~depth h
                 with D.CannotDeclareClauseForBuiltin(loc,_c) ->
                   error ?loc ("Declaring a clause for built in predicate")
                 in
@@ -1833,11 +1883,14 @@ end = struct
       in
       aux ~depth index t 
     and check_clause ~is_local ~depth ~loc ~lcs index cl h cl_overlap p amap =
-      if not @@ can_overlap p then check_overlaps ~is_local ~loc ~depth cl (h,depth) cl_overlap p cl.args (0, C.Map.find p index) amap;
+      if not @@ can_overlap p then check_overlaps ~is_local ~loc ~depth cl (h,depth) cl_overlap p cl.args (0, C.Map.find p index);
       List.iter (check_local ~loc ~depth ~lcs index amap) cl.hyps
     in
-
-    check_clause ~is_local:false ~lcs:0 ~depth:0 pred_info cl cl_st p amap
+(* state symbols ~loc pred_info cl body overlap_clause p amap *)
+    check_clause ~loc ~is_local:false ~lcs:0 ~depth:0 pred_info cl cl_st oc p amap;
+    let pred_info = C.Map.fold (fun k v -> C.Map.add k {(C.Map.find k pred_info) with has_local_without_cut = Some v}) !preds_w_eigen_var_no_cut pred_info in
+    pred_info 
+    (* Format.eprintf "The predicates with local clauses bla is :@ @[%a@]@." (C.Map.pp (Loc.pp)) !preds_w_eigen_var_no_cut *)
 
   let spill_todbl ?(ctx=Scope.Map.empty) ~builtins ~needs_spilling ~types state symb ?(depth=0) ?(amap = F.Map.empty) t =
     let t = if needs_spilling then Spilling.main ~types t else t in
@@ -1864,10 +1917,12 @@ end = struct
     let pred_info = C.Map.add p p_info pred_info in
     (* Format.eprintf "Validating local clause for predicate %a at %a@." F.pp (SymbolMap.global_name state symbols p) Loc.pp loc; *)
     
-    if not flags.skip_det_checking then
-      time_this time (fun () -> check_mut_excl state symbols ~loc pred_info cl body overlap_clause p amap);
+    let pred_info = ref pred_info in
 
-    (graft,id,p,cl) :: clauses, symbols, index, pred_info
+    if not flags.skip_det_checking then
+      time_this time (fun () -> pred_info := check_mut_excl state symbols ~loc !pred_info cl body overlap_clause p amap);
+
+    (graft,id,p,cl) :: clauses, symbols, index, !pred_info
 
 
   let check_rule_pattern_in_clique state symbols clique { D.CHR.pattern; rule_name; rule_loc } =

--- a/src/compiler/determinacy_checker.ml
+++ b/src/compiler/determinacy_checker.ml
@@ -26,7 +26,6 @@ type dtype =
 [@@deriving show, ord]
 
 module Good_call : sig
-  (* p: tells if the offending term corresponds to a polymorphics type variable *)
   (* NOTE:
       For a constructor with a non-polymorphic type, the inferred determinacy of the term
       must match the expected one exactly.

--- a/src/compiler/determinacy_checker.ml
+++ b/src/compiler/determinacy_checker.ml
@@ -550,7 +550,7 @@ let check_clause ~type_abbrevs:ta ~types ~unknown (t : ScopedTerm.t) : unit =
       | Arrow (Input, v, _, r), _ :: tl -> assume_output (choose_variadic v d r) tl var
       | Arrow (Output, v, l, r), hd :: tl ->
           Format.eprintf "Call assume of %a with dtype:%a@." ScopedTerm.pretty hd pp_dtype l;
-          let var = assume ~ctx ~var l hd in
+          let var = assume ~was_input:true ~ctx ~var l hd in
           assume_output (choose_variadic v d r) tl var
       | _ -> var
     in

--- a/src/compiler/type_checker.ml
+++ b/src/compiler/type_checker.ml
@@ -113,15 +113,15 @@ let check_indexing ~loc ~type_abbrevs availability name ty indexing =
   | Some (Ast.Structured.Index(l,k)) -> ensure_pred is_prop;
       let {static;runtime} = chose_indexing name l k in
       let overlap = overlap static in
-      TypingEnv.Index {mode;indexing=runtime; overlap}
+      TypingEnv.Index {mode;indexing=runtime; overlap; has_local_without_cut=None}
   | Some MaximizeForFunctional when availability = Ast.Structured.Elpi -> ensure_pred is_prop;
       let indexing = maximize_indexing_input mode in
       let overlap = overlap indexing in
-      Index {mode;indexing=MapOn 0; overlap }
+      Index {mode;indexing=MapOn 0; overlap; has_local_without_cut=None}
   | _ when Option.is_some is_prop ->
       let {static;runtime} = chose_indexing name [1] None in
       let overlap = overlap static in
-      TypingEnv.Index {mode;indexing=runtime; overlap}
+      TypingEnv.Index {mode;indexing=runtime; overlap; has_local_without_cut=None}
   | _ -> DontIndex
 
 let check_type ~type_abbrevs ~kinds { value; loc; name; index; availability } : Symbol.t * Symbol.t option * TypingEnv.symbol_metadata =
@@ -867,10 +867,10 @@ let check1_undeclared ~type_abbrevs w f (t, id) =
       let mode = ty2mode tya in
       let indexing = match is_prop ~type_abbrevs ty with
       | None -> TypingEnv.DontIndex
-      | Some Relation -> Index {mode; indexing=MapOn 0; overlap = Allowed} 
+      | Some Relation -> Index {mode; indexing=MapOn 0; overlap = Allowed; has_local_without_cut=None} 
       | Some Function ->
         let {static;runtime} = chose_indexing (Symbol.get_func id) [1] None in
-        TypingEnv.Index {mode;indexing=runtime; overlap=Elpi_runtime.Data.mk_Forbidden static}
+        TypingEnv.Index {mode;indexing=runtime; overlap=Elpi_runtime.Data.mk_Forbidden static; has_local_without_cut=None}
       in
       id, TypingEnv.{ ty ; indexing; availability = Elpi }
   | _ -> assert false

--- a/src/runtime/data.ml
+++ b/src/runtime/data.ml
@@ -44,7 +44,7 @@ let mk_Forbidden indexing =
     | DiscriminationTree l -> Discrimination_tree.empty_dt l
   )
 
-type pred_info = { indexing:indexing; mode:Mode.hos; overlap: overlap }
+type pred_info = { indexing:indexing; mode:Mode.hos; overlap: overlap; has_local_without_cut: Loc.t option }
 [@@deriving show]
 
 let same_indexing { indexing = i1 } { indexing = i2 } = compare_indexing i1 i2 == 0

--- a/tests/sources/functionality/test109.elpi
+++ b/tests/sources/functionality/test109.elpi
@@ -1,0 +1,11 @@
+func f int ->.
+
+func f1.
+
+f1 :-
+  pi x\ (f x :- print "CIAO") =>
+    (f x, fail).
+
+f X :- halt "Mh".
+
+main :- f1.

--- a/tests/sources/functionality/test110.elpi
+++ b/tests/sources/functionality/test110.elpi
@@ -1,0 +1,19 @@
+% YES
+
+% A simplified version from XXX, where the output of a predicate is a data.
+% This data should assume its arguments to have the determinacy declared in
+% the signature of the constructor being taken into account
+
+kind derive type.
+type derive string -> (func -> list (pred)) -> prop -> derive. 
+
+kind gref type.
+
+pred derivation o:derive.
+
+func unfold-constants.
+unfold-constants :-
+  derivation (derive _ Do _), !,
+  Do [true].
+
+main.

--- a/tests/sources/functionality/test110.elpi
+++ b/tests/sources/functionality/test110.elpi
@@ -7,8 +7,6 @@
 kind derive type.
 type derive string -> (func -> list (pred)) -> prop -> derive. 
 
-kind gref type.
-
 pred derivation o:derive.
 
 func unfold-constants.

--- a/tests/sources/functionality/test111.elpi
+++ b/tests/sources/functionality/test111.elpi
@@ -1,0 +1,5 @@
+func foo int ->.
+pred bad.
+
+
+main :- pi x\ (bad :- (foo x) => foo x, bad) => true.

--- a/tests/sources/functionality/test112.elpi
+++ b/tests/sources/functionality/test112.elpi
@@ -1,0 +1,5 @@
+func foo int ->.
+pred bad.
+
+
+main :- pi x\ (bad :- pi x\ (foo x) => foo x, bad) => true.

--- a/tests/sources/functionality/test113.elpi
+++ b/tests/sources/functionality/test113.elpi
@@ -1,0 +1,7 @@
+func f int ->.
+
+
+main :-
+  pi x\ f x => true.
+
+f (X as (Y as Z)).

--- a/tests/sources/functionality/test114.elpi
+++ b/tests/sources/functionality/test114.elpi
@@ -1,0 +1,7 @@
+func f int ->.
+
+
+main :-
+  pi x\ f x => true.
+
+f (X as (Y as 3)).

--- a/tests/suite/correctness_FO.ml
+++ b/tests/suite/correctness_FO.ml
@@ -255,6 +255,7 @@ let () =
       (* 96*) mut_excl_eigen 6 "foo"; mut_excl_eigen 6 "foo"; mut_excl_eigen 6 "foo"; Success; Success;             (*100*)
       (*101*) Success; mut_excl_no_loc "f";  duplicate_err 2 1; Success; Success;(*105*)
       (*106*) Success; constr_error 14 13; constr_error 14 13; mut_excl_eigen 9 "f"; Success; (*110*)
+      (*111*) mut_excl_eigen 5 "foo"; Success 
     |] in
   for i = 0 to Array.length status - 1 do
     let name = Printf.sprintf "functionality/test%d.elpi" (i+1) in

--- a/tests/suite/correctness_FO.ml
+++ b/tests/suite/correctness_FO.ml
@@ -254,7 +254,7 @@ let () =
       (* 91*) det_check 14 5; Success; Success; constr_error 14 17; mut_excl_eigen 6 "foo";         (*95*)
       (* 96*) mut_excl_eigen 6 "foo"; mut_excl_eigen 6 "foo"; mut_excl_eigen 6 "foo"; Success; Success;             (*100*)
       (*101*) Success; mut_excl_no_loc "f";  duplicate_err 2 1; Success; Success;(*105*)
-      (*106*) Success; constr_error 14 13; constr_error 14 13;
+      (*106*) Success; constr_error 14 13; constr_error 14 13; mut_excl_eigen 9 "f"
     |] in
   for i = 0 to Array.length status - 1 do
     let name = Printf.sprintf "functionality/test%d.elpi" (i+1) in

--- a/tests/suite/correctness_FO.ml
+++ b/tests/suite/correctness_FO.ml
@@ -254,7 +254,7 @@ let () =
       (* 91*) det_check 14 5; Success; Success; constr_error 14 17; mut_excl_eigen 6 "foo";         (*95*)
       (* 96*) mut_excl_eigen 6 "foo"; mut_excl_eigen 6 "foo"; mut_excl_eigen 6 "foo"; Success; Success;             (*100*)
       (*101*) Success; mut_excl_no_loc "f";  duplicate_err 2 1; Success; Success;(*105*)
-      (*106*) Success; constr_error 14 13; constr_error 14 13; mut_excl_eigen 9 "f"
+      (*106*) Success; constr_error 14 13; constr_error 14 13; mut_excl_eigen 9 "f"; Success; (*110*)
     |] in
   for i = 0 to Array.length status - 1 do
     let name = Printf.sprintf "functionality/test%d.elpi" (i+1) in

--- a/tests/suite/correctness_FO.ml
+++ b/tests/suite/correctness_FO.ml
@@ -231,6 +231,7 @@ let () =
   let mode_err l c = !(Format.asprintf "line %d, column %d.*\nTypechecker.*[io]:.*" l c) in
   let duplicate_err l1 l2 = !(Format.asprintf "line %d.*\n.*cannot only differ.*\n.*line %d" l1 l2) in
   let constr_error l1 l2 = !(Format.asprintf "line %d, column %d.*\n.*Invalid determinacy of constructor" l1 l2) in
+  let mut_excl_eigen l p = !(Format.asprintf "line %d.*\nMutual exclusion violated for rules of predicate %s" l p) in
   let status = Test.
     [|(* 01*) mut_excl 9 6; Success; det_check 9 7; mut_excl_no_loc "q"; mut_excl_no_loc "q";            (*05*)
       (* 06*) mut_excl_no_loc "q"; mut_excl_no_loc "q"; mut_excl_no_loc "q"; mut_excl 10 10; mut_excl 10 10; (*10*)
@@ -250,8 +251,8 @@ let () =
       (* 76*) Success; Success; det_check 7 5; Success; Success;                 (*80*)
       (* 81*) mode_err 13 6; Success; mode_err 15 6; Success; mode_err 14 26;    (*85*)
       (* 86*) Success; Success; Success; Success; Success;                       (*90*)
-      (* 91*) det_check 14 5; Success; Success; constr_error 14 17; Success;         (*95*)
-      (* 96*) mut_excl 6 6; mut_excl 6 6; Success; Success; Success;             (*100*)
+      (* 91*) det_check 14 5; Success; Success; constr_error 14 17; mut_excl_eigen 6 "foo";         (*95*)
+      (* 96*) mut_excl_eigen 6 "foo"; mut_excl_eigen 6 "foo"; mut_excl_eigen 6 "foo"; Success; Success;             (*100*)
       (*101*) Success; mut_excl_no_loc "f";  duplicate_err 2 1; Success; Success;(*105*)
       (*106*) Success; constr_error 14 13; constr_error 14 13;
     |] in

--- a/tests/suite/correctness_FO.ml
+++ b/tests/suite/correctness_FO.ml
@@ -225,7 +225,7 @@ let () = declare "trie"
 let () =
   let (!) x = Test.FailureOutput (Str.regexp x) in
   let mut_excl l1 l2 = !(Format.asprintf "line %d.*\n.*\n.*\n+.*line %d" l1 l2) in
-  let mut_excl_no_loc t = !("Mutual exclusion violated for rules of predicate " ^ t) in
+  let mut_excl_no_loc t = !("Mutual exclusion violated for rules of predicate " ^ t ^ ".\nThis rule overlaps with") in
   let det_check l c = !(Format.asprintf "line %d, column %d.*\nDetCheck.*relational atom" l c) in
   let out_err l c = !(Format.asprintf "line %d, column %d.*\nDetCheck.*output" l c) in
   let mode_err l c = !(Format.asprintf "line %d, column %d.*\nTypechecker.*[io]:.*" l c) in
@@ -233,8 +233,8 @@ let () =
   let constr_error l1 l2 = !(Format.asprintf "line %d, column %d.*\n.*Invalid determinacy of constructor" l1 l2) in
   let mut_excl_eigen l p = !(Format.asprintf "line %d.*\nMutual exclusion violated for rules of predicate %s" l p) in
   let status = Test.
-    [|(* 01*) mut_excl 9 6; Success; det_check 9 7; mut_excl_no_loc "q"; mut_excl_no_loc "q";            (*05*)
-      (* 06*) mut_excl_no_loc "q"; mut_excl_no_loc "q"; mut_excl_no_loc "q"; mut_excl 10 10; mut_excl 10 10; (*10*)
+    [|(* 01*) mut_excl 9 6; Success; det_check 9 7; mut_excl_eigen 10 "q"; mut_excl_eigen 10 "q";            (*05*)
+      (* 06*) mut_excl_eigen 10 "q"; mut_excl_eigen 10 "q"; mut_excl_eigen 11 "q"; mut_excl 10 10; mut_excl 10 10; (*10*)
       (* 11*) mut_excl 9 8; Success; mut_excl 11 10; det_check 21 9; Success;    (*15*)
       (* 16*) det_check 8 9; Success; det_check 14 7; det_check 13 7; Success;   (*20*)
       (* 21*) det_check 7 21; Success; det_check 16 9; Success; det_check 7 12;  (*25*)
@@ -253,9 +253,9 @@ let () =
       (* 86*) Success; Success; Success; Success; Success;                       (*90*)
       (* 91*) det_check 14 5; Success; Success; constr_error 14 17; mut_excl_eigen 6 "foo";         (*95*)
       (* 96*) mut_excl_eigen 6 "foo"; mut_excl_eigen 6 "foo"; mut_excl_eigen 6 "foo"; Success; Success;             (*100*)
-      (*101*) Success; mut_excl_no_loc "f";  duplicate_err 2 1; Success; Success;(*105*)
+      (*101*) Success; mut_excl_eigen 5 "f";  duplicate_err 2 1; Success; Success;(*105*)
       (*106*) Success; constr_error 14 13; constr_error 14 13; mut_excl_eigen 9 "f"; Success; (*110*)
-      (*111*) mut_excl_eigen 5 "foo"; Success 
+      (*111*) mut_excl_eigen 5 "foo"; Success; mut_excl_no_loc "f"; Success
     |] in
   for i = 0 to Array.length status - 1 do
     let name = Printf.sprintf "functionality/test%d.elpi" (i+1) in


### PR DESCRIPTION
Linked to #331 