### PR TITLE
Det check chr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           opam exec -- ls -l tests/sources/*.elpi
-          opam exec -- make tests PWD=${{ env.workspace }} RUNNERS='dune ${{ env.workspace }}/elpi-${{ matrix.ocaml-compiler }}-${{ runner.os }}.exe ${{ env.workspace }}/elpi-trace-elaborator-${{ matrix.ocaml-compiler }}-${{ runner.os }}.exe' TIME=--time=D:/cygwin/bin/time.exe
+          opam exec -- make tests PWD=${{ env.workspace }} RUNNERS='dune ${{ env.workspace }}/elpi-${{ matrix.ocaml-compiler }}-${{ runner.os }}.exe ${{ env.workspace }}/elpi-trace-elaborator-${{ matrix.ocaml-compiler }}-${{ runner.os }}.exe' TIME=--time=C:/cygwin/bin/time.exe
 
 # Artifacts 2 ################################################################
 

--- a/.github/workflows/users.yml
+++ b/.github/workflows/users.yml
@@ -30,8 +30,8 @@ jobs:
           env:
             OPAMWITHTEST: false
             
-        - run: opam pin --ignore-constraints-on elpi add rocq-elpi https://github.com/LPCIC/coq-elpi.git#fix-elpi-3.1
-        - run: opam pin --ignore-constraints-on elpi add coq-elpi https://github.com/LPCIC/coq-elpi.git#fix-elpi-3.1
+        - run: opam pin --ignore-constraints-on elpi add rocq-elpi https://github.com/LPCIC/coq-elpi.git#master
+        - run: opam pin --ignore-constraints-on elpi add coq-elpi https://github.com/LPCIC/coq-elpi.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-stdlib https://github.com/rocq-prover/stdlib.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-hierarchy-builder https://github.com/math-comp/hierarchy-builder.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-mathcomp-boot https://github.com/math-comp/math-comp.git#master

--- a/.github/workflows/users.yml
+++ b/.github/workflows/users.yml
@@ -30,10 +30,10 @@ jobs:
           env:
             OPAMWITHTEST: false
             
-        - run: opam pin --ignore-constraints-on elpi add rocq-elpi https://github.com/LPCIC/coq-elpi.git#fix-elpi-3.0
-        - run: opam pin --ignore-constraints-on elpi add coq-elpi https://github.com/LPCIC/coq-elpi.git#fix-elpi-3.0
+        - run: opam pin --ignore-constraints-on elpi add rocq-elpi https://github.com/LPCIC/coq-elpi.git#master
+        - run: opam pin --ignore-constraints-on elpi add coq-elpi https://github.com/LPCIC/coq-elpi.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-stdlib https://github.com/rocq-prover/stdlib.git#master
-        - run: opam pin --ignore-constraints-on elpi add rocq-hierarchy-builder https://github.com/gares/hierarchy-builder.git#elpi-3.0
+        - run: opam pin --ignore-constraints-on elpi add rocq-hierarchy-builder https://github.com/gares/hierarchy-builder.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-mathcomp-boot https://github.com/math-comp/math-comp.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-mathcomp-order https://github.com/math-comp/math-comp.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-mathcomp-fingroup https://github.com/math-comp/math-comp.git#master

--- a/.github/workflows/users.yml
+++ b/.github/workflows/users.yml
@@ -33,7 +33,7 @@ jobs:
         - run: opam pin --ignore-constraints-on elpi add rocq-elpi https://github.com/LPCIC/coq-elpi.git#fix-elpi-3.1
         - run: opam pin --ignore-constraints-on elpi add coq-elpi https://github.com/LPCIC/coq-elpi.git#fix-elpi-3.1
         - run: opam pin --ignore-constraints-on elpi add rocq-stdlib https://github.com/rocq-prover/stdlib.git#master
-        - run: opam pin --ignore-constraints-on elpi add rocq-hierarchy-builder https://github.com/gares/hierarchy-builder.git#master
+        - run: opam pin --ignore-constraints-on elpi add rocq-hierarchy-builder https://github.com/math-comp/hierarchy-builder.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-mathcomp-boot https://github.com/math-comp/math-comp.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-mathcomp-order https://github.com/math-comp/math-comp.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-mathcomp-fingroup https://github.com/math-comp/math-comp.git#master

--- a/.github/workflows/users.yml
+++ b/.github/workflows/users.yml
@@ -30,8 +30,8 @@ jobs:
           env:
             OPAMWITHTEST: false
             
-        - run: opam pin --ignore-constraints-on elpi add rocq-elpi https://github.com/LPCIC/coq-elpi.git#master
-        - run: opam pin --ignore-constraints-on elpi add coq-elpi https://github.com/LPCIC/coq-elpi.git#master
+        - run: opam pin --ignore-constraints-on elpi add rocq-elpi https://github.com/LPCIC/coq-elpi.git#fix-elpi-3.1
+        - run: opam pin --ignore-constraints-on elpi add coq-elpi https://github.com/LPCIC/coq-elpi.git#fix-elpi-3.1
         - run: opam pin --ignore-constraints-on elpi add rocq-stdlib https://github.com/rocq-prover/stdlib.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-hierarchy-builder https://github.com/gares/hierarchy-builder.git#master
         - run: opam pin --ignore-constraints-on elpi add rocq-mathcomp-boot https://github.com/math-comp/math-comp.git#master

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,22 @@
+# v3.1.0 UNRELEASED
+
+Requires Menhir 20211230 and OCaml 4.13 or above.
+
+- Language:
+  - Change: constraints must be functions. Hence `declare_constraint` only
+    suspends functional predicated and CHR rules can only generate
+    determinitic goals.
+  - New: the `func` syntax now supports variadic functions as in
+    ```prolog
+    func f int, int -> int.. .
+    f N D Q   :- Q is N div D.
+    f N D Q R :- f N D Q, R is N mod D.
+    ```
+
+
 # v3.0.1 (July 2025)
+
+Requires Menhir 20211230 and OCaml 4.13 or above.
 
 - Language:
   - Improve error message for non deterministic atom

--- a/ELPI.md
+++ b/ELPI.md
@@ -55,6 +55,8 @@ is very welcome. Questions or feature requests are welcome as well.
 - [Accumulate with paths](#accumulate-with-paths) accepts `accumulate "path".`
   so that one can use `.` in a file/path name.
 
+- [Variadic functions](#variadic-functions)
+
 - [Tracing facility](#tracing-facility) to debug your programs.
  
 - [Macros](#macros) are expanded at compilation time
@@ -1032,6 +1034,21 @@ Here `main` calls `std.list.map`, `std.string.concat` and finally
 
 Elpi accepts `accumulate "path".` (i.e. a string rather than an indent)
 so that one can use `.` in a file or path name.
+
+## Variadic functions
+
+Functions, both external and written in Elpi, can be variadic.
+
+```prolog
+func f int, int -> int.. .
+f N D Q   :- Q is N div D.
+f N D Q R :- f N D Q, R is N mod D.
+```
+
+Here `f` takes 3 or 4 argument: when 4 are passed it also returns the
+reminder of the division. Only the last output can be variadic.
+
+This feature is mainly used for external functions.
 
 ## Tracing facility
 

--- a/src/API.ml
+++ b/src/API.ml
@@ -518,7 +518,7 @@ end
 
 module Elpi = struct
 
-  type t = ED.uvar_body
+  type t = ED.uvar
 
   let pp = Compiler.pp_uvar_body
   let show m = Format.asprintf "%a" pp m

--- a/src/API.ml
+++ b/src/API.ml
@@ -535,7 +535,7 @@ module Elpi = struct
 
   let alloc_Elpi name state =
     let module R = (val !r) in
-    state, (ED.oref ED.dummy)
+    state, (ED.oref ~depth:0 ED.dummy)
 
   let make ?name state =
     match name with
@@ -577,11 +577,11 @@ module RawData = struct
     let module R = (val !r) in let open R in
     match deref_head ~depth t with
     | ED.Term.Arg _ | ED.Term.AppArg _ -> assert false
-    | ED.Term.AppUVar(ub,0,args) -> UnifVar (ub,args)
-    | ED.Term.AppUVar(ub,lvl,args) -> look ~depth (R.expand_appuv ub ~depth ~lvl ~args)
-    | ED.Term.UVar(ub,lvl,ano) -> look ~depth (R.expand_uv ub ~depth ~lvl ~ano)
+    | ED.Term.AppUVar(ub,args) when ub.vardepth == 0 -> UnifVar (ub,args)
+    | ED.Term.AppUVar(ub,args) -> look ~depth (R.expand_appuv ub ~depth ~args)
+    | ED.Term.UVar(ub,ano) -> look ~depth (R.expand_uv ub ~depth ~ano)
     | ED.Term.Discard ->
-        let ub = ED.oref ED.dummy in
+        let ub = ED.oref ~depth:0 ED.dummy in
         UnifVar (ub,R.mkinterval 0 depth 0)
     | ED.Term.Lam _ as t ->
         begin match R.eta_contract_flex ~depth t with
@@ -591,7 +591,7 @@ module RawData = struct
     | x -> Obj.magic x (* HACK: view is a "subtype" of Term.term *)
 
   let kool = function
-    | UnifVar(ub,args) -> ED.Term.AppUVar(ub,0,args)
+    | UnifVar(ub,args) -> ED.Term.AppUVar(ub,args)
     | x -> Obj.magic x
   [@@ inline]
 
@@ -680,7 +680,7 @@ module RawData = struct
   let no_constraints = []
 
   let mkUnifVar ub ~args state =
-    ED.Term.mkAppUVar ub 0 args
+    ED.Term.mkAppUVar ub args
 
   type Conversion.extra_goal +=
   | RawGoal = ED.Conversion.RawGoal
@@ -905,7 +905,7 @@ module BuiltInPredicate = struct
 
   let beta ~depth t args =
     let module R = (val !r) in let open R in
-    deref_appuv ~from:depth ~to_:depth ?avoid:None args t
+    deref_apparg ~from:depth ~to_:depth ?avoid:None t args
 
   module HOAdaptors = struct
 

--- a/src/API.mli
+++ b/src/API.mli
@@ -1170,8 +1170,8 @@ module RawData : sig
     | UnifVar of FlexibleData.Elpi.t * term list
 
   (** Terms must be inspected after dereferencing their head.
-      If the resulting term is UVar then its uvar_body is such that
-      get_assignment uvar_body = None *)
+      If the resulting term is UVar then its uvar is such that
+      get_assignment uvar = None *)
   val look : depth:int -> term -> view
 
   (* to reuse a term that was looked at *)

--- a/src/builtin.elpi
+++ b/src/builtin.elpi
@@ -67,7 +67,7 @@ not _.
 
 % [declare_constraint C Key1 Key2...] declares C blocked
 % on Key1 Key2 ... (variables, or lists thereof).
-external type declare_constraint any -> any -> variadic any fprop.
+external func declare_constraint (func) -> any .. .
 
 % [print_constraints] prints all constraints
 external func print_constraints.

--- a/src/builtin.ml
+++ b/src/builtin.ml
@@ -241,7 +241,7 @@ let core_builtins = let open BuiltIn in let open ContextualConversion in [
   LPCode "external symbol uvar  : A = \"core\".";
   LPCode "external symbol (as)  : A -> A -> A = \"core\".";
   LPCode "external symbol (=>)  : prop -> fprop -> fprop = \"core\".";
-  LPCode "external symbol (=>)  : list prop -> fprop -> fprop = \"core\"."; (* HACS in TC to handle this*)
+  LPCode "external symbol (=>)  : list prop -> fprop -> fprop = \"core\"."; (* HACK in TC to handle this*)
   LPCode "external symbol (==>) : prop -> fprop -> fprop.";
   LPCode "external symbol (==>) : list prop -> fprop -> fprop.";
 
@@ -259,7 +259,7 @@ let core_builtins = let open BuiltIn in let open ContextualConversion in [
    * store of syntactic constraints *)
   LPCode ("% [declare_constraint C Key1 Key2...] declares C blocked\n"^
           "% on Key1 Key2 ... (variables, or lists thereof).\n"^
-          "external type declare_constraint any -> any -> variadic any fprop.");
+          "external func declare_constraint (func) -> any .. .");
   MLCode(Pred("print_constraints",
     Full(raw_ctx,"prints all constraints"),
     (fun ~depth _ constraints state ->

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -1387,12 +1387,7 @@ end = struct
   let check_and_spill_chr ~time ~unknown ~type_abbrevs ~kinds ~types r =
     let unknown = time_this time (fun () -> Type_checker.check_chr_rule ~unknown ~type_abbrevs ~kinds ~types r) in
     Option.iter (fun { Ast.Chr.conclusion } ->
-      let guard_and_newg =
-        match r.guard with
-        | None -> [conclusion]
-        | Some guard -> [guard;conclusion]
-      in
-      Determinacy_checker.check_atoms ~type_abbrevs ~types ~unknown guard_and_newg)
+      Determinacy_checker.check_chr_guard_and_newgoal ~type_abbrevs ~types ~unknown ~guard:r.guard ~newgoal:conclusion)
       r.new_goal;
     if Option.fold ~none:false ~some:(fun x -> has_cut ~types x.Ast.Chr.conclusion) r.new_goal then
       error ~loc:r.loc "CHR new goals cannot contain cut";

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -1372,6 +1372,8 @@ end = struct
 
   let check_and_spill_chr ~time ~unknown ~type_abbrevs ~kinds ~types r =
     let unknown = time_this time (fun () -> Type_checker.check_chr_rule ~unknown ~type_abbrevs ~kinds ~types r) in
+    Option.iter (fun x -> Determinacy_checker.check_atom ~type_abbrevs ~types ~unknown x.Ast.Chr.conclusion) r.new_goal;
+    (* TODO: check no cut *)
     let guard = Option.map (Spilling.main ~type_abbrevs ~types) r.guard in
     let new_goal = Option.map (fun ({ Ast.Chr.conclusion } as x) -> { x with conclusion = Spilling.main ~types ~type_abbrevs conclusion }) r.new_goal in
     unknown, { r with guard; new_goal }

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -1736,7 +1736,7 @@ end = struct
     in
 
     let error_overlapping_eigen_variables ~loc pred (cl_st,depth : term * int) = 
-      error ~loc (Format.asprintf "@[<v 0>Mutual exclusion violated for rules of %a.@,This rule (displayed below) does not respects the principles of mutual exclution@]@ @[Principles: there is a cut in the body of the local clause and/or all indexed input arguments are eigenvariables@] @[To solve the problem, add a cut in its body.@]@ @[Offending clause is@ @[<hov 2>%a@]@] @]" pp_global_predicate pred
+      error ~loc (Format.asprintf "@[<v 0>Mutual exclusion violated for rules of %a.@,This rule (displayed below) does not respects the principles of mutual exclution@]@ @[Principles: there is a cut in the body of the local clause and/or all indexed input arguments are eigenvariables@] @[To solve the problem, add a cut in its body.@]@ @[Offending rule:@ @[<hov 2>%a@]@] @]" pp_global_predicate pred
         (pretty_term ~depth) cl_st) 
     in
 
@@ -1868,8 +1868,8 @@ end = struct
               let fresh_loc = get_fresh_loc loc in
               let (p,cl), _, morelcs =
                 try R.CompileTime.clausify1 ~tail_cut:(ik = ImplBang) ~loc:fresh_loc ~modes:(fun x -> fst (get_info x)) ~nargs:(F.Map.cardinal amap) ~depth h
-                with D.CannotDeclareClauseForBuiltin(loc,_c) ->
-                  error ?loc ("Declaring a clause for built in predicate")
+                with D.CannotDeclareClauseForBuiltin(loc,c) ->
+                  error ?loc ("Declaring a clause for built predicate:" ^ show_builtin_predicate (fun ?table x -> F.show @@ SymbolMap.global_name state symbols x) c)
                 in
 
               let cl_overlap, index = R.Indexing.add1clause_overlap_runtime ~depth ~time:(runtime_tick ()) index p cl in

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -1520,7 +1520,7 @@ end = struct
     let map =
       preds |> List.fold_left (fun acc (symb,(indexing:pred_info)) ->
         match SymbolMap.get_global_symbol symbols symb with
-        | None -> assert false
+        | None -> acc
         | Some c -> add_indexing_for (Symbol.get_str symb) (Symbol.get_loc symb) c indexing acc)
       C.Map.empty 
     in
@@ -1802,6 +1802,7 @@ end = struct
           update_bools true a;
           remove_as a :: mkpats is args mode
         | (([] as is) | (_::is)), _::args, _ :: mode -> mkDiscard :: mkpats is args mode
+        | (([] as is) | (_::is)), _::args, [] -> mkDiscard :: mkpats is args mode
         | _, _::args, [] -> error ~loc @@
           Format.asprintf "@[<hov 2>args/mode mismatch: Building query for %a: %s@]" pp_global_predicate p (String.concat " " (List.map  show_term args) ^ " != " ^ Mode.show_hos mode)
         | _ -> assert false

--- a/src/compiler/compiler.mli
+++ b/src/compiler/compiler.mli
@@ -58,9 +58,9 @@ val pp_goal : (pp_ctx:pp_ctx -> depth:int -> Format.formatter -> term -> unit) -
 val elpi_language : Compiler_data.Scope.language
 val elpi : Compiler_data.QuotationHooks.quotation
 
-val uvk : uvar_body StrMap.t State.component
-val pp_uvar_body : Format.formatter -> uvar_body -> unit
-val pp_uvar_body_raw : Format.formatter -> uvar_body -> unit
+val uvk : uvar StrMap.t State.component
+val pp_uvar_body : Format.formatter -> uvar -> unit
+val pp_uvar_body_raw : Format.formatter -> uvar -> unit
 
 val compile_term_to_raw_term :
   ?check:bool -> State.t -> program ->

--- a/src/compiler/compiler_data.ml
+++ b/src/compiler/compiler_data.ml
@@ -230,7 +230,7 @@ module TypeAssignment = struct
       fprintf fmt "@[<hov 2>%a:%a@]" show_mode m (pretty_parens ~lvl:arrs) s;
       match t with
       | Prop _ -> ()
-      | Arr(m, v, s', r) -> fprintf fmt ", %s%a" (if v = Variadic then "variadic" else "") (pretty_pred_mode m) (s',r)
+      | Arr(m, v, s', r) -> fprintf fmt ", %s%a" (if v = Variadic then "variadic " else "") (pretty_pred_mode m) (s',r)
       | _ -> assert false
     in
     let pretty fmt t = Format.fprintf fmt "@[%a@]" pretty t

--- a/src/compiler/compiler_data.ml
+++ b/src/compiler/compiler_data.ml
@@ -564,6 +564,7 @@ module SymbolResolver : sig
   val resolve : TypingEnv.t -> resolution -> Symbol.t -> unit
   val resolved_to : TypingEnv.t -> resolution -> Symbol.t option
   val is_resolved_to : TypingEnv.t -> resolution -> Symbol.t -> bool
+  val is_resolved_to_builtin : TypingEnv.t -> resolution -> bool
 
 end = struct
 
@@ -600,6 +601,15 @@ end = struct
     match resolved_to env r with
     | None -> false
     | Some s1 -> TypingEnv.same_symbol env s s1
+
+  let is_resolved_to_builtin env r =
+    match resolved_to env r with
+    | None -> false
+    | Some s ->
+        match Symbol.get_provenance s with
+        | Core -> true
+        | Builtin _ -> true
+        | _ -> false
 
 end
 

--- a/src/compiler/compiler_data.ml
+++ b/src/compiler/compiler_data.ml
@@ -424,6 +424,7 @@ module TypingEnv : sig
     ty : TypeAssignment.skema;
     indexing : indexing;
     availability : Elpi_parser.Ast.Structured.symbol_availability;
+    implemented_in_ocaml : bool;
   }
   [@@deriving show]
 
@@ -453,6 +454,8 @@ module TypingEnv : sig
   val mem_symbol : t -> Symbol.t -> bool
   val canon : t -> Symbol.t -> Symbol.t
 
+  val set_as_implemented_in_ocaml : t -> Symbol.t -> t
+
 end = struct
 
   type indexing =
@@ -464,6 +467,7 @@ end = struct
     ty : TypeAssignment.skema;
     indexing : indexing;
     availability : Elpi_parser.Ast.Structured.symbol_availability;
+    implemented_in_ocaml : bool;
   }
   [@@deriving show]
 
@@ -472,6 +476,11 @@ end = struct
     overloading : Symbol.t TypeAssignment.overloaded F.Map.t;
   }
   [@@deriving show]
+
+  let set_as_implemented_in_ocaml e s =
+    match Symbol.QMap.find_opt s e.symbols with
+    | None -> assert false
+    | Some m -> { e with symbols = Symbol.QMap.add s { m with implemented_in_ocaml = true } e.symbols }
 
   let compatible_indexing i1 i2 =
     match i1, i2 with
@@ -510,11 +519,12 @@ end = struct
   
   
   let merge_symbol_metadata s
-      { ty = ty1; indexing = idx1; availability = a1; }
-       { ty = ty2; indexing = idx2; availability = a2; } =
+      { ty = ty1; indexing = idx1; availability = a1; implemented_in_ocaml = o1; }
+       { ty = ty2; indexing = idx2; availability = a2; implemented_in_ocaml = o2; } =
     { ty = TypeAssignment.merge_skema ty1 ty2;
       indexing = merge_indexing s idx1 idx2;
       availability = merge_availability s a1 a2;
+      implemented_in_ocaml = o1 || o2;
     }
   
   let o2l = function  TypeAssignment.Single x -> [x] | Overloaded l -> l
@@ -605,11 +615,10 @@ end = struct
   let is_resolved_to_builtin env r =
     match resolved_to env r with
     | None -> false
-    | Some s ->
-        match Symbol.get_provenance s with
-        | Core -> true
-        | Builtin _ -> true
-        | _ -> false
+    | Some r ->
+        match TypingEnv.resolve_symbol_opt r env with
+        | None -> false
+        | Some s -> s.implemented_in_ocaml
 
 end
 

--- a/src/compiler/determinacy_checker.ml
+++ b/src/compiler/determinacy_checker.ml
@@ -802,9 +802,14 @@ let check_clause, check_atom =
   in
 
   let check_atom ~type_abbrevs ~types ~unknown (t : ScopedTerm.t) : unit =
-    let _var, (_dtype, _gc), _tl_cut = with_error_handling ~types ~unknown
+    let _var, (_dtype, gc), _tl_cut = with_error_handling ~types ~unknown
       (check ~type_abbrevs ~types ~ctx:BVar.empty ~var:Uvar.empty Det) t in
-    ()
+    if Good_call.is_wrong gc then
+      let f Good_call.{ term } = 
+          Format.asprintf "@[<hov  2>Found relational atom@ @[<hov 2>(%a)@]@]" 
+            ScopedTerm.pretty term 
+      in
+        err gc f
   in
 
     check_clause, check_atom

--- a/src/compiler/determinacy_checker.ml
+++ b/src/compiler/determinacy_checker.ml
@@ -295,7 +295,7 @@ let spill_err ~loc = anomaly ~loc "Everything should have already been spilled"
       Option.bind (SymbolResolver.resolved_to types x) to_dtype
     | Bound _ -> None
   
-let check_clause, check_atoms =
+let check_clause, check_chr_guard_and_newgoal =
 
   let has_undeclared_signature ~types ~unknown { ScopedTerm.scope = b; name = f } =
     match F.Map.find_opt f unknown with Some (_, symb) -> same_symb ~types symb b | _ -> false
@@ -800,22 +800,20 @@ let check_clause, check_atoms =
     ()
   in
 
-  let check_atoms ~type_abbrevs ~types ~unknown (tl : ScopedTerm.t list) : unit =
-    let _ : Uvar.t =
-      List.fold_left (fun var t ->
-        let var, (_dtype, gc) = with_error_handling ~types ~unknown
-          (check ~type_abbrevs ~types ~ctx:BVar.empty ~var Det) t in
-        begin if Good_call.is_wrong gc then
-          let f Good_call.{ term } = 
-              Format.asprintf "@[<hov  2>Found relational atom@ @[<hov 2>(%a)@]@]" 
-                ScopedTerm.pretty term 
-          in
-            err gc f
-        end;
-        var) Uvar.empty tl
-    in
-      ()
+  let check_chr_guard_and_newgoal ~type_abbrevs ~types ~unknown ~guard ~newgoal : unit =
+    let var = Uvar.empty in
+    let var =
+      match guard with
+      | Some guard -> fst @@ with_error_handling ~types ~unknown (check ~type_abbrevs ~types ~ctx:BVar.empty ~var Rel) guard
+      | None -> var in
+    let _, (_, gc) = with_error_handling ~types ~unknown (check ~type_abbrevs ~types ~ctx:BVar.empty ~var Det) newgoal in
+    if Good_call.is_wrong gc then
+      let f Good_call.{ term } = 
+          Format.asprintf "@[<hov  2>Found relational new goal in CHR rule:@ @[<hov 2>(%a)@]@]" 
+            ScopedTerm.pretty term 
+      in
+        err gc f
   in
 
-    check_clause, check_atoms
+    check_clause, check_chr_guard_and_newgoal
 

--- a/src/compiler/determinacy_checker.mli
+++ b/src/compiler/determinacy_checker.mli
@@ -11,9 +11,9 @@ val check_clause :
   unknown:env_undeclared ->
     ScopedTerm.t -> unit
 
-(* checks the atoms are det *)
-val check_atoms :
+(* checks [guard, !, newgoal] is det *)
+val check_chr_guard_and_newgoal :
   type_abbrevs:type_abbrevs ->
   types:TypingEnv.t ->
   unknown:env_undeclared ->
-    ScopedTerm.t list -> unit
+    guard:ScopedTerm.t option -> newgoal:ScopedTerm.t -> unit

--- a/src/compiler/determinacy_checker.mli
+++ b/src/compiler/determinacy_checker.mli
@@ -11,9 +11,9 @@ val check_clause :
   unknown:env_undeclared ->
     ScopedTerm.t -> unit
 
-(* checks the atom is det *)
-val check_atom :
+(* checks the atoms are det *)
+val check_atoms :
   type_abbrevs:type_abbrevs ->
   types:TypingEnv.t ->
   unknown:env_undeclared ->
-    ScopedTerm.t -> unit
+    ScopedTerm.t list -> unit

--- a/src/compiler/determinacy_checker.mli
+++ b/src/compiler/determinacy_checker.mli
@@ -4,8 +4,15 @@
 open Compiler_data
 open Type_checker
 
-(* returns if the clause is deterministic *)
+(* checks if the clause adheres to the prescribed determinacy *)
 val check_clause :
+  type_abbrevs:type_abbrevs ->
+  types:TypingEnv.t ->
+  unknown:env_undeclared ->
+    ScopedTerm.t -> unit
+
+(* checks the atom is det *)
+val check_atom :
   type_abbrevs:type_abbrevs ->
   types:TypingEnv.t ->
   unknown:env_undeclared ->

--- a/src/compiler/test_type_checker.ml
+++ b/src/compiler/test_type_checker.ml
@@ -62,7 +62,7 @@ let _ =
   let kinds = F.Map.empty in
   let types = F.Map.empty, Symbol.QMap.empty in
   let build_ty_metadata ty : TypingEnv.symbol_metadata =
-    {indexing = TypingEnv.DontIndex; availability = Elpi_parser.Ast.Structured.Elpi; ty} in
+    {indexing = TypingEnv.DontIndex; availability = Elpi_parser.Ast.Structured.Elpi; ty; implemented_in_ocaml = false } in
   let add_ty k v (overloading, symbols) = 
     let k = fs k in
     let symb = Elpi_runtime.Data.Symbol.make_builtin k in

--- a/src/compiler/type_checker.ml
+++ b/src/compiler/type_checker.ml
@@ -142,7 +142,7 @@ let check_type ~type_abbrevs ~kinds { value; loc; name; index; availability } : 
     | OCaml (Builtin { variant } as b) -> Symbol.make b name |> to_unify (variant != 0) (* TODO: this is hack for builtins, they could be overloaded as well *)
     (* | OCaml None -> Symbol.make_builtin name |> to_unify false  *)
   in
-  symb, quotient, { ty; indexing; availability }
+  symb, quotient, { ty; indexing; availability; implemented_in_ocaml = false }
 
 let arrow_of_args args ety =
   let rec aux = function
@@ -871,7 +871,7 @@ let check1_undeclared ~type_abbrevs w f (t, id) =
         let {static;runtime} = chose_indexing (Symbol.get_func id) [1] None in
         TypingEnv.Index {mode;indexing=runtime; overlap=Elpi_runtime.Data.mk_Forbidden static; has_local_without_cut=None}
       in
-      id, TypingEnv.{ ty ; indexing; availability = Elpi }
+      id, TypingEnv.{ ty ; indexing; availability = Elpi; implemented_in_ocaml = false }
   | _ -> assert false
 
 let check_undeclared ~type_abbrevs ~unknown =

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -91,7 +91,7 @@ module TypeExpression = struct
   type 'attribute t_ =
     | TConst of Func.t
     | TApp of Func.t * 'attribute t * 'attribute t list
-    | TPred of 'attribute * (Mode.t * 'attribute t) list
+    | TPred of 'attribute * (Mode.t * 'attribute t) list * bool (* true = variadic *)
     | TArr of 'attribute t * 'attribute t
   and 'a t = { tit : 'a t_; tloc : Loc.t }
   [@@ deriving show, ord]

--- a/src/parser/ast.mli
+++ b/src/parser/ast.mli
@@ -67,7 +67,7 @@ module TypeExpression : sig
   type 'attribute t_ =
    | TConst of Func.t
    | TApp of Func.t * 'attribute t * 'attribute t list
-   | TPred of 'attribute * (Mode.t * 'attribute t) list
+   | TPred of 'attribute * (Mode.t * 'attribute t) list * bool (* true = variadic *)
    | TArr of 'attribute t * 'attribute t
    and 'a t = { tit : 'a t_; tloc : Loc.t }
    [@@ deriving show, ord]

--- a/src/parser/error_messages.txt
+++ b/src/parser/error_messages.txt
@@ -575,7 +575,6 @@ You cannot ascribe a type on the head predicate.
 goal: AFTER COLON LPAREN PRED VDASH
 goal: AFTER COLON AFTER LPAREN FUNC ARROW AFTER ARROW
 goal: AFTER COLON LPAREN AFTER IO_COLON
-goal: AFTER COLON LPAREN FUNC ARROW AFTER ARROW
 
 Anonymous predicate declaration expected.
 Examples:

--- a/src/parser/error_messages.txt
+++ b/src/parser/error_messages.txt
@@ -471,12 +471,15 @@ program: FUNC AFTER ARROW VDASH
 program: FUNC AFTER LPAREN FUNC AFTER FULLSTOP
 program: FUNC AFTER LPAREN FUNC VDASH
 program: FUNC AFTER LPAREN FUNC ARROW VDASH
+program: FUNC AFTER DOTS VDASH
+program: FUNC AFTER ARROW AFTER RPAREN
 
 Predicate declaration expected. Examples:
 pred append i:list A, i:list A, o:list A.
 pred append i:list A i:list A o:list A.
 pred mapR i:list A, i:(pred i:A, o:B), o:list B.
 func map list A, (func A -> B) -> list B.
+func intdiv int, int -> int.. .
 
 program: EXPORTDEF AFTER TYPE
 program: EXPORTDEF VDASH
@@ -575,9 +578,12 @@ You cannot ascribe a type on the head predicate.
 goal: AFTER COLON LPAREN PRED VDASH
 goal: AFTER COLON AFTER LPAREN FUNC ARROW AFTER ARROW
 goal: AFTER COLON LPAREN AFTER IO_COLON
+goal: AFTER COLON AFTER LPAREN FUNC ARROW DOTS VDASH
+goal: AFTER COLON LPAREN FUNC ARROW DOTS VDASH
 
 Anonymous predicate declaration expected.
 Examples:
 (pred i:ty, o:ty)
 (pred)
-
+(func tm -> ty)
+(func)

--- a/src/parser/grammar.mly
+++ b/src/parser/grammar.mly
@@ -206,32 +206,36 @@ chr_rule:
 
 pred:
 | attributes = attributes; PRED;
-  name = constant; args = separated_list(option(CONJ),pred_item) {
-   { Type.loc=loc $sloc; name; attributes; ty = { tloc = loc $loc; tit = TPred ([], args) } }
+  name = constant; args = separated_list(option(CONJ),pred_item); o=option(DOTS) {
+    let variadic = o <> None in
+   { Type.loc=loc $sloc; name; attributes; ty = { tloc = loc $loc; tit = TPred ([], args, variadic) } }
  }
 | attributes = attributes; FUNC;
-  name = constant; in_args = separated_list(CONJ,fotype_term); ARROW; out_args = separated_list(CONJ,fotype_term) {
+  name = constant; in_args = separated_list(CONJ,fotype_term); ARROW; out_args = separated_list(CONJ,fotype_term); o=option(DOTS) {
     let args = List.map (fun x -> Mode.Input,x) in_args @ List.map (fun x -> Mode.Output,x) out_args in
-    { Type.loc=loc $sloc; name; attributes; ty = { tloc = loc $loc; tit = TPred ([Functional], args) } }
+    let variadic = o <> None in
+    { Type.loc=loc $sloc; name; attributes; ty = { tloc = loc $loc; tit = TPred ([Functional], args, variadic) } }
   }
 | attributes = attributes; FUNC;
-  name = constant; in_args = separated_list(CONJ,fotype_term) {
+  name = constant; in_args = separated_list(CONJ,fotype_term); o=option(DOTS) {
   let args = List.map (fun x -> Mode.Input,x) in_args in
-  { Type.loc=loc $sloc; name; attributes; ty = { tloc = loc $loc; tit = TPred ([Functional], args) } }
+    let variadic = o <> None in
+  { Type.loc=loc $sloc; name; attributes; ty = { tloc = loc $loc; tit = TPred ([Functional], args, variadic) } }
 }
 
 pred_item:
 | io = IO_COLON; ty = type_term { (mode_of_IO io,ty) }
 
 anonymous_pred:
-| PRED; args = separated_list(option(CONJ),pred_item) { { tloc = loc $loc; tit = TPred ([], args) } }
-| FUNC; in_args = separated_list(CONJ,fotype_term); ARROW; out_args = separated_list(CONJ,fotype_term) {
+| PRED; args = separated_list(option(CONJ),pred_item) { { tloc = loc $loc; tit = TPred ([], args, false) } }
+| FUNC; in_args = separated_list(CONJ,fotype_term); ARROW; out_args = separated_list(CONJ,fotype_term); o=option(DOTS) {
     let args = List.map (fun x -> Mode.Input,x) in_args @ List.map (fun x -> Mode.Output,x) out_args in
-    { tloc = loc $loc; tit = TPred ([Functional], args) }
+    let variadic = o <> None in
+    { tloc = loc $loc; tit = TPred ([Functional], args, variadic) }
   }
 | FUNC; in_args = separated_list(CONJ,fotype_term) {
     let args = List.map (fun x -> Mode.Input,x) in_args in
-    { tloc = loc $loc; tit = TPred ([Functional], args) }
+    { tloc = loc $loc; tit = TPred ([Functional], args, false) }
   }
 
 kind:

--- a/src/parser/lexer.mll.in
+++ b/src/parser/lexer.mll.in
@@ -237,5 +237,6 @@ and token v = parse
 | ucase idcharstar as c { CONSTANT c }
 | lcase idcharstarns as c { CONSTANT c }
 | "." idcharstarns as c { CONSTANT c }
+| ".." { DOTS }
 | '@' idcharstar as c { CONSTANT c }
 | eof { EOF }

--- a/src/parser/test_lexer.ml
+++ b/src/parser/test_lexer.ml
@@ -76,6 +76,7 @@ type t = Tokens.token =
   | EQ2
   | EQ
   | EOF
+  | DOTS
   | DIV
   | DDARROWBANG
   | DDARROW
@@ -144,7 +145,9 @@ let () =
   test  "3.4\n .5"                   [T(FLOAT 3.4, 1, 0, 0, 3); T(FLOAT 0.5, 2, 4, 5, 7)];
   (*    01234567890123456789012345 *)
   test  "3 .4"                       [T(INTEGER 3, 1, 0, 0, 1); T(FLOAT 0.4, 1, 0, 2, 4)];
-  test  "3..4"                       [T(INTEGER 3, 1, 0, 0, 1); T(FULLSTOP, 1, 0, 1, 2); T(FLOAT 0.4, 1, 0, 2, 4)];
+  test  "3..4"                       [T(INTEGER 3, 1, 0, 0, 1); T(DOTS, 1, 0, 1, 3); T(INTEGER 4, 1, 0, 3, 4)];
+  test  "3..."                       [T(INTEGER 3, 1, 0, 0, 1); T(DOTS, 1, 0, 1, 3); T(FULLSTOP, 1, 0, 3, 4)];
+  test  "3. .4"                      [T(INTEGER 3, 1, 0, 0, 1); T(FULLSTOP, 1, 0, 1, 2); T(FLOAT 0.4, 1, 0, 3, 5)];
   test  "3."                         [T(INTEGER 3, 1, 0, 0, 1); T(FULLSTOP, 1, 0, 1, 2)];
   test  "-3."                        [T(INTEGER (-3), 1, 0, 0, 2); T(FULLSTOP, 1, 0, 2, 3)];
   (*    01234567890123456789012345 *)

--- a/src/parser/tokens.mly
+++ b/src/parser/tokens.mly
@@ -76,6 +76,7 @@
 %token IFF
 %token NIL
 %token EOF
+%token DOTS
 
 %token <string> FAMILY_PLUS
 %token <string> FAMILY_TIMES

--- a/src/runtime/data.ml
+++ b/src/runtime/data.ml
@@ -185,23 +185,28 @@ type term =
   | Const of constant
   | Lam of term
   | App of constant * term * term list
+
   (* Optimizations *)
   | Cons of term * term
   | Nil
   | Discard
+
   (* FFI *)
   | Builtin of builtin_predicate * term list
   | CData of CData.t
+
   (* Heap terms: unif variables in the query *)
-  | UVar of uvar * (*argsno:*)int
-  | AppUVar of uvar * term list
-  (* Clause terms: unif variables used in clauses *)
-  | Arg of (*id:*)int * (*argsno:*)int
-  | AppArg of (*id*)int * term list
+  | UVar    of uvar * int (* number of arguments *)
+  | AppUVar of uvar * term list (* arguments *)
+
+  (* Stack terms: unif variables in the rules *)
+  | Arg    of int * int (* number of arguments *)
+  | AppArg of int * term list (* arguments *)
+
 and uvar = {
-  vardepth : int; (* the depth at which the uvar borns *)
+  vardepth : int; (* depth at creation time *)
   mutable contents : term [@printer (pp_spaghetti_any ~id:id_term pp_oref)];
-  mutable uid_private : int; (* unique name, the sign is flipped when blocks a constraint *)
+  mutable uid_private : int; (* negative if it blocks a constraint *)
 }
 [@@deriving show, ord]
 

--- a/src/runtime/data.ml
+++ b/src/runtime/data.ml
@@ -193,12 +193,12 @@ type term =
   | Builtin of builtin_predicate * term list
   | CData of CData.t
   (* Heap terms: unif variables in the query *)
-  | UVar of uvar_body * (*argsno:*)int
-  | AppUVar of uvar_body * term list
+  | UVar of uvar * (*argsno:*)int
+  | AppUVar of uvar * term list
   (* Clause terms: unif variables used in clauses *)
   | Arg of (*id:*)int * (*argsno:*)int
   | AppArg of (*id*)int * term list
-and uvar_body = {
+and uvar = {
   vardepth : int; (* the depth at which the uvar borns *)
   mutable contents : term [@printer (pp_spaghetti_any ~id:id_term pp_oref)];
   mutable uid_private : int; (* unique name, the sign is flipped when blocks a constraint *)
@@ -236,7 +236,7 @@ type stuck_goal = {
   mutable blockers : blockers;
   kind : unification_def stuck_goal_kind;
 }
-and blockers = uvar_body list
+and blockers = uvar list
 and unification_def = {
   adepth : int;
   env : term array;

--- a/src/runtime/ptmap.ml
+++ b/src/runtime/ptmap.ml
@@ -3,7 +3,7 @@
 (*  Copyright (C) Jean-Christophe Filliatre                               *)
 (*                                                                        *)
 (*  This software is free software; you can redistribute it and/or        *)
-(*  modify it under the terms of the GNU Library General Public           *)
+(*  modify it under the terms of the GNU Lesser General Public            *)
 (*  License version 2.1, with the special exception on linking            *)
 (*  described in file LICENSE.                                            *)
 (*                                                                        *)
@@ -12,8 +12,6 @@
 (*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
 (*                                                                        *)
 (**************************************************************************)
-
-(*i $Id$ i*)
 
 (*s Maps of integers implemented as Patricia trees, following Chris
     Okasaki and Andrew Gill's paper {\em Fast Mergeable Integer Maps}
@@ -44,6 +42,315 @@ let rec find k = function
   | Leaf (j,x) -> if k == j then x else raise Not_found
   | Branch (_, m, l, r) -> find k (if zero_bit k m then l else r)
 
+let find_opt k m = try Some (find k m) with Not_found -> None
+
+(* Note: find_first/last have to look in both subtrees
+   as these are little-endian Patricia trees *)
+let rec find_first_opt f = function
+  | Empty -> None
+  | Leaf (j,x) -> if f j then Some (j,x) else None
+  | Branch (_, _, l, r) ->
+    match find_first_opt f l, find_first_opt f r with
+    | Some (lk,lv) , Some (rk,rv) ->
+        if lk < rk then Some (lk,lv) else Some (rk,rv)
+    | Some v, None | None, Some v -> Some v
+    | None, None -> None
+
+let find_first f = function
+  | Empty -> raise Not_found
+  | Leaf (j,x) -> if f j then (j,x) else raise Not_found
+  | Branch (_, _, l, r) ->
+    match find_first_opt f l, find_first_opt f r with
+    | Some (lk,lv) , Some (rk,rv) -> if lk < rk then (lk,lv) else (rk,rv)
+    | Some v, None | None, Some v -> v
+    | None, None -> raise Not_found
+
+let rec find_last_opt f = function
+  | Empty -> None
+  | Leaf (j,x) -> if f j then Some (j,x) else None
+  | Branch (_, _, l, r) ->
+    match find_last_opt f l, find_last_opt f r with
+    | Some (lk,lv) , Some (rk,rv) ->
+        if lk > rk then Some (lk,lv) else Some (rk,rv)
+    | Some v, None | None, Some v -> Some v
+    | None, None -> None
+
+let find_last f = function
+  | Empty -> raise Not_found
+  | Leaf (j,x) -> if f j then (j,x) else raise Not_found
+  | Branch (_, _, l, r) ->
+    match find_last_opt f l, find_last_opt f r with
+    | Some (lk,lv) , Some (rk,rv) -> if lk > rk then (lk,lv) else (rk,rv)
+    | Some v, None | None, Some v -> v
+    | None, None -> raise Not_found
+
+let lowest_bit x = x land (-x)
+
+let branching_bit p0 p1 = lowest_bit (p0 lxor p1)
+
+let mask p m = p land (m-1)
+
+let join (p0,t0,p1,t1) =
+  let m = branching_bit p0 p1 in
+  if zero_bit p0 m then
+    Branch (mask p0 m, m, t0, t1)
+  else
+    Branch (mask p0 m, m, t1, t0)
+
+let match_prefix k p m = (mask k m) == p
+
+let add k x t =
+  let rec ins = function
+    | Empty -> Leaf (k,x)
+    | Leaf (j,_) as t ->
+      if j == k then Leaf (k,x) else join (k, Leaf (k,x), j, t)
+    | Branch (p,m,t0,t1) as t ->
+      if match_prefix k p m then
+	if zero_bit k m then
+	  Branch (p, m, ins t0, t1)
+	else
+	  Branch (p, m, t0, ins t1)
+      else
+	join (k, Leaf (k,x), p, t)
+  in
+  ins t
+
+let singleton k v =
+  add k v empty
+
+let branch = function
+  | (_,_,Empty,t) -> t
+  | (_,_,t,Empty) -> t
+  | (p,m,t0,t1)   -> Branch (p,m,t0,t1)
+
+let remove k t =
+  let rec rmv = function
+    | Empty -> Empty
+    | Leaf (j,_) as t -> if k == j then Empty else t
+    | Branch (p,m,t0,t1) as t ->
+      if match_prefix k p m then
+	if zero_bit k m then
+	  branch (p, m, rmv t0, t1)
+	else
+	  branch (p, m, t0, rmv t1)
+      else
+	t
+  in
+  rmv t
+
+let rec cardinal = function
+  | Empty -> 0
+  | Leaf _ -> 1
+  | Branch (_,_,t0,t1) -> cardinal t0 + cardinal t1
+
+let rec iter f = function
+  | Empty -> ()
+  | Leaf (k,x) -> f k x
+  | Branch (_,_,t0,t1) -> iter f t0; iter f t1
+
+let rec map f = function
+  | Empty -> Empty
+  | Leaf (k,x) -> Leaf (k, f x)
+  | Branch (p,m,t0,t1) -> Branch (p, m, map f t0, map f t1)
+
+let rec mapi f = function
+  | Empty -> Empty
+  | Leaf (k,x) -> Leaf (k, f k x)
+  | Branch (p,m,t0,t1) -> Branch (p, m, mapi f t0, mapi f t1)
+
+let rec fold f s accu = match s with
+  | Empty -> accu
+  | Leaf (k,x) -> f k x accu
+  | Branch (_,_,t0,t1) -> fold f t0 (fold f t1 accu)
+
+let rec for_all p = function
+  | Empty -> true
+  | Leaf (k, v)  -> p k v
+  | Branch (_,_,t0,t1) -> for_all p t0 && for_all p t1
+
+let rec exists p = function
+  | Empty -> false
+  | Leaf (k, v) -> p k v
+  | Branch (_,_,t0,t1) -> exists p t0 || exists p t1
+
+let rec filter pr = function
+  | Empty -> Empty
+  | Leaf (k, v) as t -> if pr k v then t else Empty
+  | Branch (p,m,t0,t1) -> branch (p, m, filter pr t0, filter pr t1)
+
+let rec filter_map pr = function
+  | Empty -> Empty
+  | Leaf (k, v) -> (match pr k v with Some v' -> Leaf (k, v') | None -> Empty)
+  | Branch (p,m,t0,t1) -> branch (p, m, filter_map pr t0, filter_map pr t1)
+
+let partition p s =
+  let rec part (t,f as acc) = function
+    | Empty -> acc
+    | Leaf (k, v) -> if p k v then (add k v t, f) else (t, add k v f)
+    | Branch (_,_,t0,t1) -> part (part acc t0) t1
+  in
+  part (Empty, Empty) s
+
+let rec choose = function
+  | Empty -> raise Not_found
+  | Leaf (k, v) -> (k, v)
+  | Branch (_, _, t0, _) -> choose t0   (* we know that [t0] is non-empty *)
+
+let rec choose_opt = function
+  | Empty -> None
+  | Leaf (k, v) -> Some (k, v)
+  | Branch (_, _, t0, _) -> choose_opt t0   (* we know that [t0] is non-empty *)
+
+let split x m =
+  let coll k v (l, b, r) =
+    if k < x then add k v l, b, r
+    else if k > x then l, b, add k v r
+    else l, Some v, r
+  in
+  fold coll m (empty, None, empty)
+
+let rec min_binding = function
+  | Empty -> raise Not_found
+  | Leaf (k, v) -> (k, v)
+  | Branch (_,_,s,t) ->
+    let (ks, _) as bs = min_binding s in
+    let (kt, _) as bt = min_binding t in
+    if ks < kt then bs else bt
+
+let rec min_binding_opt = function
+  | Empty -> None
+  | Leaf (k, v) -> Some (k, v)
+  | Branch (_,_,s,t) ->
+    match (min_binding_opt s, min_binding_opt t) with
+    | None, None -> None
+    | None, bt -> bt
+    | bs, None -> bs
+    | (Some (ks, _) as bs), (Some (kt, _) as bt) ->
+      if ks < kt then bs else bt
+
+let rec max_binding = function
+  | Empty -> raise Not_found
+  | Leaf (k, v) -> (k, v)
+  | Branch (_,_,s,t) ->
+    let (ks, _) as bs = max_binding s in
+    let (kt, _) as bt = max_binding t in
+    if ks > kt then bs else bt
+
+let rec max_binding_opt = function
+  | Empty -> None
+  | Leaf (k, v) -> Some (k, v)
+  | Branch (_,_,s,t) ->
+    match max_binding_opt s, max_binding_opt t with
+    | None, None -> None
+    | None, bt -> bt
+    | bs, None -> bs
+    | (Some (ks, _) as bs), (Some (kt, _) as bt) ->
+      if ks > kt then bs else bt
+
+let bindings m =
+  fold (fun k v acc -> (k, v) :: acc) m []
+
+(* we order constructors as Empty < Leaf < Branch *)
+let compare cmp t1 t2 =
+  let rec compare_aux t1 t2 = match t1,t2 with
+    | Empty, Empty -> 0
+    | Empty, _ -> -1
+    | _, Empty -> 1
+    | Leaf (k1,x1), Leaf (k2,x2) ->
+      let c = compare k1 k2 in
+      if c <> 0 then c else cmp x1 x2
+    | Leaf _, Branch _ -> -1
+    | Branch _, Leaf _ -> 1
+    | Branch (p1,m1,l1,r1), Branch (p2,m2,l2,r2) ->
+      let c = compare p1 p2 in
+      if c <> 0 then c else
+	let c = compare m1 m2 in
+	if c <> 0 then c else
+          let c = compare_aux l1 l2 in
+          if c <> 0 then c else
+            compare_aux r1 r2
+  in
+  compare_aux t1 t2
+
+let equal eq t1 t2 =
+  let rec equal_aux t1 t2 = match t1, t2 with
+    | Empty, Empty -> true
+    | Leaf (k1,x1), Leaf (k2,x2) -> k1 = k2 && eq x1 x2
+    | Branch (p1,m1,l1,r1), Branch (p2,m2,l2,r2) ->
+      p1 = p2 && m1 = m2 && equal_aux l1 l2 && equal_aux r1 r2
+    | _ -> false
+  in
+  equal_aux t1 t2
+
+let merge f m1 m2 =
+  let add m k = function None -> m | Some v -> add k v m in
+  (* first consider all bindings in m1 *)
+  let m = fold
+      (fun k1 v1 m -> add m k1 (f k1 (Some v1) (find_opt k1 m2))) m1 empty in
+  (* then bindings in m2 that are not in m1 *)
+  fold (fun k2 v2 m -> if mem k2 m1 then m else add m k2 (f k2 None (Some v2)))
+    m2 m
+
+let update x f m =
+  match f (find_opt x m) with
+  | None -> remove x m
+  | Some z -> add x z m
+
+let unsigned_lt n m = n >= 0 && (m < 0 || n < m)
+
+let rec union f = function
+  | Empty, t  -> t
+  | t, Empty  -> t
+  | Leaf (k,v1), t ->
+      update k (function None -> Some v1 | Some v2 -> f k v1 v2) t
+  | t, Leaf (k,v2) ->
+      update k (function None -> Some v2 | Some v1 -> f k v1 v2) t
+  | (Branch (p,m,s0,s1) as s), (Branch (q,n,t0,t1) as t) ->
+      if m == n && match_prefix q p m then
+	(* The trees have the same prefix. Merge the subtrees. *)
+	branch (p, m, union f (s0,t0), union f (s1,t1))
+      else if unsigned_lt m n && match_prefix q p m then
+	(* [q] contains [p]. Merge [t] with a subtree of [s]. *)
+	if zero_bit q m then
+	  branch (p, m, union f (s0,t), s1)
+        else
+	  branch (p, m, s0, union f (s1,t))
+      else if unsigned_lt n m && match_prefix p q n then
+	(* [p] contains [q]. Merge [s] with a subtree of [t]. *)
+	if zero_bit p n then
+	  branch (q, n, union f (s,t0), t1)
+	else
+	  branch (q, n, t0, union f (s,t1))
+      else
+	(* The prefixes disagree. *)
+	join (p, s, q, t)
+
+let union f s t = union f (s,t)
+
+let to_seq m =
+  let rec prepend_seq m s = match m with
+    | Empty -> s
+    | Leaf (k, v) -> fun () -> Seq.Cons((k,v), s)
+    | Branch (_, _, l, r) -> prepend_seq l (prepend_seq r s)
+  in
+  prepend_seq m Seq.empty
+
+let to_seq_from k m =
+  let rec prepend_seq m s = match m with
+    | Empty -> s
+    | Leaf (key, v) -> if key >= k then fun () -> Seq.Cons((key,v), s) else s
+    | Branch (_, _, l, r) -> prepend_seq l (prepend_seq r s)
+  in
+  prepend_seq m Seq.empty
+
+let add_seq s m =
+  Seq.fold_left (fun m (k, v) -> add k v m) m s
+
+let of_seq s =
+  Seq.fold_left (fun m (k, v) -> add k v m) empty s
+
+(************************************************************* *)
+
 let find_unifiables k t =
   let sol = ref [] in
   let rec aux = function 
@@ -55,164 +362,6 @@ let find_unifiables k t =
         else aux r
   in
     aux t; !sol
-
-let lowest_bit x = x land (-x)
-
-let branching_bit p0 p1 = lowest_bit (p0 lxor p1)
-
-let mask p m = p land (m-1)
-
-let join (p0,t0,p1,t1) =
-  let m = branching_bit p0 p1 in
-  if zero_bit p0 m then 
-    Branch (mask p0 m, m, t0, t1)
-  else 
-    Branch (mask p0 m, m, t1, t0)
-
-let match_prefix k p m = (mask k m) == p
-
-let add k x t =
-  let rec ins = function
-    | Empty -> Leaf (k,x)
-    | Leaf (j,_) as t -> 
-	if j == k then Leaf (k,x) else join (k, Leaf (k,x), j, t)
-    | Branch (p,m,t0,t1) as t ->
-	if match_prefix k p m then
-	  if zero_bit k m then 
-	    Branch (p, m, ins t0, t1)
-	  else
-	    Branch (p, m, t0, ins t1)
-	else
-	  join (k, Leaf (k,x), p, t)
-  in
-  ins t
-
-let branch = function
-  | (_,_,Empty,t) -> t
-  | (_,_,t,Empty) -> t
-  | (p,m,t0,t1)   -> Branch (p,m,t0,t1)
-
-let remove k t =
-  let rec rmv = function
-    | Empty -> Empty
-    | Leaf (j,_) as t -> if k == j then Empty else t
-    | Branch (p,m,t0,t1) as t -> 
-	if match_prefix k p m then
-	  if zero_bit k m then
-	    branch (p, m, rmv t0, t1)
-	  else
-	    branch (p, m, t0, rmv t1)
-	else
-	  t
-  in
-  rmv t
-
-let rec iter f = function
-  | Empty -> ()
-  | Leaf (k,x) -> f k x
-  | Branch (_,_,t0,t1) -> iter f t0; iter f t1
-
-let rec map f = function
-  | Empty -> Empty
-  | Leaf (k,x) -> Leaf (k, f x)
-  | Branch (p,m,t0,t1) -> Branch (p, m, map f t0, map f t1)
-      
-let rec mapi f = function
-  | Empty -> Empty
-  | Leaf (k,x) -> Leaf (k, f k x)
-  | Branch (p,m,t0,t1) -> Branch (p, m, mapi f t0, mapi f t1)
-      
-let rec fold f s accu = match s with
-  | Empty -> accu
-  | Leaf (k,x) -> f k x accu
-  | Branch (_,_,t0,t1) -> fold f t0 (fold f t1 accu)
-
-(* we order constructors as Empty < Leaf < Branch *)
-let compare cmp t1 t2 =
-  let rec compare_aux t1 t2 = match t1,t2 with
-    | Empty, Empty -> 0
-    | Empty, _ -> -1
-    | _, Empty -> 1
-    | Leaf (k1,x1), Leaf (k2,x2) ->
-	let c = compare k1 k2 in 
-	if c <> 0 then c else cmp x1 x2
-    | Leaf _, Branch _ -> -1
-    | Branch _, Leaf _ -> 1
-    | Branch (p1,m1,l1,r1), Branch (p2,m2,l2,r2) ->
-	let c = compare p1 p2 in
-	if c <> 0 then c else
-	let c = compare m1 m2 in
-	if c <> 0 then c else
-        let c = compare_aux l1 l2 in
-        if c <> 0 then c else
-        compare_aux r1 r2
-  in
-  compare_aux t1 t2
-
-let equal eq t1 t2 =
-  let rec equal_aux t1 t2 = match t1, t2 with
-    | Empty, Empty -> true
-    | Leaf (k1,x1), Leaf (k2,x2) -> k1 = k2 && eq x1 x2
-    | Branch (p1,m1,l1,r1), Branch (p2,m2,l2,r2) ->
-	p1 = p2 && m1 = m2 && equal_aux l1 l2 && equal_aux r1 r2
-    | _ -> false
-  in
-  equal_aux t1 t2
-
-let rec merge = function
-  | Empty, t  -> t
-  | t, Empty  -> t
-  | Leaf (k,x), t -> add k x t
-  | t, Leaf (k,x) -> add k x t
-  | (Branch (p,m,s0,s1) as s), (Branch (q,n,t0,t1) as t) ->
-      if m == n && match_prefix q p m then
-        (* The trees have the same prefix. Merge the subtrees. *)
-        Branch (p, m, merge (s0,t0), merge (s1,t1))
-      else if m < n && match_prefix q p m then
-        (* [q] contains [p]. Merge [t] with a subtree of [s]. *)
-        if zero_bit q m then
-          Branch (p, m, merge (s0,t), s1)
-        else
-          Branch (p, m, s0, merge (s1,t))
-      else if m > n && match_prefix p q n then
-        (* [p] contains [q]. Merge [s] with a subtree of [t]. *)
-        if zero_bit p n then
-          Branch (q, n, merge (s,t0), t1)
-        else
-          Branch (q, n, t0, merge (s,t1))
-      else
-        (* The prefixes disagree. *)
-        join (p, s, q, t)
-
-let rec diff f s1 s2 = match (s1,s2) with
-  | Empty, _ -> Empty
-  | _, Empty -> s1
-  | Leaf (k1,x1), _ ->
-     (try
-       let x2 = find k1 s2 in
-       match f x1 x2 with
-          None -> Empty
-        | Some x -> Leaf (k1,x)
-      with Not_found -> s1)
-  | _, Leaf (k2,x2) ->
-     (try
-       let x1 = find k2 s1 in
-       match f x1 x2 with
-          None -> remove k2 s1
-        | Some x -> add k2 x s1
-      with Not_found -> s1)
-  | Branch (p1,m1,l1,r1), Branch (p2,m2,l2,r2) ->
-      if m1 == m2 && p1 == p2 then
-        merge (diff f l1 l2, diff f r1 r2)
-      else if m1 < m2 && match_prefix p2 p1 m1 then
-        if zero_bit p2 m1 then
-          merge (diff f l1 s2, r1)
-        else
-          merge (l1, diff f r1 s2)
-      else if m1 > m2 && match_prefix p1 p2 m2 then
-        if zero_bit p1 m2 then diff f s1 l2 else diff f s1 r2
-      else
-        s1
 
 let to_list s =
   let rec elements_aux acc = function

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -183,6 +183,7 @@ let xppterm ~nice ?(pp_ctx = { Data.uv_names; table = ! C.table }) ?(min_prec=mi
    end else if nice then begin
     aux prec depth f (!do_uv_deref ~to_:depth r args)
    end else Fmt.fprintf f "<%s|%a>_%d" (string_of_uvar_body r) (aux min_prec vardepth) !!r vardepth
+
   and pp_arg prec depth f n =
    let name= try List.nth names n with Failure _ -> "A" ^ string_of_int n in
    if try env.(n) == C.dummy with Invalid_argument _ -> true then
@@ -2203,6 +2204,11 @@ let eta_contract_flex ~depth t =
 end
 (* }}} *)
 open HO
+
+let () = do_uv_deref := deref_uv
+let () = do_appuv_deref := deref_appuv
+let () = do_arg_deref := deref_arg
+let () = do_apparg_deref := deref_apparg
 
 
 (* Built-in predicates and their FFI *************************************** *)

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -111,8 +111,10 @@ let mkConst = C.mkConst
 (* Dereferencing an UVar(r,args) when !!r != dummy requires a function
    of this kind.  The pretty printer needs one but will only be defined
    later, since we need, for example, beta reduction to implement it *)
-type 'args deref_fun =
-  ?avoid:uvar_body -> from:int -> to_:int -> 'args -> term -> term
+type 'args deref_uv_fun =
+  ?avoid:uvar_body -> to_:int -> uvar_body -> 'args -> term
+type 'args deref_arg_fun =
+  ?avoid:uvar_body -> from:int -> to_:int -> term -> 'args -> term
 
 module Pp : sig
 
@@ -127,8 +129,10 @@ module Pp : sig
     Fmt.formatter -> term -> unit
 
   (* To be assigned later, used to dereference an UVar/AppUVar *)
-  val do_deref : int deref_fun ref
-  val do_app_deref : term list deref_fun ref
+  val do_uv_deref : int deref_uv_fun ref
+  val do_appuv_deref : term list deref_uv_fun ref
+  val do_arg_deref : int deref_arg_fun ref
+  val do_apparg_deref : term list deref_arg_fun ref
 
   (* To put it in the solution *)
   val uv_names : (string IntMap.t * int) Fork.local_ref
@@ -139,8 +143,10 @@ module Pp : sig
 
 end = struct (* {{{ *)
 
-let do_deref = ref (fun ?avoid ~from ~to_ _ _ -> assert false);;
-let do_app_deref = ref (fun ?avoid ~from ~to_ _ _ -> assert false);;
+let do_uv_deref = ref (fun ?avoid ~to_ _ _ -> assert false);;
+let do_appuv_deref = ref (fun ?avoid ~to_ _ _ -> assert false);;
+let do_arg_deref = ref (fun ?avoid ~from ~to_ _ _ -> assert false);;
+let do_apparg_deref = ref (fun ?avoid ~from ~to_ _ _ -> assert false);;
 
 let uv_names = Fork.new_local (IntMap.empty, 0)
 
@@ -168,13 +174,14 @@ let xppterm ~nice ?(pp_ctx = { Data.uv_names; table = ! C.table }) ?(min_prec=mi
       pp_ctx.uv_names := (m,n);
       s in
   let rec pp_uvar prec depth vardepth args f r =
+   (* for printing purposes it could be that vardepth != r.vardepth *)
    if !!r == C.dummy then begin
     let s = string_of_uvar_body r in
      Fmt.fprintf f "%s%s%s" s
       (if vardepth=0 then "" else "^" ^ string_of_int vardepth)
       (if args=0 then "" else "+" ^ string_of_int args)
    end else if nice then begin
-    aux prec depth f (!do_deref ~from:vardepth ~to_:depth args !!r)
+    aux prec depth f (!do_uv_deref ~to_:depth r args)
    end else Fmt.fprintf f "<%s|%a>_%d" (string_of_uvar_body r) (aux min_prec vardepth) !!r vardepth
   and pp_arg prec depth f n =
    let name= try List.nth names n with Failure _ -> "A" ^ string_of_int n in
@@ -182,7 +189,7 @@ let xppterm ~nice ?(pp_ctx = { Data.uv_names; table = ! C.table }) ?(min_prec=mi
     Fmt.fprintf f "%s" name
    else if nice then begin
     if argsdepth <= depth then
-     let dereffed = !do_deref ~from:argsdepth ~to_:depth 0 env.(n) in
+     let dereffed = !do_arg_deref ~from:argsdepth ~to_:depth env.(n) 0 in
      aux prec depth f dereffed
     else
      (* The instantiated Args live at an higher depth, and that's ok.
@@ -225,31 +232,31 @@ let xppterm ~nice ?(pp_ctx = { Data.uv_names; table = ! C.table }) ?(min_prec=mi
 
   (* ::(a, ::(b, nil))  -->  [a,b] *)
   and flat_cons_to_list depth acc t = match t with
-      UVar (r,vardepth,terms) when !!r != C.dummy ->
+      UVar (r,terms) when !!r != C.dummy ->
        flat_cons_to_list depth acc
-        (!do_deref ~from:vardepth ~to_:depth terms !!r)
-    | AppUVar (r,vardepth,terms) when !!r != C.dummy ->
+        (!do_uv_deref ~to_:depth r terms)
+    | AppUVar (r,terms) when !!r != C.dummy ->
        flat_cons_to_list depth acc
-        (!do_app_deref ~from:vardepth ~to_:depth terms !!r)
+        (!do_appuv_deref ~to_:depth r terms)
     | Cons (x,y) -> flat_cons_to_list depth (x::acc) y
     | _ -> List.rev acc, t
   and is_lambda depth =
    function
       Lam _ -> true
-    | UVar (r,vardepth,terms) when !!r != C.dummy ->
-       is_lambda depth (!do_deref ~from:vardepth ~to_:depth terms !!r)
-    | AppUVar (r,vardepth,terms) when !!r != C.dummy ->
-       is_lambda depth (!do_app_deref ~from:vardepth ~to_:depth terms !!r)
+    | UVar (r,terms) when !!r != C.dummy ->
+       is_lambda depth (!do_uv_deref ~to_:depth r terms)
+    | AppUVar (r,terms) when !!r != C.dummy ->
+       is_lambda depth (!do_appuv_deref ~to_:depth r terms)
     | _ -> false
   and aux_last prec depth f t =
    if nice then begin
    match t with
      Lam _ -> aux min_prec depth f t
-   | UVar (r,vardepth,terms) when !!r != C.dummy ->
-      aux_last prec depth f (!do_deref ~from:vardepth ~to_:depth terms !!r)
-   | AppUVar (r,vardepth,terms) when !!r != C.dummy ->
+   | UVar (r,terms) when !!r != C.dummy ->
+      aux_last prec depth f (!do_uv_deref ~to_:depth r terms)
+   | AppUVar (r,terms) when !!r != C.dummy ->
       aux_last prec depth f
-       (!do_app_deref ~from:vardepth ~to_:depth terms !!r)
+       (!do_appuv_deref ~to_:depth r terms)
    | _ -> aux prec depth f t
    end else aux inf_prec depth f t
   and aux prec depth f t =
@@ -301,26 +308,26 @@ let xppterm ~nice ?(pp_ctx = { Data.uv_names; table = ! C.table }) ?(min_prec=mi
         with_parens prec hdlvl (fun _ ->
           pp_app f ppbuiltin (aux inf_prec depth)
                 ~pplastarg:(aux_last inf_prec depth) (b,x::xs)))
-    | UVar (r,vardepth,argsno) when not nice ->
-       let args = List.map destConst (C.mkinterval vardepth argsno 0) in
+    | UVar (r,argsno) when not nice ->
+       let args = List.map destConst (C.mkinterval r.vardepth argsno 0) in
        with_parens prec  ~test:(args <> []) appl_prec (fun _ ->
         Fmt.fprintf f "." ;
-        pp_app f (pp_uvar inf_prec depth vardepth 0) ppconstant (r,args))
-    | UVar (r,vardepth,argsno) when !!r == C.dummy ->
-       let diff = vardepth - depth0 in
+        pp_app f (pp_uvar inf_prec depth r.vardepth 0) ppconstant (r,args))
+    | UVar (r,argsno) when !!r == C.dummy ->
+       let diff = r.vardepth - depth0 in
        let diff = if diff >= 0 then diff else 0 in
-       let vardepth = vardepth - diff in
+       let vardepth = r.vardepth - diff in
        let argsno = argsno + diff in
        let args = List.map destConst (C.mkinterval vardepth argsno 0) in
        with_parens prec ~test:(args <> []) appl_prec (fun _ ->
         pp_app f (pp_uvar inf_prec depth vardepth 0) ppconstant (r,args))
-    | UVar (r,vardepth,argsno) ->
-       pp_uvar prec depth vardepth argsno f r
-    | AppUVar (r,vardepth,terms) when !!r != C.dummy && nice ->
-       aux prec depth f (!do_app_deref ~from:vardepth ~to_:depth terms !!r)
-    | AppUVar (r,vardepth,terms) -> 
+    | UVar (r,argsno) ->
+       pp_uvar prec depth r.vardepth argsno f r
+    | AppUVar (r,terms) when !!r != C.dummy && nice ->
+       aux prec depth f (!do_appuv_deref ~to_:depth r terms)
+    | AppUVar (r,terms) -> 
        with_parens prec appl_prec (fun _ ->
-        pp_app f (pp_uvar inf_prec depth vardepth 0) (aux inf_prec depth)
+        pp_app f (pp_uvar inf_prec depth r.vardepth 0) (aux inf_prec depth)
          ~pplastarg:(aux_last inf_prec depth) (r,terms))
     | Arg (n,argsno) ->
        let args = List.map destConst (C.mkinterval argsdepth argsno 0) in
@@ -603,7 +610,7 @@ let print1 ?pp_ctx fmt x =
     pp_hyps pdiff
     (pp_goal depth) g
     (pplist (uppterm ?pp_ctx 0 [] ~argsdepth:0 empty_env) ", ")
-      (List.map (fun r -> UVar(r,0,0)) blockers)
+      (List.map (fun r -> UVar(r,0)) blockers)
 
 let print_gid fmt x =
   let { cgid  = gid [@trace]; cdepth = _ }, _ = x in
@@ -620,7 +627,7 @@ let pp_stuck_goal ?pp_ctx fmt { kind; blockers } = match kind with
         ad (uppterm ?pp_ctx ad [] ~argsdepth:0 empty_env) a
         bd (uppterm ?pp_ctx ad [] ~argsdepth:ad e) b
           (pplist ~boxed:false (uppterm ?pp_ctx 0 [] ~argsdepth:0 empty_env) ", ")
-            (List.map (fun r -> UVar(r,0,0)) blockers)
+            (List.map (fun r -> UVar(r,0)) blockers)
    | Constraint c -> print ?pp_ctx fmt [c,blockers]
    | _ -> assert false
 
@@ -672,10 +679,12 @@ module HO : sig
   (* simultaneous substitution *)
   val subst : int -> term list -> term -> term
 
-  val deref_uv : int deref_fun
-  val deref_appuv : term list deref_fun
+  val deref_uv : int deref_uv_fun
+  val deref_appuv : term list deref_uv_fun
+  val deref_arg : int deref_arg_fun
+  val deref_apparg : term list deref_arg_fun
 
-  val mkAppUVar : uvar_body -> int -> term list -> term
+  val mkAppUVar : uvar_body -> term list -> term
   val mkAppArg : int -> int -> term list -> term
   val is_flex : depth:int -> term -> uvar_body option
   val list_to_lp_list : term list -> term
@@ -693,11 +702,11 @@ module HO : sig
   (* Put a flexible term in canonical expanded form: X^0 args.
    * It returns the canonical term and an assignment if needed.
    * (The first term is the result of dereferencing after the assignment) *)
-  type assignment = uvar_body * int * term
+  type assignment = uvar_body * term
   val expand_uv :
-    depth:int -> uvar_body -> lvl:int -> ano:int -> term * assignment option
+    depth:int -> uvar_body -> ano:int -> term * assignment option
   val expand_appuv :
-    depth:int -> uvar_body -> lvl:int -> args:term list -> term * assignment option
+    depth:int -> uvar_body -> args:term list -> term * assignment option
 
   val shift_bound_vars : depth:int -> to_:int -> term -> term
 
@@ -718,7 +727,7 @@ let rec in_fragment expected =
  function
    [] -> 0
  | Const c::tl when c = expected -> 1 + in_fragment (expected+1) tl
- | UVar ({ contents = t} ,_,_)::tl -> (* XXX *)
+ | UVar ({ contents = t} ,_)::tl -> (* XXX *)
     in_fragment expected (t :: tl)
 (* Invariant not true anymore, since we may not deref aggressively
    to avoid occur-check
@@ -737,10 +746,10 @@ let deterministic_restriction e ~args_safe t =
   | App (_,t,l) -> aux t; List.iter aux l
   | Cons (x,xs) -> aux x; aux xs
   | Builtin (_,l) -> List.iter aux l
-  | UVar (r,_,_) 
-  | AppUVar (r,_,_) when !!r == C.dummy -> raise NonMetaClosed
-  | UVar (r,_,_) -> aux !!r
-  | AppUVar (r,_,l) -> aux !!r ; List.iter aux l
+  | UVar (r,_) 
+  | AppUVar (r,_) when !!r == C.dummy -> raise NonMetaClosed
+  | UVar (r,_) -> aux !!r
+  | AppUVar (r,l) -> aux !!r ; List.iter aux l
   | Arg (i,_) when e.(i) == C.dummy && not args_safe -> raise NonMetaClosed
   | AppArg (i,_) when e.(i) == C.dummy -> raise NonMetaClosed
   | Arg (i,_) -> if e.(i) != C.dummy then aux e.(i)
@@ -772,61 +781,63 @@ let occurr_check r1 r2 =
 
 let rec make_lambdas destdepth args =
  if args <= 0 then
-    UVar(oref C.dummy,destdepth,0)
+    UVar(oref ~depth:destdepth C.dummy,0)
  else
    Lam (make_lambdas (destdepth+1) (args-1))
 
 let rec mknLam n x = if n = 0 then x else Lam (mknLam (n-1) x)
 
-let mkAppUVar r lvl l =
-  try UVar(r,lvl,in_fragment lvl l)
-  with NotInTheFragment -> AppUVar(r,lvl,l)
+let mkAppUVar r l =
+  try UVar(r,in_fragment r.vardepth l)
+  with NotInTheFragment -> AppUVar(r,l)
 
 let mkAppArg i fromdepth xxs' =
   try Arg(i,in_fragment fromdepth xxs')
   with NotInTheFragment -> AppArg (i,xxs')
 
-let expand_uv r ~lvl ~ano =
+let expand_uv (r : uvar_body) ~ano =
+  let lvl = r.vardepth in
   let args = C.mkinterval 0 (lvl+ano) 0 in
-  if lvl = 0 then AppUVar(r,lvl,args), None else
-  let r1 = oref C.dummy in
-  let t = AppUVar(r1,0,args) in
+  if lvl = 0 then AppUVar(r,args), None else
+  let r1 = oref ~depth:0 C.dummy in
+  let t = AppUVar(r1,args) in
   let assignment = mknLam ano t in
-  t, Some (r,lvl,assignment)
-let expand_uv ~depth r ~lvl ~ano =
-  [%spy "dev:expand_uv:in" ~rid (uppterm depth [] ~argsdepth:0 empty_env) (UVar(r,lvl,ano))];
-  let t, ass as rc = expand_uv r ~lvl ~ano in
+  t, Some (r,assignment)
+let expand_uv ~depth (r : uvar_body) ~ano =
+  [%spy "dev:expand_uv:in" ~rid (uppterm depth [] ~argsdepth:0 empty_env) (UVar(r,ano))];
+  let t, ass as rc = expand_uv r ~ano in
   [%spy "dev:expand_uv:out" ~rid (uppterm depth [] ~argsdepth:0 empty_env) t (fun fmt -> function
     | None -> Fmt.fprintf fmt "no assignment"
-    | Some (_,_,t) ->
+    | Some (_,t) ->
         Fmt.fprintf fmt "%a := %a"
-          (uppterm depth [] ~argsdepth:0 empty_env) (UVar(r,lvl,ano))
-          (uppterm lvl [] ~argsdepth:0 empty_env) t) ass];
+          (uppterm depth [] ~argsdepth:0 empty_env) (UVar(r,ano))
+          (uppterm r.vardepth [] ~argsdepth:0 empty_env) t) ass];
   rc
 
-let expand_appuv r ~lvl ~args =
-  if lvl = 0 then AppUVar(r,lvl,args), None else
+let expand_appuv (r : uvar_body) ~args =
+  let lvl = r.vardepth in
+  if lvl = 0 then AppUVar(r,args), None else
   let args_lvl = C.mkinterval 0 lvl 0 in
-  let r1 = oref C.dummy in
-  let t = AppUVar(r1,0,args_lvl @ args) in
+  let r1 = oref ~depth:0 C.dummy in
+  let t = AppUVar(r1,args_lvl @ args) in
   let nargs = List.length args in
   let assignment =
-    mknLam nargs (AppUVar(r1,0,args_lvl @ C.mkinterval lvl nargs 0)) in
-  t, Some (r,lvl,assignment)
-let expand_appuv ~depth r ~lvl ~args =
-  [%spy "dev:expand_appuv:in" ~rid (uppterm depth [] ~argsdepth:0 empty_env) (AppUVar(r,lvl,args))];
-  let t, ass as rc = expand_appuv r ~lvl ~args in
+    mknLam nargs (AppUVar(r1,args_lvl @ C.mkinterval lvl nargs 0)) in
+  t, Some (r,assignment)
+let expand_appuv ~depth (r : uvar_body) ~args =
+  [%spy "dev:expand_appuv:in" ~rid (uppterm depth [] ~argsdepth:0 empty_env) (AppUVar(r,args))];
+  let t, ass as rc = expand_appuv r ~args in
   [%spy "dev:expand_appuv:out" ~rid (uppterm depth [] ~argsdepth:0 empty_env) t (fun fmt -> function
     | None -> Fmt.fprintf fmt "no assignment"
-    | Some (_,_,t) ->
+    | Some (_,t) ->
         Fmt.fprintf fmt "%a := %a"
-          (uppterm depth [] ~argsdepth:0 empty_env) (AppUVar(r,lvl,args))
-          (uppterm lvl [] ~argsdepth:0 empty_env) t) ass];
+          (uppterm depth [] ~argsdepth:0 empty_env) (AppUVar(r,args))
+          (uppterm r.vardepth [] ~argsdepth:0 empty_env) t) ass];
   rc
 
 let deoptimize_uv_w_args = function
-  | UVar(r,lvl,args) when args > 0 ->
-      AppUVar(r,lvl,C.mkinterval lvl args 0)
+  | UVar(r,args) when args > 0 ->
+      AppUVar(r,C.mkinterval r.vardepth args 0)
   | x -> x
 
 
@@ -964,43 +975,43 @@ let rec move ~argsdepth (e:env) ?avoid ~from ~to_ t =
     | Nil -> x
     | Discard when avoid = None -> x
     | Discard ->
-       let r = oref C.dummy in
-       UVar(r,to_,0)
+       let r = oref ~depth:to_ C.dummy in
+       UVar(r,0)
 
     (* fast path with no deref... *)
     | UVar _ when delta == 0 && avoid == None -> x
 
     (* deref *)
-    | UVar ({ contents = t }, vardepth, args) when t != C.dummy ->
-       if depth == 0 then deref_uv ?avoid ~from:vardepth ~to_ args t
-       else maux empty_env depth (deref_uv ~from:vardepth ~to_:(from+depth) args t)
-    | AppUVar ({ contents = t }, vardepth, args) when t != C.dummy ->
+    | UVar ({ contents = t } as r, args) when t != C.dummy ->
+       if depth == 0 then deref_uv ?avoid ~to_ r args
+       else maux empty_env depth (deref_uv ~to_:(from+depth) r args)
+    | AppUVar ({ contents = t } as r, args) when t != C.dummy ->
        (* wrong, args escape occur check: if depth == 0 then deref_appuv ?avoid ~from:vardepth ~to_ args t
-       else *) maux empty_env depth (deref_appuv ~from:vardepth ~to_:(from+depth) args t)
+       else *) maux empty_env depth (deref_appuv ~to_:(from+depth) r args)
     | Arg (i, argsno) when e.(i) != C.dummy ->
-       if to_ = argsdepth then deref_uv ?avoid ~from:argsdepth ~to_:(to_+depth) argsno e.(i)
+       if to_ = argsdepth then deref_arg ?avoid ~from:argsdepth ~to_:(to_+depth) e.(i) argsno 
        else
         let args = C.mkinterval from argsno 0 in
         let args =
         try smart_map3 maux e depth args
         with RestrictionFailure ->
           anomaly "move: could check if unrestrictable args are unused" in
-       deref_appuv ?avoid ~from:argsdepth ~to_:(to_+depth) args e.(i)
+       deref_apparg ?avoid ~from:argsdepth ~to_:(to_+depth) e.(i) args
 
     | AppArg(i, args) when e.(i) != C.dummy ->
        let args =
         try smart_map3 maux e depth args
         with RestrictionFailure ->
           anomaly "move: could check if unrestrictable args are unused" in
-       deref_appuv ?avoid ~from:argsdepth ~to_:(to_+depth) args e.(i)
+       deref_apparg ?avoid ~from:argsdepth ~to_:(to_+depth) e.(i) args
 
     (* heapification/restriction of Arg and AppArg *)
     | Arg (i, args) ->
        let to_ = min argsdepth to_ in
-       let r = oref C.dummy in
-       let v = UVar(r,to_,0) in
+       let r = oref ~depth:to_ C.dummy in
+       let v = UVar(r,0) in
        e.(i) <- v;
-       if args == 0 then v else UVar(r,to_,args)
+       if args == 0 then v else UVar(r,args)
     | AppArg(i, args) when
       List.for_all (deterministic_restriction e ~args_safe:(argsdepth=to_)) args
       ->
@@ -1009,10 +1020,10 @@ let rec move ~argsdepth (e:env) ?avoid ~from ~to_ t =
         try smart_map (maux e depth) args
         with RestrictionFailure ->
          anomaly "TODO: implement deterministic restriction" in
-       let r = oref C.dummy in
-       let v = UVar(r,to_,0) in
+       let r = oref ~depth:to_ C.dummy in
+       let v = UVar(r,0) in
        e.(i) <- v;
-       mkAppUVar r to_ args
+       mkAppUVar r args
     | AppArg _ ->
        Fmt.fprintf Fmt.str_formatter
         "Non deterministic pruning, delay to be implemented: t=%a, delta=%d%!"
@@ -1020,7 +1031,8 @@ let rec move ~argsdepth (e:env) ?avoid ~from ~to_ t =
        anomaly (Fmt.flush_str_formatter ())
 
     (* restriction/lifting of UVar *)
-    | UVar (r,vardepth,argsno) ->
+    | UVar (r,argsno) ->
+       let vardepth = r.vardepth in
        occurr_check avoid r;
        if delta <= 0 then (* to_ >= from *)
          if vardepth + argsno <= from then x
@@ -1029,19 +1041,20 @@ let rec move ~argsdepth (e:env) ?avoid ~from ~to_ t =
              decrease_depth r ~from:vardepth ~to_:from argsno in
            let args = C.mkinterval vardepth argsno 0 in
            let args = smart_map (maux empty_env depth) args in
-           mkAppUVar r vardepth args
+           mkAppUVar r args
        else
          if vardepth + argsno <= to_ then x
          else
-           let t, assignment = expand_uv ~depth:(from+depth) r ~lvl:vardepth ~ano:argsno in
-           option_iter (fun (r,_,assignment) ->
+           let t, assignment = expand_uv ~depth:(from+depth) r ~ano:argsno in
+           option_iter (fun (r,assignment) ->
               [%spy "user:assign:expand" ~rid (fun fmt () -> Fmt.fprintf fmt "%a := %a"
                (uppterm (from+depth) [] ~argsdepth e) x
                (uppterm vardepth [] ~argsdepth e) assignment) ()];
               r @:= assignment) assignment;
            maux e depth t
 
-    | AppUVar (r,vardepth,args) ->
+    | AppUVar (r,args) ->
+       let vardepth = r.vardepth in
        occurr_check avoid r;
        if delta < 0 then
          let r,vardepth,argsno =
@@ -1050,9 +1063,9 @@ let rec move ~argsdepth (e:env) ?avoid ~from ~to_ t =
          let args =
           try smart_map (maux e depth) (args0@args)
           with RestrictionFailure -> anomaly "impossible, delta < 0" in
-         mkAppUVar r vardepth args
+         mkAppUVar r args
        else if delta == 0 then
-         AppUVar (r,vardepth,smart_map (maux e depth) args)
+         AppUVar (r,smart_map (maux e depth) args)
        else if List.for_all (deterministic_restriction e ~args_safe:(argsdepth=to_)) args then
           (* Code for deterministic restriction *)
 
@@ -1074,16 +1087,16 @@ let rec move ~argsdepth (e:env) ?avoid ~from ~to_ t =
 
           if !pruned then begin
             let vardepth' = min vardepth to_ in
-            let r' = oref C.dummy in
-            let newvar = mkAppUVar r' vardepth' !filteredargs_vardepth in
+            let r' = oref ~depth:vardepth' C.dummy in
+            let newvar = mkAppUVar r' !filteredargs_vardepth in
             let assignment = mknLam orig_argsno newvar in
             [%spy "user:assign:restrict" ~rid (fun fmt () -> Fmt.fprintf fmt "%d %a := %a" vardepth
                (ppterm (from+depth) [] ~argsdepth e) x
                (ppterm (vardepth) [] ~argsdepth e) assignment) ()];
             r @:= assignment;
-            mkAppUVar r' vardepth' filteredargs_to
+            mkAppUVar r' filteredargs_to
           end else
-            mkAppUVar r vardepth filteredargs_to
+            mkAppUVar r filteredargs_to
 
        else begin
         Fmt.fprintf Fmt.str_formatter
@@ -1110,9 +1123,9 @@ and hmove ?avoid ~from ~to_ t =
 and decrease_depth r ~from ~to_ argsno =
  if from <= to_ then r,from,argsno
  else
-  let newr = oref C.dummy in
+  let newr = oref ~depth:to_ C.dummy in
   let newargsno = argsno+from-to_ in
-  let newvar = UVar(newr,to_,from-to_) in
+  let newvar = UVar(newr,from-to_) in
   r @:= newvar;
   newr,to_,newargsno
 
@@ -1162,24 +1175,26 @@ and subst fromdepth ts t =
        if hd == hd' && tl == tl' then orig else Cons(hd',tl')
    | Nil -> tt
    | Discard -> tt
-   | UVar({contents=g},vardepth,argsno) when g != C.dummy ->
-      [%tcall aux depth (deref_uv ~from:vardepth ~to_:depth argsno g)]
-   | UVar(r,vardepth,argsno) as orig ->
+   | UVar({contents = g } as r,argsno) when g != C.dummy ->
+      [%tcall aux depth (deref_uv ~to_:depth r argsno)]
+   | UVar(r,argsno) as orig ->
+      let vardepth = r.vardepth in
       if vardepth+argsno <= fromdepth then orig
       else
        let r,vardepth,argsno =
          decrease_depth r ~from:vardepth ~to_:fromdepth argsno in
        let args = C.mkinterval vardepth argsno 0 in
        let args = smart_map (aux depth) args in
-       mkAppUVar r vardepth args
-   | AppUVar({ contents = t },vardepth,args) when t != C.dummy ->
-      [%tcall aux depth (deref_appuv ~from:vardepth ~to_:depth args t)]
-   | AppUVar(r,vardepth,args) ->
+       mkAppUVar r args
+   | AppUVar({ contents = t } as r,args) when t != C.dummy ->
+      [%tcall aux depth (deref_appuv ~to_:depth r args)]
+   | AppUVar(r,args) ->
+      let vardepth = r.vardepth in
       let r,vardepth,argsno =
         decrease_depth r ~from:vardepth ~to_:fromdepth 0 in
       let args0 = C.mkinterval vardepth argsno 0 in
       let args = smart_map (aux depth) (args0@args) in
-      mkAppUVar r vardepth args
+      mkAppUVar r args
    | Lam t -> Lam (aux (depth+1) t)
    | CData _ as x -> x
    end] in
@@ -1191,12 +1206,12 @@ and beta depth sub t args =
      (uppterm (depth+List.length sub) [] ~argsdepth:0 empty_env) t
      (pplist (uppterm depth [] ~argsdepth:0 empty_env) ", ") args)
  begin match t, args with
- | UVar ({contents=g},vardepth,argsno), _ when g != C.dummy ->
+ | UVar ({contents = g } as r,argsno), _ when g != C.dummy ->
     [%tcall beta depth sub
-        (deref_uv ~from:vardepth ~to_:(depth+List.length sub) argsno g) args]
- | AppUVar({ contents=g },vardepth,uargs), _ when g != C.dummy ->
+        (deref_uv ~to_:(depth+List.length sub) r argsno) args]
+ | AppUVar({ contents = g } as r,uargs), _ when g != C.dummy ->
     [%tcall beta depth sub
-         (deref_appuv ~from:vardepth ~to_:(depth+List.length sub) uargs g) args]
+         (deref_appuv ~to_:(depth+List.length sub) r uargs) args]
  | Lam t', hd::tl -> [%tcall beta depth (hd::sub) t' tl]
  | _ ->
     let t' = subst depth sub t in
@@ -1210,12 +1225,13 @@ and beta depth sub t args =
          | AppArg _ -> anomaly "beta takes only heap terms"
          | App (c,arg,args1) -> App (c,arg,args1@args)
          | Builtin (c,args1) -> Builtin (c,args1@args)
-         | UVar (r,n,m) -> begin
-            try UVar(r,n,m + in_fragment (n+m) args)
+         | UVar (r,m) -> begin
+            let n = r.vardepth in
+            try UVar(r,m + in_fragment (n+m) args)
             with NotInTheFragment ->
               let args1 = C.mkinterval n m 0 in
-              AppUVar (r,n,args1@args) end
-         | AppUVar (r,depth,args1) -> AppUVar (r,depth,args1@args)
+              AppUVar (r,args1@args) end
+         | AppUVar (r,args1) -> AppUVar (r,args1@args)
          | Lam _ -> anomaly "beta: some args and some lambdas"
          | CData x -> type_error (Printf.sprintf "beta: '%s'" (CData.show x))
          | Nil -> type_error "beta: Nil"
@@ -1229,10 +1245,10 @@ and beta depth sub t args =
 and eat_args depth l t =
   match t with
   | Lam t' when l > 0 -> eat_args (depth+1) (l-1) t'
-  | UVar ({contents=t},origdepth,args) when t != C.dummy ->
-     eat_args depth l (deref_uv ~from:origdepth ~to_:depth args t)
-  | AppUVar  ({contents=t},origdepth,args) when t != C.dummy ->
-     eat_args depth l (deref_appuv ~from:origdepth ~to_:depth args t)
+  | UVar ({contents = t } as r,args) when t != C.dummy ->
+     eat_args depth l (deref_uv ~to_:depth r args)
+  | AppUVar  ({contents = t } as r,args) when t != C.dummy ->
+     eat_args depth l (deref_appuv ~to_:depth r args)
   | _ -> depth,l,t
 
 (* CSC: The following set of comments are to be revised. I found them scattered
@@ -1249,17 +1265,30 @@ and eat_args depth l t =
      when deref_uv is called inside restrict, it may be from > to_
      t lives in from; args already live in to_
 *)
-   
-and deref_appuv ?avoid ~from ~to_ args t =
-  beta to_ [] (deref_uv ?avoid ~from ~to_ 0 t) args
 
-and deref_uv ?avoid ~from ~to_ args t =
+and deref_uv ?avoid ~to_ (r : uvar_body) (args : int) : term =
+  let from = r.vardepth in
+  let t = !! r in
+  deref_arg ?avoid ~from ~to_ t args
+  [@@inline]
+
+and deref_appuv ?avoid ~to_ r args =
+  let from = r.vardepth in
+  let t = !! r in
+  beta to_ [] (deref_arg ?avoid ~from ~to_ t 0) args
+  [@@inline]
+
+and deref_apparg ?avoid ~from ~to_ t args =
+  beta to_ [] (deref_arg ?avoid ~from ~to_ t 0) args
+  [@@inline]
+
+and deref_arg ?avoid ~from ~to_ t args =
   [%trace "deref_uv" ~rid ("from:%d to:%d %a @@ %d"
       from to_ (ppterm from [] ~argsdepth:0 empty_env) t args) begin
  if args == 0 then hmove ?avoid ~from ~to_ t
  else (* O(1) reduction fragment tested here *)
    let from,args',t = eat_args from args t in
-   let t = deref_uv ?avoid ~from ~to_ 0 t in
+   let t = deref_arg ?avoid ~from ~to_ t 0 in
    if args' == 0 then t
    else
      match t with
@@ -1276,16 +1305,17 @@ and deref_uv ?avoid ~from ~to_ args t =
      (* TODO: when the UVar/Arg is not C.dummy, we call deref_uv that
         will call move that will call_deref_uv again. Optimize the
         path *)
-     | UVar(t,depth,0) when from = depth ->
-        UVar(t,depth,args')
-     | AppUVar (r,depth,args2) ->
+     | UVar(r,0) when from = r.vardepth ->
+        UVar(r,args')
+     | AppUVar (r,args2) ->
         let args = C.mkinterval from args' 0 in
-        AppUVar (r,depth,args2 @ args)
-     | UVar (r,vardepth,argsno) ->
+        AppUVar (r,args2 @ args)
+     | UVar (r,argsno) ->
+        let vardepth = r.vardepth in
         let args1 = C.mkinterval vardepth argsno 0 in
         let args2 = C.mkinterval from args' 0 in
         let args = args1 @ args2 in
-        mkAppUVar r vardepth args
+        mkAppUVar r args
      | Cons _ | Nil -> type_error "deref_uv: applied list"
      | Discard -> type_error "deref_uv: applied Discard"
      | CData _ -> t
@@ -1304,7 +1334,7 @@ let copy_heap_drop_csts ~depth ?keep_if_outside x =
     with Not_found ->
       if keep_if_outside <> None then r
       else
-        let r' = oref C.dummy in
+        let r' = oref ~depth:r.vardepth C.dummy in
         m := IntMap.add (uvar_id r) r' !m;
         r' in
   let alloc_copy r =
@@ -1330,21 +1360,21 @@ let copy_heap_drop_csts ~depth ?keep_if_outside x =
      if hd == hd' && tl == tl' then x else Cons(hd',tl')
   | Nil -> x
   | Discard ->
-     let r = oref C.dummy in
-     UVar(r,depth,0)
+     let r = oref ~depth C.dummy in
+     UVar(r,0)
   (* deref *)
-  | UVar ({ contents = t }, vardepth, args) when t != C.dummy ->
-     maux depth (deref_uv ~from:vardepth ~to_:depth args t)
-  | AppUVar ({ contents = t }, vardepth, args) when t != C.dummy ->
-     maux depth (deref_appuv ~from:vardepth ~to_:depth args t)
+  | UVar ({ contents = t } as r, args) when t != C.dummy ->
+     maux depth (deref_uv ~to_:depth r args)
+  | AppUVar ({ contents = t } as r, args) when t != C.dummy ->
+     maux depth (deref_appuv ~to_:depth r args)
   | Arg _
   | AppArg _ -> anomaly "not a heap term"
-  | UVar (r,vardepth,argsno) ->
+  | UVar (r,argsno) ->
      let r' = alloc_copy r in
-     UVar (r',vardepth,argsno)
-  | AppUVar (r,vardepth,args) ->
+     UVar (r',argsno)
+  | AppUVar (r,args) ->
      let r' = alloc_copy r in
-     AppUVar (r',vardepth,smart_map2 maux depth args)
+     AppUVar (r',smart_map2 maux depth args)
     in
     let x' = maux depth x in
     (* Format.eprintf "copy %a -> %a\n%!" (uppterm depth [] ~argsdepth:0 empty_env) x (uppterm depth [] ~argsdepth:0 empty_env) x'; *)
@@ -1358,11 +1388,11 @@ let copy_heap_drop_csts ~depth ?keep_if_outside x =
 let rec is_flex ~depth =
  function
   | Arg _ | AppArg _ -> anomaly "is_flex called on Args"
-  | UVar ({ contents = t }, vardepth, args) when t != C.dummy ->
-     is_flex ~depth (deref_uv ~from:vardepth ~to_:depth args t)
-  | AppUVar ({ contents = t }, vardepth, args) when t != C.dummy ->
-     is_flex ~depth (deref_appuv ~from:vardepth ~to_:depth args t)
-  | UVar (r, _, _) | AppUVar (r, _, _) -> Some r
+  | UVar ({ contents = t } as r, args) when t != C.dummy ->
+     is_flex ~depth (deref_uv ~to_:depth r args)
+  | AppUVar ({ contents = t } as r, args) when t != C.dummy ->
+     is_flex ~depth (deref_appuv ~to_:depth r args)
+  | UVar (r, _) | AppUVar (r, _) -> Some r
   | Const _ | Lam _ | App _ | Builtin _ | CData _ | Cons _ | Nil | Discard -> None
 
 (* Invariants:                                          |
@@ -1400,14 +1430,14 @@ let is_llam lvl args adepth bdepth depth left e =
   let to_ = if left then adepth+depth else bdepth+depth in
   let get_con = function Const x -> x | _ -> raise RestrictionFailure in
   let deref_to_const = function
-    | UVar ({ contents = t }, from, args) when t != C.dummy ->
-        get_con (deref_uv ~from ~to_ args t)
-    | AppUVar ({ contents = t }, from, args) when t != C.dummy ->
-        get_con (deref_appuv ~from ~to_ args t)
+    | UVar ({ contents = t } as r, args) when t != C.dummy ->
+        get_con (deref_uv ~to_ r args)
+    | AppUVar ({ contents = t } as r, args) when t != C.dummy ->
+        get_con (deref_appuv ~to_ r args)
     | Arg (i,args) when e.(i) != C.dummy ->
-        get_con (deref_uv ~from:adepth ~to_ args e.(i))
+        get_con (deref_arg ~from:adepth ~to_ e.(i) args)
     | AppArg (i,args) when e.(i) != C.dummy ->
-        get_con (deref_appuv ~from:adepth ~to_ args e.(i))
+        get_con (deref_apparg ~from:adepth ~to_ e.(i) args )
     | Const x -> if not left && x >= bdepth then x + (adepth-bdepth) else x
     | _ -> raise RestrictionFailure
   in
@@ -1439,7 +1469,8 @@ let rec mknLam n t = if n = 0 then t else mknLam (n-1) (Lam t)
  * left is true when the variable being assigned is on the left (goal)
  * t is the term we are assigning to r
  * e is the env for args *)
-let bind ~argsdepth r gamma l a d delta b left t e =
+let bind ~argsdepth r l a d delta b left t e =
+  let gamma = r.vardepth in
   let new_lams = List.length l in
   let pos x = try List.assoc x l with Not_found -> raise RestrictionFailure in
   (* hmove = false makes the code insensitive to left/right, i.e. no hmove from b
@@ -1468,7 +1499,7 @@ let bind ~argsdepth r gamma l a d delta b left t e =
         (ppterm a [] ~argsdepth e) (mkConst x) n) " ") l
         (ppterm a [] ~argsdepth empty_env) t a delta d w b) begin
     match t with
-    | UVar (r1,_,_) | AppUVar (r1,_,_) when r == r1 -> raise RestrictionFailure
+    | UVar (r1,_) | AppUVar (r1,_) when r == r1 -> raise RestrictionFailure
     | Const c -> let n = cst c b delta in if n < 0 then mkConst n else Const n
     | Lam t -> Lam (bind b delta (w+1) t)
     | App (c,t,ts) -> App (cst c b delta, bind b delta w t, smart_map (bind b delta w) ts)
@@ -1478,48 +1509,49 @@ let bind ~argsdepth r gamma l a d delta b left t e =
     | CData _ -> t
     (* deref_uv *)
     | Arg (i,args) when e.(i) != C.dummy ->
-        bind a 0 w (deref_uv ~from:argsdepth ~to_:(a+d+w) args e.(i))
+        bind a 0 w (deref_arg ~from:argsdepth ~to_:(a+d+w) e.(i) args)
     | AppArg (i,args) when e.(i) != C.dummy ->
-        bind a 0 w (deref_appuv ~from:argsdepth ~to_:(a+d+w) args e.(i))
-    | UVar ({ contents = t }, from, args) when t != C.dummy ->
-        bind b delta w (deref_uv ~from ~to_:((if left then b else a)+d+w) args t)
-    | AppUVar ({ contents = t }, from, args) when t != C.dummy ->
-        bind b delta w (deref_appuv ~from ~to_:((if left then b else a)+d+w) args t)
+        bind a 0 w (deref_apparg ~from:argsdepth ~to_:(a+d+w) e.(i) args)
+    | UVar ({ contents = t } as r, args) when t != C.dummy ->
+        bind b delta w (deref_uv ~to_:((if left then b else a)+d+w) r args)
+    | AppUVar ({ contents = t } as r, args) when t != C.dummy ->
+        bind b delta w (deref_appuv ~to_:((if left then b else a)+d+w) r args)
     (* pruning *)
     | (UVar _ | AppUVar _ | Arg _ | AppArg _ | Discard) as orig ->
         (* We deal with all flexible terms in a uniform way *)
-        let r, lvl, (is_llam, args), orig_args = match orig with
-          | UVar(r,lvl,0) -> r, lvl, (true, []), []
-          | UVar(r,lvl,args) ->
-              let r' = oref C.dummy in
-              let v = UVar(r',lvl+args,0) in
+        let r, (is_llam, args), orig_args = match orig with
+          | UVar(r,0) -> r, (true, []), []
+          | UVar(r,args) ->
+              let r' = oref ~depth:(r.vardepth+args) C.dummy in
+              let v = UVar(r',0) in
               r @:= mknLam args v;
-              r', (lvl+args),  (true,[]), []
-          | AppUVar (r,lvl, orig_args) ->
-              r, lvl, is_llam lvl orig_args a b (d+w) left e, orig_args
+              r', (true,[]), []
+          | AppUVar (r, orig_args) ->
+              r, is_llam r.vardepth orig_args a b (d+w) left e, orig_args
           | Discard ->
-              let r = oref C.dummy in
-              r, a+d+w, (true,[]), []
+              let r = oref ~depth:(a+d+w) C.dummy in
+              r, (true,[]), []
           | Arg (i,0) ->
-              let r = oref C.dummy in
-              let v = UVar(r,a,0) in
+              let r = oref ~depth:a C.dummy in
+              let v = UVar(r,0) in
               e.(i) <- v;
-              r, a, (true,[]), []
+              r, (true,[]), []
           | Arg (i,args) ->
-              let r = oref C.dummy in
-              let v = UVar(r,a,0) in
+              let r = oref ~depth:a C.dummy in
+              let v = UVar(r,0) in
               e.(i) <- v;
-              let r' = oref C.dummy in
-              let v' = UVar(r',a+args,0) in
+              let r' = oref ~depth:(a+args) C.dummy in
+              let v' = UVar(r',0) in
               r @:= mknLam args v';
-              r', a+args, (true, []), []
+              r', (true, []), []
           | AppArg (i,orig_args) ->
               let is_llam, args = is_llam a orig_args a b (d+w) false e in
-              let r = oref C.dummy in
-              let v = UVar(r,a,0) in
+              let r = oref ~depth:a C.dummy in
+              let v = UVar(r,0) in
               e.(i) <- v;
-              r, a, (is_llam, args), orig_args
+              r, (is_llam, args), orig_args
           | _ -> assert false in
+        let lvl = r.vardepth in
         [%spy "dev:bind:maybe-prune" ~rid (fun fmt () ->
            Fmt.fprintf fmt "lvl:%d is_llam:%b args:%a orig_args:%a orig:%a"
              lvl is_llam
@@ -1556,9 +1588,9 @@ let bind ~argsdepth r gamma l a d delta b left t e =
                        (mkConst (lvl+nn), mkConst mm) :: keep_cst_for_lvl rest
                       with Not_found -> keep_cst_for_lvl rest) in
               List.split (keep_cst_for_lvl (List.sort Stdlib.compare l)) in
-            let r' = oref C.dummy in
-            r @:= mknLam n_args (mkAppUVar r' gamma args_gamma_lvl_abs);
-            mkAppUVar r' gamma args_gamma_lvl_here
+            let r' = oref ~depth:gamma C.dummy in
+            r @:= mknLam n_args (mkAppUVar r' args_gamma_lvl_abs);
+            mkAppUVar r' args_gamma_lvl_here
           else
             (* given that we need to make lambdas to prune some args,
              * we also permute to make the restricted meta eventually
@@ -1576,22 +1608,22 @@ let bind ~argsdepth r gamma l a d delta b left t e =
                 with RestrictionFailure -> acc) args ([],[]) in
             if n_args = List.length args_here then
               (* no pruning, just binding the args as a normal App *)
-              mkAppUVar r lvl (smart_map (bind b delta w) orig_args)
+              mkAppUVar r (smart_map (bind b delta w) orig_args)
             else
               (* we need to project away some of the args *)
-              let r' = oref C.dummy in
-              let v = mkAppUVar r' lvl args_lvl in
+              let r' = oref ~depth:lvl C.dummy in
+              let v = mkAppUVar r' args_lvl in
               r @:= mknLam n_args v;
               (* This should be the beta reduct. One could also
                * return the non reduced but bound as in the other if branch *)
-              mkAppUVar r' lvl args_here
+              mkAppUVar r' args_here
         end else begin
-          mkAppUVar r lvl (smart_map (bind b delta w) orig_args)
+          mkAppUVar r (smart_map (bind b delta w) orig_args)
         end
   end] in
     let v = mknLam new_lams (bind b delta 0 t) in
     [%spy "user:assign:HO" ~rid (fun fmt () -> Fmt.fprintf fmt "%a := %a"
-        (uppterm gamma [] ~argsdepth e) (UVar(r,gamma,0))
+        (uppterm gamma [] ~argsdepth e) (UVar(r,0))
         (uppterm gamma [] ~argsdepth e) v) ()];
     r @:= v;
     true
@@ -1614,12 +1646,12 @@ let error_msg_hard_unif a b =
   "(deprecated, for Teyjus compatibility)."
 
 let rec deref_head ~depth = function
-  | UVar ({ contents = t }, from, ano)
+  | UVar ({ contents = t } as r, ano)
     when t != C.dummy ->
-      deref_head ~depth (deref_uv ~from ~to_:depth ano t)
-  | AppUVar ({contents = t}, from, args)
+      deref_head ~depth (deref_uv ~to_:depth r ano)
+  | AppUVar ({contents = t } as r, args)
     when t != C.dummy ->
-      deref_head ~depth (deref_appuv ~from ~to_:depth args t)
+      deref_head ~depth (deref_appuv ~to_:depth r args)
   | x -> x
 
 (* constant x occurs in term t with level d? *)
@@ -1628,17 +1660,17 @@ let occurs x d adepth e t =
     | Const c -> c = x
     | Lam t -> aux (d+1) t
     | App (c, v, vs) -> c = x || aux d v || auxs d vs
-    | UVar (r, lvl, ano) ->
-       let t, assignment = expand_uv ~depth:d r ~lvl ~ano in
-       option_iter (fun (r,_,assignment) -> r @:= assignment) assignment;
+    | UVar (r, ano) ->
+       let t, assignment = expand_uv ~depth:d r ~ano in
+       option_iter (fun (r,assignment) -> r @:= assignment) assignment;
        aux d t
-    | AppUVar (_, _, args) -> auxs d args
+    | AppUVar (_, args) -> auxs d args
     | Builtin (_, vs) -> auxs d vs
     | Cons (v1, v2) -> aux d v1 || aux d v2
     | Arg(i,args) when e.(i) != C.dummy ->
-      aux d (deref_uv ~from:adepth ~to_:d args e.(i))
+      aux d (deref_arg ~from:adepth ~to_:d e.(i) args)
     | AppArg(i,args) when e.(i) != C.dummy ->
-      aux d (deref_appuv ~from:adepth ~to_:d args e.(i))
+      aux d (deref_apparg ~from:adepth ~to_:d e.(i) args)
     | Nil | CData _ | Discard | Arg _ | AppArg _ -> false
   and auxs d = function
     | [] -> false
@@ -1650,7 +1682,7 @@ let rec eta_contract_args ~orig_depth ~depth r args eat ~argsdepth e =
   match args, eat with
   | _, [] -> [%spy "eta_contract_flex" ~rid (fun fmt () -> Fmt.fprintf fmt "all eaten") ()];
       begin
-        try Some (AppUVar(r,0,smart_map (move ~argsdepth ~from:depth ~to_:orig_depth e) (List.rev args)))
+        try Some (AppUVar(r,smart_map (move ~argsdepth ~from:depth ~to_:orig_depth e) (List.rev args)))
         with RestrictionFailure -> None
       end
   | Const x::xs, y::ys when x == y && not (List.exists (occurs y depth argsdepth e) xs) ->
@@ -1666,37 +1698,37 @@ let rec eta_contract_flex orig_depth depth xdepth ~argsdepth e t eat =
   xdepth depth (ppterm (xdepth+depth) [] ~argsdepth e) t
   (pplist (fun fmt i -> Fmt.fprintf fmt "%d" i) " ") eat) begin
   match deref_head ~depth:(xdepth+depth) t with
-  | AppUVar(r,0,args) ->
+  | AppUVar(r,args) when r.vardepth == 0 ->
       eta_contract_args ~orig_depth:(xdepth+orig_depth) ~depth:(xdepth+depth) r (List.rev args) eat ~argsdepth e
   | Lam t -> eta_contract_flex orig_depth (depth+1) xdepth ~argsdepth e t (depth+xdepth::eat)
-  | UVar(r,lvl,ano) ->
-      let t, assignment = expand_uv ~depth r ~lvl ~ano in
-      option_iter (fun (r,_,assignment) -> r @:= assignment) assignment;
+  | UVar(r,ano) ->
+      let t, assignment = expand_uv ~depth r ~ano in
+      option_iter (fun (r,assignment) -> r @:= assignment) assignment;
       eta_contract_flex orig_depth depth xdepth ~argsdepth e t eat
-  | AppUVar(r,lvl,args) ->
-      let t, assignment = expand_appuv ~depth r ~lvl ~args in
-      option_iter (fun (r,_,assignment) -> r @:= assignment) assignment;
+  | AppUVar(r,args) ->
+      let t, assignment = expand_appuv ~depth r ~args in
+      option_iter (fun (r,assignment) -> r @:= assignment) assignment;
       eta_contract_flex orig_depth depth xdepth ~argsdepth e t eat
   | Arg (i, args) when e.(i) != C.dummy ->
       eta_contract_flex orig_depth depth xdepth ~argsdepth e
-        (deref_uv ~from:argsdepth ~to_:(xdepth+depth) args e.(i)) eat
+        (deref_arg ~from:argsdepth ~to_:(xdepth+depth) e.(i) args) eat
   | AppArg(i, args) when e.(i) != C.dummy ->
       eta_contract_flex orig_depth depth xdepth ~argsdepth e
-        (deref_appuv ~from:argsdepth ~to_:(xdepth+depth) args e.(i)) eat
+        (deref_apparg ~from:argsdepth ~to_:(xdepth+depth) e.(i) args) eat
   | Arg (i, args) ->
       let to_ = argsdepth in
-      let r = oref C.dummy in
-      let v = UVar(r,to_,0) in
+      let r = oref ~depth:to_ C.dummy in
+      let v = UVar(r,0) in
       e.(i) <- v;
       eta_contract_flex orig_depth depth xdepth ~argsdepth e
-        (if args == 0 then v else UVar(r,to_,args)) eat
+        (if args == 0 then v else UVar(r,args)) eat
    | AppArg(i, args) ->
       let to_ = argsdepth in
-      let r = oref C.dummy in
-      let v = UVar(r,to_,0) in
+      let r = oref ~depth:to_ C.dummy in
+      let v = UVar(r,0) in
       e.(i) <- v;
       eta_contract_flex orig_depth depth xdepth ~argsdepth e
-        (mkAppUVar r to_ args) eat
+        (mkAppUVar r args) eat
   | _ -> None
    end]
 ;;
@@ -1729,14 +1761,14 @@ let rec unif argsdepth matching depth adepth a bdepth b e =
 
 (* TODO: test if it is better to deref_uv first or not, i.e. the relative order
    of the clauses below *)
-   | UVar(r1,_,args1), UVar(r2,_,args2)
+   | UVar(r1,args1), UVar(r2,args2)
      when r1 == r2 && !!r1 == C.dummy -> args1 == args2
      (* XXX this would be a type error *)
-   | UVar(r1,vd,xs), AppUVar(r2,_,ys)
-     when r1 == r2 && !!r1 == C.dummy -> unif argsdepth matching depth adepth (AppUVar(r1,vd,C.mkinterval vd xs 0)) bdepth b e
-   | AppUVar(r1,vd,xs), UVar(r2,_,ys)
-     when r1 == r2 && !!r1 == C.dummy -> unif argsdepth matching depth adepth a bdepth (AppUVar(r1,vd,C.mkinterval vd ys 0)) e
-   | AppUVar(r1,vd,xs), AppUVar(r2,_,ys)
+   | UVar(r1,xs), AppUVar(r2,ys)
+     when r1 == r2 && !!r1 == C.dummy -> unif argsdepth matching depth adepth (AppUVar(r1,C.mkinterval r1.vardepth xs 0)) bdepth b e
+   | AppUVar(r1,xs), UVar(r2,ys)
+     when r1 == r2 && !!r1 == C.dummy -> unif argsdepth matching depth adepth a bdepth (AppUVar(r1,C.mkinterval r1.vardepth ys 0)) e
+   | AppUVar(r1,xs), AppUVar(r2,ys)
      when r1 == r2 && !!r1 == C.dummy ->
        let pruned = ref false in
        let filtered_args_rev = fold_left2i (fun i args x y ->
@@ -1746,26 +1778,26 @@ let rec unif argsdepth matching depth adepth a bdepth b e =
          ) [] xs ys in
        if !pruned then begin
          let len = List.length xs in
-         let r = oref C.dummy in
-         r1 @:= mknLam len (mkAppUVar r vd (List.rev filtered_args_rev));
+         let r = oref ~depth:r1.vardepth C.dummy in
+         r1 @:= mknLam len (mkAppUVar r (List.rev filtered_args_rev));
        end;
        true
 
    (* deref_uv *)
-   | UVar ({ contents = t }, from, args), _ when t != C.dummy ->
-      unif argsdepth matching depth adepth (deref_uv ~from ~to_:(adepth+depth) args t) bdepth b e
-   | AppUVar ({ contents = t }, from, args), _ when t != C.dummy ->
-      unif argsdepth matching depth adepth (deref_appuv ~from ~to_:(adepth+depth) args t) bdepth b e
-   | _, UVar ({ contents = t }, from, args) when t != C.dummy ->
-      unif argsdepth matching depth adepth a bdepth (deref_uv ~from ~to_:(bdepth+depth) args t) empty_env
-   | _, AppUVar ({ contents = t }, from, args) when t != C.dummy ->
-      unif argsdepth matching depth adepth a bdepth (deref_appuv ~from ~to_:(bdepth+depth) args t) empty_env
+   | UVar ({ contents = t } as r, args), _ when t != C.dummy ->
+      unif argsdepth matching depth adepth (deref_uv ~to_:(adepth+depth) r args) bdepth b e
+   | AppUVar ({ contents = t } as r, args), _ when t != C.dummy ->
+      unif argsdepth matching depth adepth (deref_appuv ~to_:(adepth+depth) r args) bdepth b e
+   | _, UVar ({ contents = t } as r, args) when t != C.dummy ->
+      unif argsdepth matching depth adepth a bdepth (deref_uv ~to_:(bdepth+depth) r args) empty_env
+   | _, AppUVar ({ contents = t } as r, args) when t != C.dummy ->
+      unif argsdepth matching depth adepth a bdepth (deref_appuv ~to_:(bdepth+depth) r args) empty_env
    | _, Arg (i,args) when e.(i) != C.dummy ->
       (* e.(i) is a heap term living at argsdepth wich can be > bdepth (e.g.
          the clause is at 0 and we are under a pi x\. As a result we do the
          deref to and the rec call at adepth *)
       unif argsdepth matching depth adepth a adepth
-        (deref_uv ~from:argsdepth ~to_:(adepth+depth) args e.(i)) empty_env
+        (deref_arg ~from:argsdepth ~to_:(adepth+depth) e.(i) args) empty_env
    | _, AppArg (i,args) when e.(i) != C.dummy ->
       (* e.(i) is a heap term living at argsdepth wich can be > bdepth (e.g.
          the clause is at 0 and we are under a pi x\. As a result we do the
@@ -1773,25 +1805,27 @@ let rec unif argsdepth matching depth adepth a bdepth b e =
       let args =
         smart_map (move ~argsdepth ~from:bdepth ~to_:adepth e) args in
       unif argsdepth matching depth adepth a adepth
-        (deref_appuv ~from:argsdepth ~to_:(adepth+depth) args e.(i)) empty_env
+        (deref_apparg ~from:argsdepth ~to_:(adepth+depth) e.(i) args) empty_env
 
    (* UVar introspection (matching) *)
    | (UVar _ | AppUVar _), Const c when c == Global_symbols.uvarc && matching -> true
-   | UVar(r,vd,ano), App(c,hd,[]) when c == Global_symbols.uvarc && matching ->
-      unif argsdepth matching depth adepth (UVar(r,vd,ano)) bdepth hd e
-   | AppUVar(r,vd,_), App(c,hd,[]) when c == Global_symbols.uvarc && matching ->
-      unif argsdepth matching depth adepth (UVar(r,vd,0)) bdepth hd e
-   | UVar(r,vd,ano), App(c,hd,[arg]) when c == Global_symbols.uvarc && matching ->
-      let r_exp = oref C.dummy in
-      let exp = UVar(r_exp,0,0) in
-      r @:= UVar(r_exp,0,vd);
+   | UVar(r,ano), App(c,hd,[]) when c == Global_symbols.uvarc && matching ->
+      unif argsdepth matching depth adepth (UVar(r,ano)) bdepth hd e
+   | AppUVar(r,_), App(c,hd,[]) when c == Global_symbols.uvarc && matching ->
+      unif argsdepth matching depth adepth (UVar(r,0)) bdepth hd e
+   | UVar(r,ano), App(c,hd,[arg]) when c == Global_symbols.uvarc && matching ->
+      let vd = r.vardepth in
+      let r_exp = oref ~depth:0 C.dummy in
+      let exp = UVar(r_exp,0) in
+      r @:= UVar(r_exp,vd);
       unif argsdepth matching depth adepth exp bdepth hd e &&
       let args = list_to_lp_list (C.mkinterval 0 (vd+ano) 0) in
       unif argsdepth matching depth adepth args bdepth arg e
-   | AppUVar(r,vd,args), App(c,hd,[arg]) when c == Global_symbols.uvarc && matching ->
-      let r_exp = oref C.dummy in
-      let exp = UVar(r_exp,0,0) in
-      r @:= UVar(r_exp,0,vd);
+   | AppUVar(r,args), App(c,hd,[arg]) when c == Global_symbols.uvarc && matching ->
+      let vd = r.vardepth in
+      let r_exp = oref ~depth:0 C.dummy in
+      let exp = UVar(r_exp,0) in
+      r @:= UVar(r_exp,vd);
       unif argsdepth matching depth adepth exp bdepth hd e &&
       let args = list_to_lp_list (C.mkinterval 0 vd 0 @ args) in
       unif argsdepth matching depth adepth args bdepth arg e
@@ -1814,9 +1848,10 @@ let rec unif argsdepth matching depth adepth a bdepth b e =
       e.(i) <- v;
       true
      with RestrictionFailure -> false end
-   | UVar(r1,_,0), UVar (r2,_,0) when uvar_uvar_assignment_order r1 r2-> unif argsdepth matching depth bdepth b adepth a e
-   | AppUVar(r1,_,_), UVar (r2,_,0) when uvar_uvar_assignment_order r1 r2 -> unif argsdepth matching depth bdepth b adepth a e
-   | _, UVar (r,origdepth,0) ->
+   | UVar(r1,0), UVar (r2,0) when uvar_uvar_assignment_order r1 r2-> unif argsdepth matching depth bdepth b adepth a e
+   | AppUVar(r1,_), UVar (r2,0) when uvar_uvar_assignment_order r1 r2 -> unif argsdepth matching depth bdepth b adepth a e
+   | _, UVar (r,0) ->
+       let origdepth = r.vardepth in
        begin try
          let t =
            if depth = 0 then
@@ -1834,12 +1869,13 @@ let rec unif argsdepth matching depth adepth a bdepth b e =
        with RestrictionFailure when isLam a ->
           (* avoid fail occur-check on: x\A x = A  | x\y\A y x = A
              we eta expand and see how it is under the lambdas *)
-          let b = (mkLam @@ mkAppUVar r origdepth [mkConst @@ depth + bdepth]) in
+          let b = (mkLam @@ mkAppUVar r [mkConst @@ depth + bdepth]) in
           let a = hmove ~from:(adepth+depth) ~to_:(bdepth+depth) a in
           unif argsdepth matching depth bdepth a bdepth b e
        | RestrictionFailure -> false
        end
-   | UVar (r,origdepth,0), _ when not matching ->
+   | UVar (r,0), _ when not matching ->
+       let origdepth = r.vardepth in
        begin try
          let t =
            if depth=0 then
@@ -1857,7 +1893,7 @@ let rec unif argsdepth matching depth adepth a bdepth b e =
        with RestrictionFailure when isLam b ->
           (* avoid fail occur-check on: x\A x = A  | x\y\A y x = A
              we eta expand and see how it is under the lambdas *)
-          let a = (mkLam @@ mkAppUVar r origdepth [mkConst @@ depth + adepth]) in
+          let a = (mkLam @@ mkAppUVar r [mkConst @@ depth + adepth]) in
           let b = move ~argsdepth ~from:(bdepth+depth) ~to_:(adepth+depth) e b in
           unif argsdepth matching depth adepth a adepth b e
        | RestrictionFailure -> false
@@ -1871,41 +1907,43 @@ let rec unif argsdepth matching depth adepth a bdepth b e =
         (uppterm depth [] ~argsdepth e) v) ()];
       e.(i) <- v;
       let bdepth = adepth in (* like in deref for arg *)
-      let b = deoptimize_uv_w_args @@ deref_uv ~from:argsdepth ~to_:(bdepth+depth) args v in
+      let b = deoptimize_uv_w_args @@ deref_arg ~from:argsdepth ~to_:(bdepth+depth) v args in
       unif argsdepth matching depth adepth a bdepth b e
-   | UVar(r1,_,a1), UVar (r2,_,a2) when uvar_uvar_assignment_order r1 r2 -> unif argsdepth matching depth bdepth b adepth a e (* TODO argsdepth *)
-   | AppUVar(r1,_,_), UVar (r2,_,a2) when uvar_uvar_assignment_order r1 r2 -> unif argsdepth matching depth bdepth b adepth a e
+   | UVar(r1,a1), UVar (r2,a2) when uvar_uvar_assignment_order r1 r2 -> unif argsdepth matching depth bdepth b adepth a e (* TODO argsdepth *)
+   | AppUVar(r1,_), UVar (r2,a2) when uvar_uvar_assignment_order r1 r2 -> unif argsdepth matching depth bdepth b adepth a e
 
-   | _, UVar (r,origdepth,args) when args > 0 && match a with UVar(r1,_,_) | AppUVar(r1,_,_) -> r != r1 | _ -> true ->
+   | _, UVar (r,args) when args > 0 && match a with UVar(r1,_) | AppUVar(r1,_) -> r != r1 | _ -> true ->
+      let origdepth = r.vardepth in
       let v = make_lambdas origdepth (args - depth) in
       [%spy "user:assign:simplify:stack:uvar" ~rid (fun fmt () -> Fmt.fprintf fmt "%a := %a"
-        (uppterm depth [] ~argsdepth e) (UVar(r,origdepth,0))
+        (uppterm depth [] ~argsdepth e) (UVar(r,0))
         (uppterm depth [] ~argsdepth e) v) ()];
       r @:= v;
-      let b = deoptimize_uv_w_args @@ deref_uv ~from:origdepth ~to_:(bdepth+depth) args v in
+      let b = deoptimize_uv_w_args @@ deref_arg ~from:origdepth ~to_:(bdepth+depth) v args in
       unif argsdepth matching depth adepth a bdepth b e
-   | UVar (r,origdepth,args), _ when args > 0 && match b with UVar(r1,_,_) | AppUVar(r1,_,_) -> r != r1 | _ -> true ->
+   | UVar (r,args), _ when args > 0 && match b with UVar(r1,_) | AppUVar(r1,_) -> r != r1 | _ -> true ->
+      let origdepth = r.vardepth in
       let v = make_lambdas origdepth (args - depth) in
       [%spy "user:assign:simplify:heap" ~rid (fun fmt () -> Fmt.fprintf fmt "%a := %a"
-         (uppterm depth [] ~argsdepth e) (UVar(r,origdepth,0))
+         (uppterm depth [] ~argsdepth e) (UVar(r,0))
          (uppterm depth [] ~argsdepth e) v) ()];
       r @:= v;
-      let a = deoptimize_uv_w_args @@ deref_uv ~from:origdepth ~to_:(adepth+depth) args v in
+      let a = deoptimize_uv_w_args @@ deref_arg ~from:origdepth ~to_:(adepth+depth) v args in
       unif argsdepth matching depth adepth a bdepth b e
 
    (* HO *)
    | other, AppArg(i,args) ->
        let is_llam, args = is_llam adepth args adepth bdepth depth false e in
        if is_llam then
-         let r = oref C.dummy in
-         e.(i) <- UVar(r,adepth,0);
-         try bind ~argsdepth r adepth args adepth depth delta bdepth false other e
+         let r = oref ~depth:adepth C.dummy in
+         e.(i) <- UVar(r,0);
+         try bind ~argsdepth r args adepth depth delta bdepth false other e
          with RestrictionFailure -> false
        else if !delay_hard_unif_problems then begin
        Fmt.fprintf Fmt.std_formatter "HO unification delayed: %a = %a\n%!"
          (uppterm depth [] ~argsdepth empty_env) a (uppterm depth [] ~argsdepth e) b ;
-       let r = oref C.dummy in
-       e.(i) <- UVar(r,adepth,0);
+       let r = oref ~depth:adepth C.dummy in
+       e.(i) <- UVar(r,0);
        let kind = Unification {adepth = adepth+depth; env = e; bdepth = bdepth+depth; a; b; matching} in
        let blockers =
          match is_flex ~depth:(adepth+depth) other with
@@ -1914,14 +1952,15 @@ let rec unif argsdepth matching depth adepth a bdepth b e =
        CS.declare_new { kind; blockers };
        true
        end else error (error_msg_hard_unif a b)
-   | AppUVar(r2,_,_), (AppUVar (r1,_,_) | UVar (r1,_,_)) when uvar_uvar_assignment_order r1 r2 ->
+   | AppUVar(r2,_), (AppUVar (r1,_) | UVar (r1,_)) when uvar_uvar_assignment_order r1 r2 ->
        unif argsdepth matching depth bdepth b adepth a e
-   | AppUVar (r, lvl,(args as oargs)), other when not matching ->
+   | AppUVar (r, (args as oargs)), other when not matching ->
+       let lvl = r.vardepth in
        let is_llam, args = is_llam lvl args adepth bdepth depth true e in
        if is_llam then
-         try bind ~argsdepth r lvl args adepth depth delta bdepth true other e
+         try bind ~argsdepth r args adepth depth delta bdepth true other e
          with RestrictionFailure when isLam other ->
-          let a = mkLam @@ mkAppUVar r lvl (smart_map (move ~argsdepth e ~from:(depth+adepth) ~to_:(depth+adepth+1)) oargs @ [mkConst @@ depth + adepth]) in
+          let a = mkLam @@ mkAppUVar r (smart_map (move ~argsdepth e ~from:(depth+adepth) ~to_:(depth+adepth+1)) oargs @ [mkConst @@ depth + adepth]) in
           let b = move ~from:(depth+bdepth) ~to_:(depth+adepth) ~argsdepth e b in
           unif argsdepth matching depth adepth a adepth b e
          | RestrictionFailure -> false
@@ -1933,12 +1972,13 @@ let rec unif argsdepth matching depth adepth a bdepth b e =
        CS.declare_new { kind; blockers };
        true
        end else error (error_msg_hard_unif a b)
-   | other, AppUVar (r, lvl,(args as oargs)) ->
+   | other, AppUVar (r, (args as oargs)) ->
+       let lvl = r.vardepth in
        let is_llam, args = is_llam lvl args adepth bdepth depth false e in
        if is_llam then
-         try bind ~argsdepth r lvl args adepth depth delta bdepth false other e
+         try bind ~argsdepth r args adepth depth delta bdepth false other e
          with RestrictionFailure when isLam other ->
-          let b = mkLam @@ mkAppUVar r lvl (smart_map (move ~argsdepth e ~from:(depth+bdepth) ~to_:(depth+bdepth+1)) oargs @ [mkConst @@ depth + bdepth]) in
+          let b = mkLam @@ mkAppUVar r (smart_map (move ~argsdepth e ~from:(depth+bdepth) ~to_:(depth+bdepth+1)) oargs @ [mkConst @@ depth + bdepth]) in
           let a = hmove ~from:(depth+adepth) ~to_:(depth+bdepth) a in
           unif argsdepth matching depth bdepth a bdepth b e
          | RestrictionFailure -> false
@@ -2042,23 +2082,23 @@ let full_deref ~adepth env ~depth t =
   | Nil as x -> x
   | Discard as x -> x
   | Arg (i,ano) when env.(i) != C.dummy ->
-      deref d (deref_uv ~from:adepth ~to_:d ano env.(i))
+      deref d (deref_arg ~from:adepth ~to_:d env.(i) ano)
   | Arg _ as x -> x
   | AppArg (i,args) when env.(i) != C.dummy ->
-      deref d (deref_appuv ~from:adepth ~to_:d args env.(i))
+      deref d (deref_apparg ~from:adepth ~to_:d env.(i) args)
   | AppArg (i,args) as orig ->
       let args' = smart_map (deref d) args in
       if args == args' then orig
       else AppArg (i, args')
-  | UVar (r,lvl,ano) when !!r != C.dummy ->
-      deref d (deref_uv ~from:lvl ~to_:d ano !!r)
+  | UVar (r,ano) when !!r != C.dummy ->
+      deref d (deref_uv ~to_:d r ano)
   | UVar _ as x -> x
-  | AppUVar (r,lvl,args) when !!r != C.dummy ->
-      deref d (deref_appuv ~from:lvl ~to_:d args !!r)
-  | AppUVar (r,lvl,args) as orig ->
+  | AppUVar (r,args) when !!r != C.dummy ->
+      deref d (deref_appuv ~to_:d r args)
+  | AppUVar (r,args) as orig ->
       let args' = smart_map (deref d) args in
       if args == args' then orig
-      else AppUVar (r,lvl,args')
+      else AppUVar (r,args')
   | Builtin(c,xs) as orig ->
       let xs' = smart_map (deref d) xs in
       if xs == xs' then orig
@@ -2067,7 +2107,7 @@ let full_deref ~adepth env ~depth t =
   in
     deref depth t
 
-type assignment = uvar_body * int * term
+type assignment = uvar_body * term
 
 let shift_bound_vars ~depth ~to_ t =
   let shift_db d n =
@@ -2096,13 +2136,13 @@ let shift_bound_vars ~depth ~to_ t =
       let args' = smart_map (shift d) args in
       if args == args' then orig
       else AppArg (i, args')
-  | (UVar (r,_,_) | AppUVar(r,_,_)) when !!r != C.dummy ->
+  | (UVar (r,_) | AppUVar(r,_)) when !!r != C.dummy ->
       anomaly "shift_bound_vars: non-derefd term"
   | UVar _ as x -> x
-  | AppUVar (r,lvl,args) as orig ->
+  | AppUVar (r,args) as orig ->
       let args' = smart_map (shift d) args in
       if args == args' then orig
-      else AppUVar (r,lvl,args')
+      else AppUVar (r,args')
   | Builtin(c,xs) as orig ->
       let xs' = smart_map (shift d) xs in
       if xs == xs' then orig
@@ -2144,10 +2184,10 @@ let map_free_vars ~map ~depth ~to_ t =
     let args' = smart_map (shift d) args in
     if args == args' then orig
     else AppArg (i, args')
-  | (UVar (r,_,_) | AppUVar(r,_,_)) when !!r != C.dummy ->
+  | (UVar (r,_) | AppUVar(r,_)) when !!r != C.dummy ->
       anomaly "map_free_vars: non-derefd term"
-  | UVar(r,lvl,ano) -> UVar(r,min lvl to_,ano)
-  | AppUVar (r,lvl,args) -> AppUVar (r,min lvl to_,smart_map (shift d) args)
+  | UVar(r,ano) as orig -> assert(r.vardepth = min r.vardepth to_); orig
+  | AppUVar (r,args) -> assert(r.vardepth = min r.vardepth to_); AppUVar (r,smart_map (shift d) args)
   | Builtin(c,xs) as orig ->
     let xs' = smart_map (shift d) xs in
     if xs == xs' then orig
@@ -2163,9 +2203,6 @@ let eta_contract_flex ~depth t =
 end
 (* }}} *)
 open HO
-
-let _ = do_deref := deref_uv;;
-let _ = do_app_deref := deref_appuv;;
 
 
 (* Built-in predicates and their FFI *************************************** *)
@@ -2561,7 +2598,7 @@ let hash_goal_arg_list = hash_arg_list true
 *)
 let rec max_list_length acc = function
   | Nil -> acc
-  | Cons (a, (UVar (_, _, _) | AppUVar (_, _, _) | Arg (_, _) | AppArg (_, _) | Discard)) -> 
+  | Cons (a, (UVar (_, _) | AppUVar (_, _) | Arg (_, _) | AppArg (_, _) | Discard)) -> 
       let alen = max_list_length 0 a in
       max (acc+2) alen
   | Cons (a, b)-> 
@@ -2571,7 +2608,7 @@ let rec max_list_length acc = function
   | App (_,x,xs) -> List.fold_left (fun acc x -> max acc (max_list_length 0 x)) acc (x::xs)
   | Builtin (_, xs) -> List.fold_left (fun acc x -> max acc (max_list_length 0 x)) acc xs
   | Lam t -> max_list_length acc t
-  | Discard | Const _ |CData _ | UVar (_, _, _) | AppUVar (_, _, _) | Arg (_, _) | AppArg (_, _) -> acc
+  | Discard | Const _ |CData _ | UVar (_, _) | AppUVar (_, _) | Arg (_, _) | AppArg (_, _) -> acc
 
 let max_lists_length = List.fold_left (fun acc e -> max (max_list_length 0 e) acc) 0
 
@@ -3096,10 +3133,10 @@ let rec split_conj ~depth = function
       split_conj ~depth hd @ List.(flatten (map (split_conj ~depth) args))
   | Nil -> []
   | Cons(x,xs) -> split_conj ~depth x @ split_conj ~depth xs
-  | UVar ({ contents=g },from,args) when g != C.dummy ->
-    split_conj ~depth (deref_uv ~from ~to_:depth args g)
-  | AppUVar ({contents=g},from,args) when g != C.dummy ->
-    split_conj ~depth (deref_appuv ~from ~to_:depth args g)
+  | UVar ({ contents=g } as r,args) when g != C.dummy ->
+    split_conj ~depth (deref_uv ~to_:depth r args)
+  | AppUVar ({contents=g } as r,args) when g != C.dummy ->
+    split_conj ~depth (deref_appuv ~to_:depth r args)
   | Discard -> []
   | _ as f -> [ f ]
 ;;
@@ -3107,18 +3144,18 @@ let rec split_conj ~depth = function
 let rec lp_list_to_list ~depth = function
   | Cons(hd, tl) -> hd :: lp_list_to_list ~depth tl
   | Nil -> []
-  | UVar ({ contents=g },from,args) when g != C.dummy ->
-    lp_list_to_list ~depth (deref_uv ~from ~to_:depth args g)
-  | AppUVar ({contents=g},from,args) when g != C.dummy ->
-    lp_list_to_list ~depth (deref_appuv ~from ~to_:depth args g)
+  | UVar ({ contents=g } as r,args) when g != C.dummy ->
+    lp_list_to_list ~depth (deref_uv ~to_:depth r args)
+  | AppUVar ({contents=g} as r,args) when g != C.dummy ->
+    lp_list_to_list ~depth (deref_appuv ~to_:depth r args)
   | x -> error (Fmt.sprintf "%s is not a list" (show_term x))
 ;;
 
 let rec get_lambda_body ~depth = function
- | UVar ({ contents=g },from,args) when g != C.dummy ->
-    get_lambda_body ~depth (deref_uv ~from ~to_:depth args g)
- | AppUVar ({contents=g},from,args) when g != C.dummy ->
-    get_lambda_body ~depth (deref_appuv ~from ~to_:depth args g)
+ | UVar ({ contents=g } as r,args) when g != C.dummy ->
+    get_lambda_body ~depth (deref_uv ~to_:depth r args)
+ | AppUVar ({contents=g} as r,args) when g != C.dummy ->
+    get_lambda_body ~depth (deref_appuv ~to_:depth r args)
  | Lam b -> b
  | _ -> error "pi/sigma applied to something that is not a Lam"
 ;;
@@ -3196,12 +3233,12 @@ let rec claux1 loc get_mode vars depth hyps ts lts lcs t =
      let c = { depth = depth+lcs; args; hyps; mode = get_mode hd; vars; loc; timestamp = [] } in
      [%spy "dev:claudify:extra-clause" ~rid (ppclause ~hd) c];
      (hd,c), { hdepth = depth; hsrc = g }, lcs
-  | UVar ({ contents=g },from,args) when g != C.dummy ->
+  | UVar ({ contents=g } as r,args) when g != C.dummy ->
      claux1 loc get_mode vars depth hyps ts lts lcs
-       (deref_uv ~from ~to_:(depth+lts) args g)
-  | AppUVar ({contents=g},from,args) when g != C.dummy ->
+       (deref_uv ~to_:(depth+lts) r args)
+  | AppUVar ({contents=g } as r,args) when g != C.dummy ->
      claux1 loc get_mode vars depth hyps ts lts lcs
-       (deref_appuv ~from ~to_:(depth+lts) args g)
+       (deref_appuv ~to_:(depth+lts) r args)
   | Arg _ | AppArg _ -> raise Flex_head
   | Builtin (c,_) -> raise @@ CannotDeclareClauseForBuiltin(loc,c)
   | (Lam _ | CData _ ) as x ->
@@ -3386,15 +3423,16 @@ end = struct (* {{{ *)
     let f = ref f in
     let log_assignment = function
       | t, None -> t
-      | t, Some (r,_,nt as s) ->
+      | t, Some (r,nt as s) ->
           f := { !f with assignments = s :: !f.assignments };
           r @::== nt;
           t in
     let freeze_uv r =
+      assert(r.vardepth = 0);
       try List.assq r !f.uv2c
       with Not_found ->
         let n, c = C.fresh_global_constant () in
-        [%spy "dev:freeze_uv:new" ~rid (fun fmt () -> let tt = UVar (r,0,0) in
+        [%spy "dev:freeze_uv:new" ~rid (fun fmt () -> let tt = UVar (r,0) in
           Fmt.fprintf fmt "%s == %a" (C.show n) (ppterm 0 [] ~argsdepth:0 empty_env) tt) ()];
         f := { !f with c2uv = C.Map.add n r !f.c2uv;
                        uv2c = (r,c) :: !f.uv2c };
@@ -3421,17 +3459,17 @@ end = struct (* {{{ *)
           if t == t' then orig
           else Lam t'
       (* freeze *)
-      | AppUVar(r,0,args) when !!r == C.dummy ->
+      | AppUVar(r,args) when r.vardepth == 0 && !!r == C.dummy ->
           let args = smart_map (faux d) args in
           App(Global_symbols.uvarc, freeze_uv r, [list_to_lp_list args])
       (* expansion *)
-      | UVar(r,lvl,ano) when !!r == C.dummy ->
-          faux d (log_assignment(expand_uv ~depth:d r ~lvl ~ano))
-      | AppUVar(r,lvl,args) when !!r == C.dummy ->
-          faux d (log_assignment(expand_appuv ~depth:d r ~lvl ~args))
+      | UVar(r,ano) when !!r == C.dummy ->
+          faux d (log_assignment(expand_uv ~depth:d r ~ano))
+      | AppUVar(r,args) when !!r == C.dummy ->
+          faux d (log_assignment(expand_appuv ~depth:d r ~args))
       (* deref *)
-      | UVar(r,lvl,ano) -> faux d (deref_uv ~from:lvl ~to_:d ano !!r)
-      | AppUVar(r,lvl,args) -> faux d (deref_appuv ~from:lvl ~to_:d args !!r)
+      | UVar(r,ano) -> faux d (deref_uv ~to_:d r ano)
+      | AppUVar(r,args) -> faux d (deref_appuv ~to_:d r args)
     in
     [%spy "dev:freeze:in" ~rid (fun fmt () ->
       Fmt.fprintf fmt "depth:%d ground:%d newground:%d maxground:%d %a"
@@ -3458,29 +3496,39 @@ end = struct (* {{{ *)
   [%spy "dev:defrost:shifted" ~rid (fun fmt () ->
     Fmt.fprintf fmt "from:%d to:%d %a" from to_
       (uppterm to_ [] ~argsdepth:0 empty_env) t) ()];
+    let fresh_uv = ref IntMap.empty in
+    let mk_fresh_uv_for r =
+      let uid = uvar_id r in
+      try IntMap.find uid !fresh_uv
+      with Not_found ->
+        let r' = oref ~depth:0 C.dummy in
+        fresh_uv := IntMap.add uid r' !fresh_uv;
+        r' in
     let rec daux d = function
       | Const c when C.Map.mem c f.c2uv ->
-          UVar(C.Map.find c f.c2uv,0,0)
+          UVar(C.Map.find c f.c2uv,0)
       | (Const _ | CData _ | Nil | Discard) as x -> x
       | Cons(hd,tl) as orig ->
           let hd' = daux d hd in
           let tl' = daux d tl in
           if hd == hd' && tl == tl' then orig
           else Cons(hd',tl')
-      | App(c,UVar(r,lvl,ano),a) when !!r != C.dummy ->
-          daux d (App(c,deref_uv ~to_:d ~from:lvl ano !!r,a))
-      | App(c,AppUVar(r,lvl,args),a) when !!r != C.dummy ->
-          daux d (App(c,deref_appuv ~to_:d ~from:lvl args !!r,a))
+      | App(c,UVar(r,ano),a) when !!r != C.dummy ->
+          daux d (App(c,deref_uv ~to_:d r ano,a))
+      | App(c,AppUVar(r,args),a) when !!r != C.dummy ->
+          daux d (App(c,deref_appuv ~to_:d r args,a))
       | App(c,Const x,[args]) when c == Global_symbols.uvarc ->
           let r = C.Map.find x f.c2uv in
           let args = lp_list_to_list ~depth:d args in
-          mkAppUVar r 0 (smart_map (daux d) args)
-      | App(c,UVar(r,_,_),[args]) when c == Global_symbols.uvarc ->
+          mkAppUVar r (smart_map (daux d) args)
+      | App(c,UVar(r,0),[args]) when c == Global_symbols.uvarc ->
           let args = lp_list_to_list ~depth:d args in
-          mkAppUVar r 0 (smart_map (daux d) args)
-      | App(c,AppUVar(r,_,_),[args]) when c == Global_symbols.uvarc ->
+          let r' = mk_fresh_uv_for r in
+          mkAppUVar r' (smart_map (daux d) args)
+      | App(c,AppUVar(r,_),[args]) when c == Global_symbols.uvarc ->
           let args = lp_list_to_list ~depth:d args in
-          mkAppUVar r 0 (smart_map (daux d) args)
+          let r' = mk_fresh_uv_for r in
+          mkAppUVar r' (smart_map (daux d) args)
       | App(c,x,xs) as orig ->
           let x' = daux d x in
           let xs' = smart_map (daux d) xs in
@@ -3491,21 +3539,21 @@ end = struct (* {{{ *)
           if args == args' then orig
           else Builtin(c,args')
       | Arg(i,ano) when env.(i) != C.dummy ->
-          daux d (deref_uv ~from:to_ ~to_:d ano env.(i))
+          daux d (deref_arg ~from:to_ ~to_:d env.(i) ano)
       | AppArg (i,args) when env.(i) != C.dummy ->
-          daux d (deref_appuv ~from:to_ ~to_:d args env.(i))
+          daux d (deref_apparg ~from:to_ ~to_:d env.(i) args)
       | (Arg(i,_) | AppArg(i,_)) as x ->
-          env.(i) <- UVar(oref C.dummy, to_, 0);
+          env.(i) <- UVar(oref ~depth:to_ C.dummy, 0);
           daux d x
       | Lam t as orig ->
           let t' = daux (d+1) t in
           if t == t' then orig
           else Lam t'
       | UVar _ as x -> x
-      | AppUVar(r,lvl,args) as orig ->
+      | AppUVar(r,args) as orig ->
           let args' = smart_map (daux d) args in
           if args == args' then orig
-          else AppUVar(r,lvl,args')
+          else AppUVar(r,args')
     in
      daux to_ t
 
@@ -3571,8 +3619,8 @@ let rec head_of = function
   | Builtin(And,hd :: _) -> head_of hd (* FIXME *)
   | App(x,_,_) -> x
   | Builtin(x,_) -> const_of_builtin_predicate x
-  | AppUVar(r,_,_)
-  | UVar(r,_,_) when !!r != C.dummy -> head_of !!r
+  | AppUVar(r,_)
+  | UVar(r,_) when !!r != C.dummy -> head_of !!r
   | CData _ -> type_error "A constraint cannot be a primitive data"
   | Cons(x,_) -> head_of x
   | Nil -> type_error "A constraint cannot be a list"
@@ -3589,7 +3637,7 @@ let declare_constraint ~depth prog (gid[@trace]) args =
         "The Key arguments of declare_constraint must be variables or list of variables. Got: " ^ show_term t
       in
       let rec collect_keys t = match deref_head ~depth t with
-        | UVar (r, _, _) | AppUVar (r, _, _) -> [r]
+        | UVar (r, _) | AppUVar (r, _) -> [r]
         | Discard -> [dummy_uvar_body]
         | Lam _ ->
             begin match HO.eta_contract_flex ~depth t with
@@ -3875,7 +3923,7 @@ let propagation () =
                    [%spyl "user:CHR:rule-remove-constraints" ~rid ~gid: (active.cgid[@trace]) (fun fmt { cgid } -> UUID.pp fmt cgid) to_be_removed];
                    removed := to_be_removed @ !removed;
                    List.iter CS.remove_old_constraint to_be_removed;
-                   List.iter (fun (r,_lvl,t) -> r @:= t) assignments;
+                   List.iter (fun (r,t) -> r @:= t) assignments;
                    match to_be_added with
                    | None -> ()
                    | Some to_be_added -> to_be_resumed_rev := to_be_added :: !to_be_resumed_rev
@@ -4017,7 +4065,7 @@ let make_runtime : ?max_steps: int -> ?delay_outside_fragment: bool -> executabl
        [%tcall run (depth+1) p f (gid[@trace]) gs next alts cutto_alts]
     | Builtin(Sigma, [arg]) -> [%spy "user:rule" ~rid ~gid pp_string "sigma"];
        let f = get_lambda_body ~depth arg in
-       let v = UVar(oref C.dummy, depth, 0) in
+       let v = UVar(oref ~depth C.dummy, 0) in
        let fv = subst depth [v] f in
        let gid[@trace] = make_subgoal_id gid ((depth,fv)[@trace]) in
        [%spy "user:rule:sigma" ~rid ~gid pp_string "success"];
@@ -4058,10 +4106,10 @@ let make_runtime : ?max_steps: int -> ?delay_outside_fragment: bool -> executabl
       | { depth; program; goal; gid = gid [@trace] } :: gs ->
         [%tcall run depth program goal (gid[@trace]) gs next alts cutto_alts]
       end
-    | UVar ({ contents = g }, from, args) when g != C.dummy -> [%spy "user:rule" ~rid ~gid pp_string "deref"]; [%spy "user:rule:deref" ~rid ~gid pp_string "success"];
-       [%tcall run depth p (deref_uv ~from ~to_:depth args g) (gid[@trace]) gs next alts cutto_alts]
-    | AppUVar ({contents = t}, from, args) when t != C.dummy -> [%spy "user:rule" ~rid ~gid pp_string "deref"]; [%spy "user:rule:deref" ~rid ~gid pp_string "success"];
-       [%tcall run depth p (deref_appuv ~from ~to_:depth args t) (gid[@trace]) gs next alts cutto_alts]
+    | UVar ({ contents = g } as r, args) when g != C.dummy -> [%spy "user:rule" ~rid ~gid pp_string "deref"]; [%spy "user:rule:deref" ~rid ~gid pp_string "success"];
+       [%tcall run depth p (deref_uv ~to_:depth r args) (gid[@trace]) gs next alts cutto_alts]
+    | AppUVar ({contents = t } as r, args) when t != C.dummy -> [%spy "user:rule" ~rid ~gid pp_string "deref"]; [%spy "user:rule:deref" ~rid ~gid pp_string "success"];
+       [%tcall run depth p (deref_appuv ~to_:depth r args) (gid[@trace]) gs next alts cutto_alts]
     | Const k ->
        let clauses = get_clauses ~depth k g p.index in
        [%spy "user:rule" ~rid ~gid pp_string "backchain"];
@@ -4402,6 +4450,7 @@ let pp_stuck_goal ?pp_ctx fmt s = CS.pp_stuck_goal ?pp_ctx fmt s
 let is_flex = HO.is_flex
 let deref_uv = HO.deref_uv
 let deref_appuv = HO.deref_appuv
+let deref_apparg = HO.deref_apparg
 let deref_head = HO.deref_head
 let full_deref = HO.full_deref ~adepth:0 empty_env
 let eta_contract_flex = HO.eta_contract_flex
@@ -4416,13 +4465,13 @@ let mkinterval = C.mkinterval
 let mkAppL = C.mkAppL
 let lex_insertion = lex_insertion
 
-let expand_uv ~depth r ~lvl ~ano =
-  let t, assignment = HO.expand_uv ~depth r ~lvl ~ano in
-  option_iter (fun (r,_,assignment) -> r @:= assignment) assignment;
+let expand_uv ~depth r ~ano =
+  let t, assignment = HO.expand_uv ~depth r ~ano in
+  option_iter (fun (r,assignment) -> r @:= assignment) assignment;
   t
-let expand_appuv ~depth r ~lvl ~args =
-  let t, assignment = HO.expand_appuv ~depth r ~lvl ~args in
-  option_iter (fun (r,_,assignment) -> r @:= assignment) assignment;
+let expand_appuv ~depth r ~args =
+  let t, assignment = HO.expand_appuv ~depth r ~args in
+  option_iter (fun (r,assignment) -> r @:= assignment) assignment;
   t
 
 module CompileTime = struct
@@ -4432,5 +4481,5 @@ module CompileTime = struct
   let get_clauses ~depth goal args_idx : overlap_clause Bl.scan =
     get_clauses_dt ~check_mut_excl:On ~pp_clause:pp_overlap_clause ~cmp_clause:(fun (c1:overlap_clause) c2 -> lex_insertion c1.timestamp c2.timestamp) ~depth goal args_idx
 
-  let fresh_uvar () = oref C.dummy
+  let fresh_uvar ~depth = oref ~depth C.dummy
 end

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -28,14 +28,15 @@ val execute_loop :
   ?delay_outside_fragment:bool -> executable -> more:(unit -> bool) -> pp:(float -> 'a outcome -> unit) -> unit
 
 (* Functions useful to implement built-in predicates and evaluable functions *)
-val deref_uv : ?avoid:uvar_body -> from:constant -> to_:constant -> int -> term -> term
-val deref_appuv : ?avoid:uvar_body -> from:constant -> to_:constant -> term list -> term -> term
+val deref_uv : ?avoid:uvar_body -> to_:int -> uvar_body -> int -> term
+val deref_appuv : ?avoid:uvar_body -> to_:int -> uvar_body -> term list -> term
+val deref_apparg : ?avoid:uvar_body -> from:int -> to_:int -> term -> term list -> term
 val deref_head : depth:int -> term -> term
 val eta_contract_flex : depth:int -> term -> term option
 val is_flex : depth:int -> term -> uvar_body option
 
-val expand_uv : depth:int -> uvar_body -> lvl:int -> ano:int -> term
-val expand_appuv : depth:int -> uvar_body -> lvl:int -> args:term list -> term
+val expand_uv : depth:int -> uvar_body -> ano:int -> term
+val expand_appuv : depth:int -> uvar_body -> args:term list -> term
 
 val lp_list_to_list : depth:int -> term -> term list
 val list_to_lp_list : term list -> term
@@ -89,7 +90,7 @@ module CompileTime : sig
 
   val get_clauses : depth:int -> term -> overlap_clause Discrimination_tree.t -> overlap_clause Bl.scan
 
-  val fresh_uvar : unit -> uvar_body
+  val fresh_uvar : depth:int -> uvar_body
 end
 
 module Indexing : sig

--- a/src/runtime/runtime.mli
+++ b/src/runtime/runtime.mli
@@ -28,15 +28,15 @@ val execute_loop :
   ?delay_outside_fragment:bool -> executable -> more:(unit -> bool) -> pp:(float -> 'a outcome -> unit) -> unit
 
 (* Functions useful to implement built-in predicates and evaluable functions *)
-val deref_uv : ?avoid:uvar_body -> to_:int -> uvar_body -> int -> term
-val deref_appuv : ?avoid:uvar_body -> to_:int -> uvar_body -> term list -> term
-val deref_apparg : ?avoid:uvar_body -> from:int -> to_:int -> term -> term list -> term
+val deref_uv : ?avoid:uvar -> to_:int -> uvar -> int -> term
+val deref_appuv : ?avoid:uvar -> to_:int -> uvar -> term list -> term
+val deref_apparg : ?avoid:uvar -> from:int -> to_:int -> term -> term list -> term
 val deref_head : depth:int -> term -> term
 val eta_contract_flex : depth:int -> term -> term option
-val is_flex : depth:int -> term -> uvar_body option
+val is_flex : depth:int -> term -> uvar option
 
-val expand_uv : depth:int -> uvar_body -> ano:int -> term
-val expand_appuv : depth:int -> uvar_body -> args:term list -> term
+val expand_uv : depth:int -> uvar -> ano:int -> term
+val expand_appuv : depth:int -> uvar -> args:term list -> term
 
 val lp_list_to_list : depth:int -> term -> term list
 val list_to_lp_list : term list -> term
@@ -50,10 +50,10 @@ val mkAppL : constant -> term list -> term
 val mkAppArg : int -> int -> term list -> term
 val move : 
   argsdepth:int -> env ->
-  ?avoid:uvar_body ->
+  ?avoid:uvar ->
   from:int -> to_:int -> term -> term
 val hmove : 
-  ?avoid:uvar_body ->
+  ?avoid:uvar ->
   from:int -> to_:int -> term -> term
 val subst: depth:int -> term list -> term -> term
 
@@ -90,7 +90,7 @@ module CompileTime : sig
 
   val get_clauses : depth:int -> term -> overlap_clause Discrimination_tree.t -> overlap_clause Bl.scan
 
-  val fresh_uvar : depth:int -> uvar_body
+  val fresh_uvar : depth:int -> uvar
 end
 
 module Indexing : sig

--- a/tests/sources/chr-scope-change-failure.elpi
+++ b/tests/sources/chr-scope-change-failure.elpi
@@ -2,9 +2,9 @@ constraint foo good bad {
     rule \ ([C1,C2] :> D ?- foo G B) <=> ([] :> D ?- foo G B).
 }
 
-pred good i:int.
-pred bad i:int.
-pred foo i:int, i:int.
+func good int.
+func bad  int.
+func foo  int, int.
 foo A B :- print A B, good A, bad B.
 
 main :-

--- a/tests/sources/chr-scope-change.elpi
+++ b/tests/sources/chr-scope-change.elpi
@@ -2,9 +2,9 @@ constraint foo good bad {
     rule \ (L :> D ?- foo G B) | (std.rev L L1) <=> (L1 :> D ?- foo G B).
 }
 
-pred good i:int.
-pred bad i:int.
-pred foo i:int, i:int.
+func good int.
+func bad int.
+func foo int, int.
 foo A B :- print A B, good A, bad B.
 
 main :-

--- a/tests/sources/chr-scope.elpi
+++ b/tests/sources/chr-scope.elpi
@@ -4,7 +4,7 @@ type f tm -> tm -> tm.
 pred move i:tm, i:tm, i:tm -> tm, o:tm -> tm.
 move A B (x\f B x) (x\f A x).
 
-pred c i:tm, i:tm -> tm.
+func c tm, (tm -> tm).
 
 constraint c {
     rule (E :> G ?- c (uvar X [A]) T1) \ (F :> _ ?- c (uvar X [B]) T2)

--- a/tests/sources/chr.elpi
+++ b/tests/sources/chr.elpi
@@ -26,11 +26,11 @@ constraint term {
      \ (GY ?- term (uvar K LY) TY)
      | (print "compat" GX "|-" K LX TX "," GY "|-" K LY TY, 
         compatible GX LX GY LY CTXCONSTR)
-   <=> (print "NEW" CTXCONSTR TX "=" TY, CTXCONSTR, TX = TY).
+   <=> (print "NEW" CTXCONSTR TX "=" TY, std.do! CTXCONSTR, TX = TY).
 
 }
 
-pred compatible i:list prop, i:list term,i:list prop,i:list term,o:list prop.
+pred compatible i:list prop, i:list term,i:list prop,i:list term,o:list (func).
 compatible _ [] _ [] [] :- !.
 compatible GX [X|XS] GY [Y|YS] [TX = TY | K] :-
  (GX => term X TX),

--- a/tests/sources/chr.elpi
+++ b/tests/sources/chr.elpi
@@ -7,7 +7,7 @@ type arr ty -> ty -> ty.
 type nat ty.
 type bool ty.
 
-pred term i:term, o:ty.
+func term term -> ty.
 term (app HD ARG) TGT :- term HD (arr SRC TGT), term ARG SRC.
 term (lam F) (arr SRC TGT) :- pi x\ term x SRC => term (F x) TGT.
 term (uvar as X) T :- declare_constraint (term X T) [X].

--- a/tests/sources/chrGCD.elpi
+++ b/tests/sources/chrGCD.elpi
@@ -1,4 +1,4 @@
-pred gcd i:int, i:group.
+func gcd int, group.
 kind group type.
 type group-1 group.
 type group-2 group.

--- a/tests/sources/chrLEQ.elpi
+++ b/tests/sources/chrLEQ.elpi
@@ -1,9 +1,9 @@
-pred leq i:int, i:int.
+func leq int, int.
 leq (uvar as A) (uvar as B) :- !,  declare_constraint (leq A B) [A,B].
 leq A         (uvar as B) :- !,  declare_constraint (leq A B) [B].
 leq (uvar as A) B         :- !,  declare_constraint (leq A B) [A].
 
-pred ltn i:int, i:int.
+func ltn int, int.
 ltn (uvar as A) (uvar as B) :- !,  declare_constraint (ltn A B) [A,B].
 ltn A         (uvar as B) :- !,  declare_constraint (ltn A B) [B].
 ltn (uvar as A) B         :- !,  declare_constraint (ltn A B) [A].

--- a/tests/sources/chr_cut.elpi
+++ b/tests/sources/chr_cut.elpi
@@ -1,0 +1,5 @@
+func p.
+constraint p {
+    rule <=> (p,!).
+}
+main :- p.

--- a/tests/sources/chr_nokey.elpi
+++ b/tests/sources/chr_nokey.elpi
@@ -1,4 +1,4 @@
-type test int -> prop.
+func test int.
 
 main :- declare_constraint (test 1) [_], declare_constraint (test 2) [_].
 

--- a/tests/sources/chr_nokey2.elpi
+++ b/tests/sources/chr_nokey2.elpi
@@ -1,5 +1,5 @@
-type foo prop.
-type bar any -> prop.
+func foo.
+func bar any.
 
 main :- declare_constraint foo [], declare_constraint (bar X) [], X.
 

--- a/tests/sources/chr_sem.elpi
+++ b/tests/sources/chr_sem.elpi
@@ -1,4 +1,7 @@
-type a, b, c, d prop.
+func a.
+func b.
+func c.
+func d.
 main :- declare_constraint a [_],
         declare_constraint b [_],
         declare_constraint b [_],

--- a/tests/sources/chr_with_hypotheses.elpi
+++ b/tests/sources/chr_with_hypotheses.elpi
@@ -1,13 +1,12 @@
-pred p i:int.
-pred trig.
+func p int.
+func trig.
+func q int.
+func trig1.
 
-pred q i:int.
-pred trig1.
+func acc int.
+func acc1 int.
 
-pred acc i:int.
-pred acc1 i:int.
-
-pred tester i:string, i:list prop, i:int.
+func tester string, list prop, int.
 tester Str Ctx Var :-
   print "In" Str "ctx is" Ctx,
   print "Doing acc with" Var,
@@ -33,14 +32,14 @@ constraint acc ?- q trig1 {
 
 pred q&trig1.
 q&trig1 :-
-  acc 4 => declare_constraint (q 4) [_], declare_constraint trig1 [_],
-  acc 4 => declare_constraint (q 5) [_], not (declare_constraint trig1 [_]).
+  (acc 4 =!=> declare_constraint (q 4) [_]), declare_constraint trig1 [_],
+  (acc 4 =!=> declare_constraint (q 5) [_]), not (declare_constraint trig1 [_]).
 
 pred p&trig.
 p&trig :-
-  acc 3 => acc1 3 => declare_constraint (p 3) [_], declare_constraint trig [_],
-  acc 4 => acc1 5 => declare_constraint (p 4) [_], not (declare_constraint trig [_]), 
-  acc 2 => acc1 4 => declare_constraint (p 4) [_], declare_constraint trig [_].
+  (acc 3 =!=> acc1 3 =!=> declare_constraint (p 3) [_]), declare_constraint trig [_],
+  (acc 4 =!=> acc1 5 =!=> declare_constraint (p 4) [_]), not (declare_constraint trig [_]), 
+  (acc 2 =!=> acc1 4 =!=> declare_constraint (p 4) [_]), declare_constraint trig [_].
 
 main :-
   p&trig, q&trig1.

--- a/tests/sources/ctx_loading.elpi
+++ b/tests/sources/ctx_loading.elpi
@@ -10,7 +10,12 @@ type p prop -> prop.
 type a prop.
 type b prop.
 type c prop.
-type d1, d2, d3, d11, d22, d33 prop -> prop.
+func d1 prop.
+func d2 prop.
+func d3 prop.
+func d11 prop.
+func d22 prop.
+func d33 prop.
 
 main :-
   (p b ==> p a ==> p W), !, W = a,

--- a/tests/sources/even-odd.elpi
+++ b/tests/sources/even-odd.elpi
@@ -2,19 +2,19 @@ kind nat type.
 type zero nat.
 type succ nat -> nat.
 
-pred odd i:nat.
-pred even i:nat.
-pred double i:nat, o:nat.
+func odd nat.
+func even nat.
+func double nat -> nat.
 
 even zero.
 odd (succ X) :- even X.
 even (succ X) :- odd X.
-even X :- var X, declare_constraint (even X) [X].
-odd X :- var X, declare_constraint (odd X) [X].
+even (uvar as X) :- declare_constraint (even X) [X].
+odd (uvar as X) :- declare_constraint (odd X) [X].
 
 double zero zero.
 double (succ X) (succ (succ Y)) :- double X Y.
-double X Y :- var X, declare_constraint (double X Y) [X].
+double (uvar as X) Y :- declare_constraint (double X Y) [X].
 
 main :- odd X, not(X = zero), not(double Z X).
 

--- a/tests/sources/llamchr.elpi
+++ b/tests/sources/llamchr.elpi
@@ -1,7 +1,7 @@
 kind tm type.
 symbol true : tm.
 symbol false : tm.
-pred term i:tm, o:tm.
+func term tm -> tm.
 
 term (app X Y) B :- term X (arr A B), term Y A.
 term (lam A F) (arr A B) :- pi x\ term x A => term (F x) B.
@@ -41,7 +41,7 @@ watch X :- print "watch" X.
 main :- 
   % this is tricky becasuse X sees w, so CHR has to deal with a dirty context
   pi w\ (sigma X A B C A' B' T1 T2 \ pi v\
-    term b2n (arr bool nat) =>
+    term b2n (arr bool nat) =!=>
       (T1 = (lam _ x \ lam _ y\ X x y),
        T2 = (lam _ x \ lam _ y\ X y x),
        term T1 (arr A (arr B nat)),

--- a/tests/sources/mk-evar-meta.elpi
+++ b/tests/sources/mk-evar-meta.elpi
@@ -2,7 +2,7 @@ main :-
   (pi x y z\ sigma X XL\ mk-uvar [y] X XL, print "1)" X "/" XL, var XL X [y]).
 
   
-type mk-uvar list A -> B -> C -> o.
+func mk-uvar list A, B, C.
 mk-uvar L U UL :- declare_constraint (mk-uvar L U UL) [_].
 
 constraint mk-uvar {

--- a/tests/sources/polymorphic_variants.elpi
+++ b/tests/sources/polymorphic_variants.elpi
@@ -15,12 +15,12 @@ type app i -> i -> i.
 type check list (list i -> i) -> list i -> list i -> prop.
 type union list i -> list i -> list i -> prop.
 type propagate list prop -> list prop -> prop -> prop.
-type mem_ list i -> i -> prop.
-type mem list i -> i -> prop.
+func mem_ list i, i.
+func mem list i, i.
 type main2 prop.
 type main1 prop.
-type is_subset_ list i -> list i -> prop.
-type is_subset list i -> list i -> prop.
+func is_subset_ list i, list i.
+func is_subset list i, list i.
 type is_ground list i -> prop.
 type inter list i -> list i -> list i -> prop.
 type inputs list i -> list i -> prop.
@@ -55,7 +55,7 @@ check_domain B T :- inputs B I, is_subset T I.
 %is_subset A B :- print (is_subset A B), fail.
 is_subset A B :- var A, !, declare_constraint (is_subset A B) [A].
 is_subset A B :- var B, !, declare_constraint (is_subset A B) [B].
-is_subset A B :- is_subset_ A B.
+is_subset A B :- is_subset_ A B, !.
 is_subset_ [] _.
 is_subset_ [X|TL] TL1 :- mem TL1 X, is_subset TL TL1.
 

--- a/tests/sources/trace-w/main.elpi
+++ b/tests/sources/trace-w/main.elpi
@@ -57,26 +57,26 @@ specialize (mono T) T.
 specialize (all any F) T :- specialize (F Fresh_) T.
 specialize (all eqt F) T :- specialize (F Fresh) T, eqbar Fresh.
 
-pred eqbar i:tye.
+func eqbar tye.
 
-eqbar bool.
-eqbar int.
-eqbar (list A) :- eqbar A.
-eqbar (pair A B) :- eqbar A, eqbar B.
+eqbar bool :- !.
+eqbar int :- !.
+eqbar (list A) :- !, eqbar A.
+eqbar (pair A B) :- !, eqbar A, eqbar B.
 
-eqbar T :- var T, new_constraint (eqbar T) [T,_].
+eqbar (uvar as T) :- !, new_constraint (eqbar T) [T,_].
 
-eqbar T :- eqtype-error T.
+eqbar T :- eqtype-error T, !.
 
 %%%%%%%%%%%%% type schema introduction %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % theta carries the list of type variables for which eqbar has to hold
-pred theta i:list tye.
+func theta list tye.
 
 theta L :- new_constraint (theta L) [_].
 
 % gammabar is not a real constraint, but rather a 
-pred gammabar i:ty, o:ty.
+func gammabar ty -> ty.
 
 gammabar (mono T) TS :-
   new_constraint (gammabar (mono T) TS) [_].
@@ -154,7 +154,7 @@ assert T TY ETY :- print "KO: term (" T ") has type (" TY ") but its context exp
 pred eqtype-error i:tye.
 eqtype-error T :- print "KO: type (" T ") has no equality\n", halt.
 
-pred new_constraint i:prop, i:A.
+func new_constraint (func), A.
 new_constraint P X :- declare_constraint P X.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/tests/sources/trace.elab.json
+++ b/tests/sources/trace.elab.json
@@ -265,7 +265,7 @@
                       "filename": "builtin.elpi",
                       "line": 86,
                       "column": 0,
-                      "character": 1488
+                      "character": 1473
                     }
                   ]
                 }
@@ -291,7 +291,7 @@
                     "filename": "builtin.elpi",
                     "line": 86,
                     "column": 0,
-                    "character": 1488
+                    "character": 1473
                   }
                 ]
               }
@@ -399,7 +399,7 @@
                     "filename": "builtin.elpi",
                     "line": 86,
                     "column": 0,
-                    "character": 1488
+                    "character": 1473
                   }
                 ]
               }
@@ -508,7 +508,7 @@
                     "filename": "builtin.elpi",
                     "line": 86,
                     "column": 0,
-                    "character": 1488
+                    "character": 1473
                   }
                 ]
               }

--- a/tests/sources/trace.json
+++ b/tests/sources/trace.json
@@ -24,8 +24,8 @@
 {"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["is","1 is 2 + 3"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 86, column 0, characters 1488-1506:"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 86, column 0, characters 1488-1506:","(A1 is A0) :- (calc A0 A1)."]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 86, column 0, characters 1473-1491:"]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 86, column 0, characters 1473-1491:","(A1 is A0) :- (calc A0 A1)."]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := 1"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := 2 + 3"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["8"]}

--- a/tests/sources/trace_chr.elab.json
+++ b/tests/sources/trace_chr.elab.json
@@ -28,7 +28,7 @@
                       "filename": "tests/sources/trace_chr.elpi",
                       "line": 19,
                       "column": 0,
-                      "character": 353
+                      "character": 349
                     }
                   ]
                 }
@@ -57,7 +57,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -93,7 +93,7 @@
                       "filename": "tests/sources/trace_chr.elpi",
                       "line": 16,
                       "column": 0,
-                      "character": 252
+                      "character": 248
                     }
                   ]
                 }
@@ -122,7 +122,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 16,
                     "column": 0,
-                    "character": 252
+                    "character": 248
                   }
                 ]
               }
@@ -141,7 +141,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -180,7 +180,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 16,
                     "column": 0,
-                    "character": 252
+                    "character": 248
                   }
                 ]
               }
@@ -199,7 +199,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -238,7 +238,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -291,7 +291,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -392,7 +392,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -428,7 +428,7 @@
                       "filename": "tests/sources/trace_chr.elpi",
                       "line": 14,
                       "column": 0,
-                      "character": 230
+                      "character": 226
                     }
                   ]
                 }
@@ -452,7 +452,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 14,
                     "column": 0,
-                    "character": 230
+                    "character": 226
                   }
                 ]
               }
@@ -481,7 +481,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 16,
                     "column": 0,
-                    "character": 252
+                    "character": 248
                   }
                 ]
               }
@@ -500,7 +500,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -536,7 +536,7 @@
                       "filename": "tests/sources/trace_chr.elpi",
                       "line": 17,
                       "column": 0,
-                      "character": 303
+                      "character": 299
                     }
                   ]
                 }
@@ -565,7 +565,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 17,
                     "column": 0,
-                    "character": 303
+                    "character": 299
                   }
                 ]
               }
@@ -584,7 +584,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 14,
                     "column": 0,
-                    "character": 230
+                    "character": 226
                   }
                 ]
               }
@@ -613,7 +613,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 16,
                     "column": 0,
-                    "character": 252
+                    "character": 248
                   }
                 ]
               }
@@ -632,7 +632,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -671,7 +671,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 17,
                     "column": 0,
-                    "character": 303
+                    "character": 299
                   }
                 ]
               }
@@ -690,7 +690,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 14,
                     "column": 0,
-                    "character": 230
+                    "character": 226
                   }
                 ]
               }
@@ -719,7 +719,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 16,
                     "column": 0,
-                    "character": 252
+                    "character": 248
                   }
                 ]
               }
@@ -738,7 +738,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -821,7 +821,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -857,7 +857,7 @@
                       "filename": "tests/sources/trace_chr.elpi",
                       "line": 16,
                       "column": 0,
-                      "character": 252
+                      "character": 248
                     }
                   ]
                 }
@@ -886,7 +886,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 16,
                     "column": 0,
-                    "character": 252
+                    "character": 248
                   }
                 ]
               }
@@ -924,7 +924,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -963,7 +963,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 16,
                     "column": 0,
-                    "character": 252
+                    "character": 248
                   }
                 ]
               }
@@ -1001,7 +1001,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }
@@ -1098,7 +1098,7 @@
                                     "filename": "tests/sources/trace_chr.elpi",
                                     "line": 13,
                                     "column": 0,
-                                    "character": 209
+                                    "character": 205
                                   }
                                 ]
                               }
@@ -1124,7 +1124,7 @@
                                   "filename": "tests/sources/trace_chr.elpi",
                                   "line": 13,
                                   "column": 0,
-                                  "character": 209
+                                  "character": 205
                                 }
                               ]
                             }
@@ -1160,7 +1160,7 @@
                                     "filename": "tests/sources/trace_chr.elpi",
                                     "line": 11,
                                     "column": 0,
-                                    "character": 200
+                                    "character": 196
                                   }
                                 ]
                               }
@@ -1184,7 +1184,7 @@
                                   "filename": "tests/sources/trace_chr.elpi",
                                   "line": 11,
                                   "column": 0,
-                                  "character": 200
+                                  "character": 196
                                 }
                               ]
                             }
@@ -1203,7 +1203,7 @@
                                   "filename": "tests/sources/trace_chr.elpi",
                                   "line": 13,
                                   "column": 0,
-                                  "character": 209
+                                  "character": 205
                                 }
                               ]
                             }
@@ -1352,7 +1352,7 @@
                     "filename": "tests/sources/trace_chr.elpi",
                     "line": 19,
                     "column": 0,
-                    "character": 353
+                    "character": 349
                   }
                 ]
               }

--- a/tests/sources/trace_chr.elpi
+++ b/tests/sources/trace_chr.elpi
@@ -6,8 +6,8 @@ kind nat type.
 type s nat -> nat.
 type z nat.
 
-pred even i:nat.
-pred odd i:nat.
+func even nat.
+func odd nat.
 even z.
 
 odd (s X) :- even X.

--- a/tests/sources/trace_chr.json
+++ b/tests/sources/trace_chr.json
@@ -1,8 +1,8 @@
 {"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 19, column 0, characters 353-424:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 19, column 0, characters 353-424:","main :- (even A0), (declare_constraint true A0), (A0 = s A1), \n (not (even A1))."]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 19, column 0, characters 349-420:"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 19, column 0, characters 349-420:","main :- (even A0), (declare_constraint true A0), (A0 = s A1), \n (not (even A1))."]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["even X0"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
@@ -14,8 +14,8 @@
 {"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["even","even X0"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 252-301:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 252-301:","(even (as uvar A0)) :- (declare_constraint (even A0) A0)."]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:","(even (as uvar A0)) :- (declare_constraint (even A0) A0)."]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := X0"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["9"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["declare_constraint (even X0) X0"]}
@@ -49,16 +49,16 @@
 {"step" : 7,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["even","even (s X1)"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 14, column 0, characters 230-249:"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 14, column 0, characters 230-249:","(even (s A0)) :- (odd A0)."]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 14, column 0, characters 226-245:"]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 14, column 0, characters 226-245:","(even (s A0)) :- (odd A0)."]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := X1"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["12"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["odd X1"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["odd","odd X1"]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 17, column 0, characters 303-350:"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 17, column 0, characters 303-350:","(odd (as uvar A0)) :- (declare_constraint (odd A0) A0)."]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 17, column 0, characters 299-346:"]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 17, column 0, characters 299-346:","(odd (as uvar A0)) :- (declare_constraint (odd A0) A0)."]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := X1"]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["13"]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["declare_constraint (odd X1) X1"]}
@@ -83,8 +83,8 @@
 {"step" : 11,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["even","even X1"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 252-301:"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 252-301:","(even (as uvar A0)) :- (declare_constraint (even A0) A0)."]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:"]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:","(even (as uvar A0)) :- (declare_constraint (even A0) A0)."]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := X1"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["18"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["declare_constraint (even X1) X1"]}
@@ -108,16 +108,16 @@
 {"step" : 0,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:newgoal","payload" : ["odd (s z)"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:curgoal","payload" : ["odd","odd (s z)"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 13, column 0, characters 209-228:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 13, column 0, characters 209-228:","(odd (s A0)) :- (even A0)."]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 13, column 0, characters 205-224:"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 13, column 0, characters 205-224:","(odd (s A0)) :- (even A0)."]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 2,"name" : "user:assign","payload" : ["A0 := z"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:subgoal","payload" : ["22"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:newgoal","payload" : ["even z"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:curgoal","payload" : ["even","even z"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 11, column 0, characters 200-206:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 11, column 0, characters 200-206:","(even z) :- ."]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 11, column 0, characters 196-202:"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 11, column 0, characters 196-202:","(even z) :- ."]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["23"]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["_ => fail"]}

--- a/tests/sources/trace_w.elab.json
+++ b/tests/sources/trace_w.elab.json
@@ -28,7 +28,7 @@
                       "filename": "tests/sources/trace-w/main.elpi",
                       "line": 177,
                       "column": 0,
-                      "character": 4807
+                      "character": 4824
                     }
                   ]
                 }
@@ -52,7 +52,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -88,7 +88,7 @@
                       "filename": "tests/sources/trace-w/main.elpi",
                       "line": 175,
                       "column": 0,
-                      "character": 4768
+                      "character": 4785
                     }
                   ]
                 }
@@ -115,7 +115,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -134,7 +134,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -170,7 +170,7 @@
                       "filename": "tests/sources/trace-w/main.elpi",
                       "line": 184,
                       "column": 0,
-                      "character": 4931
+                      "character": 4948
                     }
                   ]
                 }
@@ -199,7 +199,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 184,
                     "column": 0,
-                    "character": 4931
+                    "character": 4948
                   }
                 ]
               }
@@ -218,7 +218,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -237,7 +237,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -273,7 +273,7 @@
                       "filename": "tests/sources/trace-w/main.elpi",
                       "line": 167,
                       "column": 0,
-                      "character": 4648
+                      "character": 4665
                     }
                   ]
                 }
@@ -318,7 +318,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -337,7 +337,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -356,7 +356,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -407,7 +407,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -426,7 +426,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -445,7 +445,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -481,7 +481,7 @@
                       "filename": "tests/sources/trace-w/main.elpi",
                       "line": 76,
                       "column": 0,
-                      "character": 1761
+                      "character": 1782
                     }
                   ]
                 }
@@ -507,7 +507,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 76,
                     "column": 0,
-                    "character": 1761
+                    "character": 1782
                   }
                 ]
               }
@@ -526,7 +526,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -545,7 +545,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -564,7 +564,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -600,7 +600,7 @@
                       "filename": "tests/sources/trace-w/main.elpi",
                       "line": 158,
                       "column": 0,
-                      "character": 4357
+                      "character": 4374
                     }
                   ]
                 }
@@ -631,7 +631,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 158,
                     "column": 0,
-                    "character": 4357
+                    "character": 4374
                   }
                 ]
               }
@@ -650,7 +650,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 76,
                     "column": 0,
-                    "character": 1761
+                    "character": 1782
                   }
                 ]
               }
@@ -669,7 +669,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -688,7 +688,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -707,7 +707,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -746,7 +746,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 158,
                     "column": 0,
-                    "character": 4357
+                    "character": 4374
                   }
                 ]
               }
@@ -765,7 +765,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 76,
                     "column": 0,
-                    "character": 1761
+                    "character": 1782
                   }
                 ]
               }
@@ -784,7 +784,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -803,7 +803,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -822,7 +822,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -913,7 +913,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -932,7 +932,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -951,7 +951,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -1057,7 +1057,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -1076,7 +1076,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -1095,7 +1095,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -1189,7 +1189,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -1208,7 +1208,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -1227,7 +1227,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -1321,7 +1321,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -1340,7 +1340,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -1359,7 +1359,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -1470,7 +1470,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -1489,7 +1489,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -1508,7 +1508,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -1544,7 +1544,7 @@
                       "filename": "tests/sources/trace-w/main.elpi",
                       "line": 81,
                       "column": 0,
-                      "character": 1881
+                      "character": 1900
                     }
                   ]
                 }
@@ -1575,7 +1575,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 81,
                     "column": 0,
-                    "character": 1881
+                    "character": 1900
                   }
                 ]
               }
@@ -1613,7 +1613,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -1632,7 +1632,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -1651,7 +1651,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -1687,7 +1687,7 @@
                       "filename": "tests/sources/trace-w/main.elpi",
                       "line": 158,
                       "column": 0,
-                      "character": 4357
+                      "character": 4374
                     }
                   ]
                 }
@@ -1719,7 +1719,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 158,
                     "column": 0,
-                    "character": 4357
+                    "character": 4374
                   }
                 ]
               }
@@ -1738,7 +1738,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 81,
                     "column": 0,
-                    "character": 1881
+                    "character": 1900
                   }
                 ]
               }
@@ -1776,7 +1776,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -1795,7 +1795,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -1814,7 +1814,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -1856,7 +1856,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 158,
                     "column": 0,
-                    "character": 4357
+                    "character": 4374
                   }
                 ]
               }
@@ -1875,7 +1875,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 81,
                     "column": 0,
-                    "character": 1881
+                    "character": 1900
                   }
                 ]
               }
@@ -1913,7 +1913,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -1932,7 +1932,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -1951,7 +1951,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -1979,7 +1979,7 @@
                 "filename": "tests/sources/trace-w/main.elpi",
                 "line": 85,
                 "column": 36,
-                "character": 2008
+                "character": 2027
               },
               "chr_condition_cards": [
                 {
@@ -2017,7 +2017,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 97,
                                     "column": 0,
-                                    "character": 2327
+                                    "character": 2346
                                   }
                                 ]
                               }
@@ -2066,7 +2066,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -2102,7 +2102,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 105,
                                     "column": 0,
-                                    "character": 2618
+                                    "character": 2637
                                   }
                                 ]
                               }
@@ -2138,7 +2138,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -2157,7 +2157,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -2193,7 +2193,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 117,
                                     "column": 0,
-                                    "character": 3004
+                                    "character": 3023
                                   }
                                 ]
                               }
@@ -2231,7 +2231,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -2250,7 +2250,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -2269,7 +2269,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -2305,7 +2305,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 118,
                                     "column": 0,
-                                    "character": 3055
+                                    "character": 3074
                                   }
                                 ]
                               }
@@ -2338,7 +2338,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 118,
                                   "column": 0,
-                                  "character": 3055
+                                  "character": 3074
                                 }
                               ]
                             }
@@ -2357,7 +2357,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -2376,7 +2376,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -2395,7 +2395,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -2431,7 +2431,7 @@
                                     "filename": "builtin.elpi",
                                     "line": 526,
                                     "column": 0,
-                                    "character": 13710
+                                    "character": 13695
                                   }
                                 ]
                               }
@@ -2468,7 +2468,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 526,
                                   "column": 0,
-                                  "character": 13710
+                                  "character": 13695
                                 }
                               ]
                             }
@@ -2487,7 +2487,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 118,
                                   "column": 0,
-                                  "character": 3055
+                                  "character": 3074
                                 }
                               ]
                             }
@@ -2506,7 +2506,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -2525,7 +2525,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -2544,7 +2544,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -2580,7 +2580,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 148,
                                     "column": 0,
-                                    "character": 4013
+                                    "character": 4032
                                   }
                                 ]
                               }
@@ -2612,7 +2612,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 148,
                                   "column": 0,
-                                  "character": 4013
+                                  "character": 4032
                                 }
                               ]
                             }
@@ -2631,7 +2631,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 526,
                                   "column": 0,
-                                  "character": 13710
+                                  "character": 13695
                                 }
                               ]
                             }
@@ -2650,7 +2650,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 118,
                                   "column": 0,
-                                  "character": 3055
+                                  "character": 3074
                                 }
                               ]
                             }
@@ -2669,7 +2669,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -2688,7 +2688,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -2707,7 +2707,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -2744,7 +2744,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 148,
                                   "column": 0,
-                                  "character": 4013
+                                  "character": 4032
                                 }
                               ]
                             }
@@ -2763,7 +2763,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 526,
                                   "column": 0,
-                                  "character": 13710
+                                  "character": 13695
                                 }
                               ]
                             }
@@ -2782,7 +2782,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 118,
                                   "column": 0,
-                                  "character": 3055
+                                  "character": 3074
                                 }
                               ]
                             }
@@ -2801,7 +2801,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -2820,7 +2820,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -2839,7 +2839,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -2875,7 +2875,7 @@
                                     "filename": "builtin.elpi",
                                     "line": 527,
                                     "column": 0,
-                                    "character": 13731
+                                    "character": 13716
                                   }
                                 ]
                               }
@@ -2908,7 +2908,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 527,
                                   "column": 0,
-                                  "character": 13731
+                                  "character": 13716
                                 }
                               ]
                             }
@@ -2927,7 +2927,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 118,
                                   "column": 0,
-                                  "character": 3055
+                                  "character": 3074
                                 }
                               ]
                             }
@@ -2946,7 +2946,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -2965,7 +2965,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -2984,7 +2984,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -3037,7 +3037,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 527,
                                   "column": 0,
-                                  "character": 13731
+                                  "character": 13716
                                 }
                               ]
                             }
@@ -3056,7 +3056,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 118,
                                   "column": 0,
-                                  "character": 3055
+                                  "character": 3074
                                 }
                               ]
                             }
@@ -3075,7 +3075,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -3094,7 +3094,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -3113,7 +3113,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -3149,7 +3149,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 118,
                                     "column": 0,
-                                    "character": 3055
+                                    "character": 3074
                                   }
                                 ]
                               }
@@ -3182,7 +3182,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 118,
                                   "column": 0,
-                                  "character": 3055
+                                  "character": 3074
                                 }
                               ]
                             }
@@ -3201,7 +3201,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -3220,7 +3220,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -3239,7 +3239,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -3275,7 +3275,7 @@
                                     "filename": "builtin.elpi",
                                     "line": 526,
                                     "column": 0,
-                                    "character": 13710
+                                    "character": 13695
                                   }
                                 ]
                               }
@@ -3317,7 +3317,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 526,
                                   "column": 0,
-                                  "character": 13710
+                                  "character": 13695
                                 }
                               ]
                             }
@@ -3336,7 +3336,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 118,
                                   "column": 0,
-                                  "character": 3055
+                                  "character": 3074
                                 }
                               ]
                             }
@@ -3355,7 +3355,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -3374,7 +3374,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -3393,7 +3393,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -3429,7 +3429,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 148,
                                     "column": 0,
-                                    "character": 4013
+                                    "character": 4032
                                   }
                                 ]
                               }
@@ -3461,7 +3461,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 148,
                                   "column": 0,
-                                  "character": 4013
+                                  "character": 4032
                                 }
                               ]
                             }
@@ -3480,7 +3480,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 526,
                                   "column": 0,
-                                  "character": 13710
+                                  "character": 13695
                                 }
                               ]
                             }
@@ -3499,7 +3499,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 118,
                                   "column": 0,
-                                  "character": 3055
+                                  "character": 3074
                                 }
                               ]
                             }
@@ -3518,7 +3518,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -3537,7 +3537,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -3556,7 +3556,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -3592,7 +3592,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 143,
                                     "column": 0,
-                                    "character": 3884
+                                    "character": 3903
                                   }
                                 ]
                               }
@@ -3619,7 +3619,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 143,
                                   "column": 0,
-                                  "character": 3884
+                                  "character": 3903
                                 }
                               ]
                             }
@@ -3638,7 +3638,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 148,
                                   "column": 0,
-                                  "character": 4013
+                                  "character": 4032
                                 }
                               ]
                             }
@@ -3657,7 +3657,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 526,
                                   "column": 0,
-                                  "character": 13710
+                                  "character": 13695
                                 }
                               ]
                             }
@@ -3676,7 +3676,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 118,
                                   "column": 0,
-                                  "character": 3055
+                                  "character": 3074
                                 }
                               ]
                             }
@@ -3695,7 +3695,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -3714,7 +3714,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -3733,7 +3733,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -3767,7 +3767,7 @@
                                 "filename": "tests/sources/trace-w/main.elpi",
                                 "line": 144,
                                 "column": 0,
-                                "character": 3903
+                                "character": 3922
                               }
                             ]
                           }
@@ -3798,7 +3798,7 @@
                                 "filename": "builtin.elpi",
                                 "line": 527,
                                 "column": 0,
-                                "character": 13731
+                                "character": 13716
                               }
                             ]
                           }
@@ -3848,7 +3848,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 526,
                                   "column": 0,
-                                  "character": 13710
+                                  "character": 13695
                                 }
                               ]
                             }
@@ -3867,7 +3867,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 118,
                                   "column": 0,
-                                  "character": 3055
+                                  "character": 3074
                                 }
                               ]
                             }
@@ -3886,7 +3886,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 117,
                                   "column": 0,
-                                  "character": 3004
+                                  "character": 3023
                                 }
                               ]
                             }
@@ -3905,7 +3905,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 105,
                                   "column": 0,
-                                  "character": 2618
+                                  "character": 2637
                                 }
                               ]
                             }
@@ -3924,7 +3924,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -3960,7 +3960,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 109,
                                     "column": 0,
-                                    "character": 2762
+                                    "character": 2781
                                   }
                                 ]
                               }
@@ -3987,7 +3987,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 109,
                                   "column": 0,
-                                  "character": 2762
+                                  "character": 2781
                                 }
                               ]
                             }
@@ -4006,7 +4006,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -4042,7 +4042,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 139,
                                     "column": 0,
-                                    "character": 3770
+                                    "character": 3789
                                   }
                                 ]
                               }
@@ -4083,7 +4083,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 139,
                                   "column": 0,
-                                  "character": 3770
+                                  "character": 3789
                                 }
                               ]
                             }
@@ -4102,7 +4102,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -4193,7 +4193,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 139,
                                   "column": 0,
-                                  "character": 3770
+                                  "character": 3789
                                 }
                               ]
                             }
@@ -4212,7 +4212,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -4248,7 +4248,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 148,
                                     "column": 0,
-                                    "character": 4013
+                                    "character": 4032
                                   }
                                 ]
                               }
@@ -4280,7 +4280,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 148,
                                   "column": 0,
-                                  "character": 4013
+                                  "character": 4032
                                 }
                               ]
                             }
@@ -4318,7 +4318,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 139,
                                   "column": 0,
-                                  "character": 3770
+                                  "character": 3789
                                 }
                               ]
                             }
@@ -4337,7 +4337,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -4374,7 +4374,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 148,
                                   "column": 0,
-                                  "character": 4013
+                                  "character": 4032
                                 }
                               ]
                             }
@@ -4412,7 +4412,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 139,
                                   "column": 0,
-                                  "character": 3770
+                                  "character": 3789
                                 }
                               ]
                             }
@@ -4431,7 +4431,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -4510,7 +4510,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 139,
                                   "column": 0,
-                                  "character": 3770
+                                  "character": 3789
                                 }
                               ]
                             }
@@ -4529,7 +4529,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -4563,7 +4563,7 @@
                                 "filename": "tests/sources/trace-w/main.elpi",
                                 "line": 140,
                                 "column": 0,
-                                "character": 3820
+                                "character": 3839
                               }
                             ]
                           }
@@ -4596,7 +4596,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 138,
                                     "column": 0,
-                                    "character": 3754
+                                    "character": 3773
                                   }
                                 ]
                               }
@@ -4620,7 +4620,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 138,
                                   "column": 0,
-                                  "character": 3754
+                                  "character": 3773
                                 }
                               ]
                             }
@@ -4639,7 +4639,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 139,
                                   "column": 0,
-                                  "character": 3770
+                                  "character": 3789
                                 }
                               ]
                             }
@@ -4658,7 +4658,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -4694,7 +4694,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 123,
                                     "column": 0,
-                                    "character": 3278
+                                    "character": 3297
                                   }
                                 ]
                               }
@@ -4736,7 +4736,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -4755,7 +4755,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -4791,7 +4791,7 @@
                                     "filename": "builtin.elpi",
                                     "line": 526,
                                     "column": 0,
-                                    "character": 13710
+                                    "character": 13695
                                   }
                                 ]
                               }
@@ -4828,7 +4828,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 526,
                                   "column": 0,
-                                  "character": 13710
+                                  "character": 13695
                                 }
                               ]
                             }
@@ -4847,7 +4847,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -4866,7 +4866,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -4902,7 +4902,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 148,
                                     "column": 0,
-                                    "character": 4013
+                                    "character": 4032
                                   }
                                 ]
                               }
@@ -4934,7 +4934,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 148,
                                   "column": 0,
-                                  "character": 4013
+                                  "character": 4032
                                 }
                               ]
                             }
@@ -4953,7 +4953,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 526,
                                   "column": 0,
-                                  "character": 13710
+                                  "character": 13695
                                 }
                               ]
                             }
@@ -4972,7 +4972,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -4991,7 +4991,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -5028,7 +5028,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 148,
                                   "column": 0,
-                                  "character": 4013
+                                  "character": 4032
                                 }
                               ]
                             }
@@ -5047,7 +5047,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 526,
                                   "column": 0,
-                                  "character": 13710
+                                  "character": 13695
                                 }
                               ]
                             }
@@ -5066,7 +5066,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -5085,7 +5085,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -5121,7 +5121,7 @@
                                     "filename": "builtin.elpi",
                                     "line": 527,
                                     "column": 0,
-                                    "character": 13731
+                                    "character": 13716
                                   }
                                 ]
                               }
@@ -5147,7 +5147,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 527,
                                   "column": 0,
-                                  "character": 13731
+                                  "character": 13716
                                 }
                               ]
                             }
@@ -5166,7 +5166,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -5185,7 +5185,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -5236,7 +5236,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 527,
                                   "column": 0,
-                                  "character": 13731
+                                  "character": 13716
                                 }
                               ]
                             }
@@ -5255,7 +5255,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -5274,7 +5274,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -5330,7 +5330,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -5349,7 +5349,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -5414,7 +5414,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -5433,7 +5433,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -5469,7 +5469,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 122,
                                     "column": 0,
-                                    "character": 3242
+                                    "character": 3261
                                   }
                                 ]
                               }
@@ -5505,7 +5505,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 122,
                                   "column": 0,
-                                  "character": 3242
+                                  "character": 3261
                                 }
                               ]
                             }
@@ -5536,7 +5536,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -5555,7 +5555,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -5591,7 +5591,7 @@
                                     "filename": "tests/sources/trace-w/main.elpi",
                                     "line": 130,
                                     "column": 0,
-                                    "character": 3456
+                                    "character": 3475
                                   }
                                 ]
                               }
@@ -5628,7 +5628,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 130,
                                   "column": 0,
-                                  "character": 3456
+                                  "character": 3475
                                 }
                               ]
                             }
@@ -5647,7 +5647,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 122,
                                   "column": 0,
-                                  "character": 3242
+                                  "character": 3261
                                 }
                               ]
                             }
@@ -5678,7 +5678,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -5697,7 +5697,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -5760,7 +5760,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 130,
                                   "column": 0,
-                                  "character": 3456
+                                  "character": 3475
                                 }
                               ]
                             }
@@ -5779,7 +5779,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 122,
                                   "column": 0,
-                                  "character": 3242
+                                  "character": 3261
                                 }
                               ]
                             }
@@ -5810,7 +5810,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -5829,7 +5829,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -5892,7 +5892,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 130,
                                   "column": 0,
-                                  "character": 3456
+                                  "character": 3475
                                 }
                               ]
                             }
@@ -5911,7 +5911,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 122,
                                   "column": 0,
-                                  "character": 3242
+                                  "character": 3261
                                 }
                               ]
                             }
@@ -5942,7 +5942,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 123,
                                   "column": 0,
-                                  "character": 3278
+                                  "character": 3297
                                 }
                               ]
                             }
@@ -5961,7 +5961,7 @@
                                   "filename": "tests/sources/trace-w/main.elpi",
                                   "line": 97,
                                   "column": 0,
-                                  "character": 2327
+                                  "character": 2346
                                 }
                               ]
                             }
@@ -6137,7 +6137,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -6156,7 +6156,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -6175,7 +6175,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -6255,7 +6255,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -6274,7 +6274,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -6293,7 +6293,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -6408,7 +6408,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -6427,7 +6427,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -6446,7 +6446,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -6589,7 +6589,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -6608,7 +6608,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -6627,7 +6627,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -6752,7 +6752,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -6771,7 +6771,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -6790,7 +6790,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -6936,7 +6936,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -6955,7 +6955,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -6974,7 +6974,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -7135,7 +7135,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -7154,7 +7154,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -7173,7 +7173,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -7476,7 +7476,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -7495,7 +7495,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -7514,7 +7514,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -7736,7 +7736,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -7755,7 +7755,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -7774,7 +7774,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -7928,7 +7928,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -7947,7 +7947,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -7966,7 +7966,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -8136,7 +8136,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -8155,7 +8155,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -8174,7 +8174,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -8316,7 +8316,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 163,
                   "column": 0,
-                  "character": 4490
+                  "character": 4507
                 }
               ]
             }
@@ -8334,7 +8334,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 164,
                   "column": 0,
-                  "character": 4561
+                  "character": 4578
                 }
               ]
             }
@@ -8352,7 +8352,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 163,
                   "column": 0,
-                  "character": 4490
+                  "character": 4507
                 }
               ]
             }
@@ -8370,7 +8370,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 164,
                   "column": 0,
-                  "character": 4561
+                  "character": 4578
                 }
               ]
             }
@@ -8424,7 +8424,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 163,
                   "column": 0,
-                  "character": 4490
+                  "character": 4507
                 }
               ]
             }
@@ -8442,7 +8442,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 164,
                   "column": 0,
-                  "character": 4561
+                  "character": 4578
                 }
               ]
             }
@@ -8460,7 +8460,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 163,
                   "column": 0,
-                  "character": 4490
+                  "character": 4507
                 }
               ]
             }
@@ -8478,7 +8478,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 164,
                   "column": 0,
-                  "character": 4561
+                  "character": 4578
                 }
               ]
             }
@@ -8514,7 +8514,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 163,
                   "column": 0,
-                  "character": 4490
+                  "character": 4507
                 }
               ]
             }
@@ -8532,7 +8532,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 164,
                   "column": 0,
-                  "character": 4561
+                  "character": 4578
                 }
               ]
             }
@@ -8568,7 +8568,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 163,
                   "column": 0,
-                  "character": 4490
+                  "character": 4507
                 }
               ]
             }
@@ -8586,7 +8586,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 164,
                   "column": 0,
-                  "character": 4561
+                  "character": 4578
                 }
               ]
             }
@@ -8622,7 +8622,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 163,
                   "column": 0,
-                  "character": 4490
+                  "character": 4507
                 }
               ]
             }
@@ -8640,7 +8640,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 164,
                   "column": 0,
-                  "character": 4561
+                  "character": 4578
                 }
               ]
             }
@@ -8676,7 +8676,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 163,
                   "column": 0,
-                  "character": 4490
+                  "character": 4507
                 }
               ]
             }
@@ -8694,7 +8694,7 @@
                   "filename": "tests/sources/trace-w/main.elpi",
                   "line": 164,
                   "column": 0,
-                  "character": 4561
+                  "character": 4578
                 }
               ]
             }
@@ -8742,7 +8742,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -8761,7 +8761,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -8780,7 +8780,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }
@@ -8831,7 +8831,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 167,
                     "column": 0,
-                    "character": 4648
+                    "character": 4665
                   }
                 ]
               }
@@ -8850,7 +8850,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 175,
                     "column": 0,
-                    "character": 4768
+                    "character": 4785
                   }
                 ]
               }
@@ -8869,7 +8869,7 @@
                     "filename": "tests/sources/trace-w/main.elpi",
                     "line": 177,
                     "column": 0,
-                    "character": 4807
+                    "character": 4824
                   }
                 ]
               }

--- a/tests/sources/trace_w.json
+++ b/tests/sources/trace_w.json
@@ -1,15 +1,15 @@
 {"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 177, column 0, characters 4807-4826:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 177, column 0, characters 4807-4826:","main :- (tests [2])."]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 177, column 0, characters 4824-4843:"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 177, column 0, characters 4824-4843:","main :- (tests [2])."]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["tests [2]"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["tests","tests [2]"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 175, column 0, characters 4768-4804:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 175, column 0, characters 4768-4804:","(tests [A0]) :- (test A0 A1), (typecheck A1)."]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 175, column 0, characters 4785-4821:"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 175, column 0, characters 4785-4821:","(tests [A0]) :- (test A0 A1), (typecheck A1)."]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := 2"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["test 2 X0"]}
@@ -18,14 +18,14 @@
 {"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["test","test 2 X0"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 184, column 0, characters 4931-4994:"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 184, column 0, characters 4931-4994:","(test 2 (let (lam (c0 \\ c0)) A0 (c0 \\ (app c0 (global []))))) :- ."]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 184, column 0, characters 4948-5011:"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 184, column 0, characters 4948-5011:","(test 2 (let (lam (c0 \\ c0)) A0 (c0 \\ (app c0 (global []))))) :- ."]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := let (lam c0 \\ c0) X1 c0 \\ app c0 (global [])"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["typecheck","typecheck (let (lam c0 \\ c0) X1 c0 \\ app c0 (global []))"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 167, column 0, characters 4648-4739:"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 167, column 0, characters 4648-4739:","(typecheck A0) :- (print Checking: A0), (theta []), (of A0 A1), !, \n (print A0  :  A1), print."]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 167, column 0, characters 4665-4756:"]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 167, column 0, characters 4665-4756:","(typecheck A0) :- (print Checking: A0), (theta []), (of A0 A1), !, \n (print A0  :  A1), print."]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := let (lam c0 \\ c0) X1 c0 \\ app c0 (global [])"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["8"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["print Checking: (let (lam c0 \\ c0) X1 c0 \\ app c0 (global []))"]}
@@ -46,16 +46,16 @@
 {"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["theta","theta []"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 76, column 0, characters 1761-1800:"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 76, column 0, characters 1761-1800:","(theta A0) :- (new_constraint (theta A0) [_])."]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 76, column 0, characters 1782-1821:"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 76, column 0, characters 1782-1821:","(theta A0) :- (new_constraint (theta A0) [_])."]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := []"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["14"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["new_constraint (theta []) [_]"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["new_constraint","new_constraint (theta []) [_]"]}
 {"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4357-4401:"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4357-4401:","(new_constraint A0 A1) :- (declare_constraint A0 A1)."]}
+{"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:"]}
+{"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:","(new_constraint A0 A1) :- (declare_constraint A0 A1)."]}
 {"step" : 7,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := theta []"]}
 {"step" : 7,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := [_]"]}
 {"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["15"]}
@@ -69,7 +69,7 @@
 {"step" : 8,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of (let (lam c0 \\ c0) X1 c0 \\ app c0 (global [])) X2"]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 11, column 0, characters 177-284:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:"]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 11, column 0, characters 177-284:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 11, column 0, characters 177-284:","(of (let A0 A2 A3) (mono A4)) :- (of A0 (mono A1)), (gammabar (mono A1) A2), \n (pi (c0 \\ (of c0 A2 => of (A3 c0) (mono A4))))."]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := lam c0 \\ c0"]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A2 := X1"]}
@@ -84,7 +84,7 @@
 {"step" : 9,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of (lam c0 \\ c0) (mono X4)"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 8, column 0, characters 100-174:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 8, column 0, characters 100-174:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 8, column 0, characters 100-174:","(of (lam A0) (mono (A2 ===> A1))) :- (pi (c0 \\\n                                       (of c0 (mono A2) =>\n                                         of (A0 c0) (mono A1))))."]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := c0 \\\nc0"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X4 := X5 ===> X6"]}
@@ -103,14 +103,14 @@
 {"step" : 12,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of c0 (mono X6)"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:12)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:"]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:12)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:12)\", line 1, column 0, characters 0-0:","(of c0 (mono X5)) :- ."]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X6 := X5"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["gammabar","gammabar (mono (X5 ===> X5)) X1"]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 81, column 0, characters 1881-1948:"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 81, column 0, characters 1881-1948:","(gammabar (mono A0) A1) :- (new_constraint (gammabar (mono A0) A1) [_])."]}
+{"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 81, column 0, characters 1900-1967:"]}
+{"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 81, column 0, characters 1900-1967:","(gammabar (mono A0) A1) :- (new_constraint (gammabar (mono A0) A1) [_])."]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := X5 ===> X5"]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := X1"]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["23"]}
@@ -118,8 +118,8 @@
 {"step" : 14,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["new_constraint","new_constraint (gammabar (mono (X5 ===> X5)) X1) [_]"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4357-4401:"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4357-4401:","(new_constraint A0 A1) :- (declare_constraint A0 A1)."]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:"]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:","(new_constraint A0 A1) :- (declare_constraint A0 A1)."]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := gammabar (mono (X5 ===> X5)) X1"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := [_]"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["24"]}
@@ -131,7 +131,7 @@
 {"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["25"]}
 {"step" : 16,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["gammabar (mono (X5 ===> X5)) X1"]}
 {"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:CHR:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 85, column 36, characters 2008-2180:","(theta A0) \\ (A1 ?- gammabar A2 A3) | (generalize A0 A1 A2 A4) <=> (A3 = A4)"]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:CHR:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 85, column 36, characters 2027-2199:","(theta A0) \\ (A1 ?- gammabar A2 A3) | (generalize A0 A1 A2 A4) <=> (A3 = A4)"]}
 {"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X0 := []"]}
 {"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X1 := mono (uvar frozen--402 [] ===> uvar frozen--402 [])"]}
 {"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A3 := uvar frozen--403 []"]}
@@ -139,8 +139,8 @@
 {"step" : 0,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["generalize [] [] (mono (uvar frozen--402 [] ===> uvar frozen--402 [])) X3"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["generalize","generalize [] [] (mono (uvar frozen--402 [] ===> uvar frozen--402 [])) X3"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 97, column 0, characters 2327-2502:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 97, column 0, characters 2327-2502:","(generalize A5 A2 (mono A0) A6) :- (free-ty (mono A0) [] A1), \n (free-gamma A2 [] A3), (filter A1 (c0 \\ (not (mem A3 c0))) A4), \n (bind A4 A5 A0 A6)."]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 97, column 0, characters 2346-2521:"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 97, column 0, characters 2346-2521:","(generalize A5 A2 (mono A0) A6) :- (free-ty (mono A0) [] A1), \n (free-gamma A2 [] A3), (filter A1 (c0 \\ (not (mem A3 c0))) A4), \n (bind A4 A5 A0 A6)."]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A5 := []"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := []"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--402 [] ===> uvar frozen--402 []"]}
@@ -156,8 +156,8 @@
 {"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free-ty","free-ty (mono (uvar frozen--402 [] ===> uvar frozen--402 [])) [] X4"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 105, column 0, characters 2618-2654:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 105, column 0, characters 2618-2654:","(free-ty (mono A0) A1 A2) :- (free A0 A1 A2)."]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 105, column 0, characters 2637-2673:"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 105, column 0, characters 2637-2673:","(free-ty (mono A0) A1 A2) :- (free A0 A1 A2)."]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--402 [] ===> uvar frozen--402 []"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := []"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := X4"]}
@@ -166,8 +166,8 @@
 {"step" : 2,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--402 [] ===> uvar frozen--402 []) [] X4"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 117, column 0, characters 3004-3053:"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 117, column 0, characters 3004-3053:","(free (A0 ===> A3) A1 A4) :- (free A0 A1 A2), (free A3 A2 A4)."]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 117, column 0, characters 3023-3072:"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 117, column 0, characters 3023-3072:","(free (A0 ===> A3) A1 A4) :- (free A0 A1 A2), (free A3 A2 A4)."]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--402 []"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A3 := uvar frozen--402 []"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := []"]}
@@ -179,8 +179,8 @@
 {"step" : 3,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--402 []) [] X7"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3055-3118:"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3055-3118:","(free (as (uvar _ _) A1) A0 A2) :- (if (mem A0 A1) (A2 = A0) (A2 = [A1 | A0]))."]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:"]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:","(free (as (uvar _ _) A1) A0 A2) :- (if (mem A0 A1) (A2 = A0) (A2 = [A1 | A0]))."]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--402 []"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := X7"]}
@@ -189,8 +189,8 @@
 {"step" : 4,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--402 [])) (X7 = []) (X7 = [uvar frozen--402 []])"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13710-13729:","File \"builtin.elpi\", line 527, column 0, characters 13731-13744:"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13710-13729:","(if A0 A1 _) :- A0, !, A1."]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13695-13714:","File \"builtin.elpi\", line 527, column 0, characters 13716-13729:"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13695-13714:","(if A0 A1 _) :- A0, !, A1."]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--402 [])"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X7 = []"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["35"]}
@@ -202,8 +202,8 @@
 {"step" : 5,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--402 [])"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4013-4055:"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4013-4055:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--402"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["38"]}
@@ -215,8 +215,8 @@
 {"step" : 7,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--402 [])) (X7 = []) (X7 = [uvar frozen--402 []])"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 527, column 0, characters 13731-13744:"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 527, column 0, characters 13731-13744:","(if _ _ A0) :- A0."]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 527, column 0, characters 13716-13729:"]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 527, column 0, characters 13716-13729:","(if _ _ A0) :- A0."]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := X7 = [uvar frozen--402 []]"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["39"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X7 = [uvar frozen--402 []]"]}
@@ -228,8 +228,8 @@
 {"step" : 9,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:rule:eq","payload" : ["success"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--402 []) [uvar frozen--402 []] X4"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3055-3118:"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3055-3118:","(free (as (uvar _ _) A1) A0 A2) :- (if (mem A0 A1) (A2 = A0) (A2 = [A1 | A0]))."]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:","(free (as (uvar _ _) A1) A0 A2) :- (if (mem A0 A1) (A2 = A0) (A2 = [A1 | A0]))."]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--402 []"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := [uvar frozen--402 []]"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := X4"]}
@@ -238,8 +238,8 @@
 {"step" : 10,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [uvar frozen--402 []] (uvar frozen--402 [])) \n (X4 = [uvar frozen--402 []]) \n (X4 = [uvar frozen--402 [], uvar frozen--402 []])"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13710-13729:","File \"builtin.elpi\", line 527, column 0, characters 13731-13744:"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13710-13729:","(if A0 A1 _) :- A0, !, A1."]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13695-13714:","File \"builtin.elpi\", line 527, column 0, characters 13716-13729:"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13695-13714:","(if A0 A1 _) :- A0, !, A1."]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [uvar frozen--402 []] (uvar frozen--402 [])"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X4 = [uvar frozen--402 []]"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["41"]}
@@ -251,8 +251,8 @@
 {"step" : 11,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [uvar frozen--402 []] (uvar frozen--402 [])"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4013-4055:"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4013-4055:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := [uvar frozen--402 []]"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--402"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["44"]}
@@ -260,8 +260,8 @@
 {"step" : 12,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [uvar frozen--402 []] (uvar frozen--402 X9)"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 143, column 0, characters 3884-3901:","File \"tests/sources/trace-w/main.elpi\", line 144, column 0, characters 3903-3929:"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 143, column 0, characters 3884-3901:","(mem! [A0 | _] A0) :- !."]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 143, column 0, characters 3903-3920:","File \"tests/sources/trace-w/main.elpi\", line 144, column 0, characters 3922-3948:"]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 143, column 0, characters 3903-3920:","(mem! [A0 | _] A0) :- !."]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--402 []"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X9 := []"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["45"]}
@@ -269,11 +269,11 @@
 {"step" : 13,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["!","!"]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["44","File \"tests/sources/trace-w/main.elpi\", line 144, column 0, characters 3903-3929:","(mem! [_ | A0] A1) :- (mem! A0 A1)."]}
+{"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["44","File \"tests/sources/trace-w/main.elpi\", line 144, column 0, characters 3922-3948:","(mem! [_ | A0] A1) :- (mem! A0 A1)."]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:rule:cut","payload" : ["success"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["!","!"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["40","File \"builtin.elpi\", line 527, column 0, characters 13731-13744:","(if _ _ A0) :- A0."]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["40","File \"builtin.elpi\", line 527, column 0, characters 13716-13729:","(if _ _ A0) :- A0."]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:rule:cut","payload" : ["success"]}
 {"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=","X4 = [uvar frozen--402 []]"]}
 {"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:rule","payload" : ["eq"]}
@@ -282,15 +282,15 @@
 {"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:rule:eq","payload" : ["success"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free-gamma","free-gamma [] [] X5"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 109, column 0, characters 2762-2779:"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 109, column 0, characters 2762-2779:","(free-gamma [] A0 A0) :- ."]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 109, column 0, characters 2781-2798:"]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 109, column 0, characters 2781-2798:","(free-gamma [] A0 A0) :- ."]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X5 := []"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["filter","filter [uvar frozen--402 []] (c0 \\ not (mem [] c0)) X6"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 139, column 0, characters 3770-3818:","File \"tests/sources/trace-w/main.elpi\", line 140, column 0, characters 3820-3856:"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 139, column 0, characters 3770-3818:","(filter [A0 | A2] A1 [A0 | A3]) :- (A1 A0), !, (filter A2 A1 A3)."]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 139, column 0, characters 3789-3837:","File \"tests/sources/trace-w/main.elpi\", line 140, column 0, characters 3839-3875:"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 139, column 0, characters 3789-3837:","(filter [A0 | A2] A1 [A0 | A3]) :- (A1 A0), !, (filter A2 A1 A3)."]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--402 []"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := []"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := c0 \\\nnot (mem [] c0)"]}
@@ -316,8 +316,8 @@
 {"step" : 19,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--402 [])"]}
 {"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4013-4055:"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4013-4055:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
+{"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
+{"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
 {"step" : 20,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
 {"step" : 20,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--402"]}
 {"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["52"]}
@@ -334,18 +334,18 @@
 {"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 23,"kind" : ["Info"],"goal_id" : 47,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["!","!"]}
 {"step" : 23,"kind" : ["Info"],"goal_id" : 47,"runtime_id" : 1,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["29","File \"tests/sources/trace-w/main.elpi\", line 140, column 0, characters 3820-3856:","(filter [_ | A0] A1 A2) :- (filter A0 A1 A2)."]}
+{"step" : 23,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["29","File \"tests/sources/trace-w/main.elpi\", line 140, column 0, characters 3839-3875:","(filter [_ | A0] A1 A2) :- (filter A0 A1 A2)."]}
 {"step" : 23,"kind" : ["Info"],"goal_id" : 47,"runtime_id" : 1,"name" : "user:rule:cut","payload" : ["success"]}
 {"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["filter","filter [] (c0 \\ not (mem [] c0)) X10"]}
 {"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 138, column 0, characters 3754-3768:"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 138, column 0, characters 3754-3768:","(filter [] _ []) :- ."]}
+{"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 138, column 0, characters 3773-3787:"]}
+{"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 138, column 0, characters 3773-3787:","(filter [] _ []) :- ."]}
 {"step" : 24,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X10 := []"]}
 {"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["bind","bind [uvar frozen--402 []] [] (uvar frozen--402 [] ===> uvar frozen--402 []) \n X3"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 123, column 0, characters 3278-3399:"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 123, column 0, characters 3278-3399:","(bind [A1 | A3] A0 A4 (all A2 (c0 \\ (A5 c0)))) :- (if (mem A0 A1) (A2 = eqt) \n                                                    (A2 = any)), \n (pi (c0 \\ (copy A1 c0 => bind A3 A0 A4 (A5 c0))))."]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 123, column 0, characters 3297-3418:"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 123, column 0, characters 3297-3418:","(bind [A1 | A3] A0 A4 (all A2 (c0 \\ (A5 c0)))) :- (if (mem A0 A1) (A2 = eqt) \n                                                    (A2 = any)), \n (pi (c0 \\ (copy A1 c0 => bind A3 A0 A4 (A5 c0))))."]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--402 []"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A3 := []"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
@@ -358,8 +358,8 @@
 {"step" : 25,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--402 [])) (X12 = eqt) (X12 = any)"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13710-13729:","File \"builtin.elpi\", line 527, column 0, characters 13731-13744:"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13710-13729:","(if A0 A1 _) :- A0, !, A1."]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13695-13714:","File \"builtin.elpi\", line 527, column 0, characters 13716-13729:"]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 526, column 0, characters 13695-13714:","(if A0 A1 _) :- A0, !, A1."]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--402 [])"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X12 = eqt"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["55"]}
@@ -371,8 +371,8 @@
 {"step" : 26,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--402 [])"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4013-4055:"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4013-4055:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
+{"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
+{"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--402"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["58"]}
@@ -384,8 +384,8 @@
 {"step" : 28,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--402 [])) (X12 = eqt) (X12 = any)"]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 527, column 0, characters 13731-13744:"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 527, column 0, characters 13731-13744:","(if _ _ A0) :- A0."]}
+{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 527, column 0, characters 13716-13729:"]}
+{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 527, column 0, characters 13716-13729:","(if _ _ A0) :- A0."]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := X12 = any"]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["59"]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 59,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X12 = any"]}
@@ -407,8 +407,8 @@
 {"step" : 32,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:implication","payload" : ["success"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["bind","bind [] [] (uvar frozen--402 [] ===> uvar frozen--402 []) (X13 c0)"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, characters 3242-3276:"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, characters 3242-3276:","(bind [] _ A0 (mono A1)) :- (copy A0 A1)."]}
+{"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, characters 3261-3295:"]}
+{"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, characters 3261-3295:","(bind [] _ A0 (mono A1)) :- (copy A0 A1)."]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--402 [] ===> uvar frozen--402 []"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign:simplify:heap","payload" : ["X13 := c0 \\\nX15 c0"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X15^1 := mono X16^1"]}
@@ -417,8 +417,8 @@
 {"step" : 33,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--402 [] ===> uvar frozen--402 []) X16^1"]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 130, column 0, characters 3456-3508:"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 130, column 0, characters 3456-3508:","(copy (A0 ===> A2) (A1 ===> A3)) :- (copy A0 A1), (copy A2 A3)."]}
+{"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 130, column 0, characters 3475-3527:"]}
+{"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 130, column 0, characters 3475-3527:","(copy (A0 ===> A2) (A1 ===> A3)) :- (copy A0 A1), (copy A2 A3)."]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--402 []"]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := uvar frozen--402 []"]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X16^1 := X17^1 ===> X18^1"]}
@@ -429,19 +429,19 @@
 {"step" : 34,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--402 []) X17^1"]}
 {"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/main.elpi\", line 133, column 0, characters 3602-3628:"]}
+{"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/main.elpi\", line 133, column 0, characters 3621-3647:"]}
 {"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","(copy (uvar frozen--402 []) c0) :- ."]}
 {"step" : 35,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X17^1 := c0"]}
 {"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--402 []) X18^1"]}
 {"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/main.elpi\", line 133, column 0, characters 3602-3628:"]}
+{"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/main.elpi\", line 133, column 0, characters 3621-3647:"]}
 {"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","(copy (uvar frozen--402 []) c0) :- ."]}
 {"step" : 36,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X18^1 := c0"]}
 {"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["65"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 65,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["_ => X1 = all any c0 \\ mono (c0 ===> c0)"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:CHR:rule-fired","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 85, column 36, characters 2008-2180:"]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:CHR:rule-fired","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 85, column 36, characters 2027-2199:"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:CHR:rule-remove-constraints","payload" : ["25"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:CHR:store:before","payload" : ["25"," gammabar (mono (X5 ===> X5)) X1  /* suspended on X7 */"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:CHR:store:before","payload" : ["16"," theta []  /* suspended on X7 */"]}
@@ -469,7 +469,7 @@
 {"step" : 21,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
 {"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of (app c0 (global [])) (mono X3)"]}
 {"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 4, column 0, characters 31-97:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:"]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 4, column 0, characters 31-97:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
 {"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 4, column 0, characters 31-97:","(of (app A0 A3) (mono A2)) :- (of A0 (mono (A1 ===> A2))), (of A3 (mono A1))."]}
 {"step" : 22,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := c0"]}
 {"step" : 22,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A3 := global []"]}
@@ -481,7 +481,7 @@
 {"step" : 22,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of c0 (mono (X8^1 ===> X3))"]}
 {"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:"]}
+{"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
 {"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."]}
 {"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify mono (X8^1 ===> X3) with all any c1 \\ mono (c1 ===> c1)"]}
 {"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
@@ -494,7 +494,7 @@
 {"step" : 23,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 24,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of c0 (all X9^1 X10^1)"]}
 {"step" : 24,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:"]}
+{"step" : 24,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
 {"step" : 24,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."]}
 {"step" : 24,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X9^1 := any"]}
 {"step" : 24,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X10^1 := c1 \\\nmono (c1 ===> c1)"]}
@@ -518,7 +518,7 @@
 {"step" : 26,"kind" : ["Info"],"goal_id" : 73,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of (global []) (mono X3)"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:"]}
+{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","(of (global 1) (mono int)) :- ."]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global 1"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","(of (global 2) (mono int)) :- ."]}
@@ -547,7 +547,7 @@
 {"step" : 27,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of (global []) (all X12^1 X13^1)"]}
 {"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:"]}
+{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
 {"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","(of (global 1) (mono int)) :- ."]}
 {"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global 1"]}
 {"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","(of (global 2) (mono int)) :- ."]}
@@ -586,28 +586,28 @@
 {"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","(of (global undup) (all eqt (c0 \\ (mono (list c0 ===> list c0))))) :- ."]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","(of (global ,) \n  (all any (c0 \\ (all any (c1 \\ (mono (c0 ===> c1 ===> pair c0 c1))))))) :- ."]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["70","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["70","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["70","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["70","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["72","File \"tests/sources/trace-w/main.elpi\", line 58, column 0, characters 1335-1398:","(specialize (all eqt A1) A2) :- (specialize (A1 A0) A2), (eqbar A0)."]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["71","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["71","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["71","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["69","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["69","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["71","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["71","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["69","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["69","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["68","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["68","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["68","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["68","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["68","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["22","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["22","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["22","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["22","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["22","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["17","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["17","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["17","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["17","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["17","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["10","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["10","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4490-4559:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["10","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4561-4622:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["10","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["10","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:cut","payload" : ["success"]}
 {"step" : 32,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["print","print\n (let (lam c0 \\ c0) (all any c0 \\ mono (c0 ===> c0)) c0 \\ app c0 (global [])) \n  :  (mono (list X16))"]}
 {"step" : 32,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}

--- a/tests/sources/uvar_chr.elpi
+++ b/tests/sources/uvar_chr.elpi
@@ -22,7 +22,7 @@ pred copy-list i:list term, o:list term.
 copy-list [] [].
 copy-list [X|XS] [Y|YS] :- copy X Y, copy-list XS YS.
 
-pred meta-copy i:term, o:term.
+func meta-copy term -> term.
 constraint meta-copy {
   rule (meta-copy I O) | (copy I X) <=> (O = X).
 }

--- a/tests/sources/variadic.elpi
+++ b/tests/sources/variadic.elpi
@@ -1,5 +1,5 @@
 func f int, int -> int.. .
-f N D R :- R is N div D.
+f N D R :- !, R is N div D.
 f N D R M :- f N D R, M is N mod D.
 
 main :- f 3 2 R, f 3 2 _ Q, R = 1, Q = 1.

--- a/tests/sources/variadic.elpi
+++ b/tests/sources/variadic.elpi
@@ -1,0 +1,5 @@
+func f int, int -> int.. .
+f N D R :- R is N div D.
+f N D R M :- f N D R, M is N mod D.
+
+main :- f 3 2 R, f 3 2 _ Q, R = 1, Q = 1.

--- a/tests/sources/variadic_declare_constraints.elpi
+++ b/tests/sources/variadic_declare_constraints.elpi
@@ -1,5 +1,5 @@
 kind tm type.
-type foo tm -> (tm -> tm) -> prop.
+func foo tm, (tm -> tm).
 
 main :-
   declare_constraint (foo X Y) X [Y, Z].

--- a/tests/sources/w.elpi
+++ b/tests/sources/w.elpi
@@ -63,7 +63,7 @@ pred specialize i:ty, o:tye.
 specialize (all F) T :- specialize (F FRESH_) T.
 specialize (mono X) X.
 
-pred overbar i:ty, o:ty.
+func overbar ty -> ty.
 
 constraint w overbar {
 

--- a/tests/suite/elpi_specific.ml
+++ b/tests/suite/elpi_specific.ml
@@ -510,3 +510,8 @@ let () = declare "tc_ambiguous"
   ~description:"tc_ambiguous"
   ~expectation:(FailureOutput Str.(regexp "too many"))
   ()
+
+let () = declare "variadic"
+  ~source_elpi:"variadic.elpi"
+  ~description:"variadic"
+  ()

--- a/tests/suite/elpi_specific.ml
+++ b/tests/suite/elpi_specific.ml
@@ -95,6 +95,12 @@ let () = declare "chr_ut"
   ~description:"type checker with UT via CHR"
   ()
 
+let () = declare "chr_cut"
+  ~source_elpi:"chr_cut.elpi"
+  ~description:"cut not allowed"
+  ~expectation:(FailureOutput (Str.regexp "cannot contain cut"))
+  ()
+
 let () = declare "chr_even_odd"
   ~source_elpi:"even-odd.elpi"
   ~description:"CHR example at MLWS"


### PR DESCRIPTION
constraints must be deterministic, since they can be resumed at any time
- we export the function
- we make declare_constraint require a func
- we make miscalled builtins an error
- we add syntax for variadinc func

todo:
- [x] test variadic func (not just builtin)
- [x] document variadic syntax
- [x] update error_messages.txt
- [x] fix test suite
- [x] CHR cannot return a !