### PR TITLE
API: accumulated files are visible in the API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           opam exec -- cygpath -m ${{ github.workspace }} | % {$_ -replace "^","workspace=" }  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           opam exec -- sed -i ' ' tests/sources/*.elpi
-          & "setup-x86_64.exe" -v -q -P time,which,wdiff
+          & "C:/.opam/.cygwin/setup-x86_64.exe" -s https://mirrors.kernel.org/sourceware/cygwin/ -v -q -P time,which,wdiff
 
 # Build ######################################################################
 #
@@ -120,7 +120,7 @@ jobs:
         if: runner.os == 'Windows' && matrix.profile != 'fatalwarnings'
         run: |
           opam exec -- ls -l tests/sources/*.elpi
-          opam exec -- make tests PWD=${{ env.workspace }} RUNNERS='dune ${{ env.workspace }}/elpi-${{ matrix.ocaml-compiler }}-${{ runner.os }}.exe ${{ env.workspace }}/elpi-trace-elaborator-${{ matrix.ocaml-compiler }}-${{ runner.os }}.exe' TIME=--time=C:/cygwin/bin/time.exe
+          opam exec -- make tests PWD=${{ env.workspace }} RUNNERS='dune ${{ env.workspace }}/elpi-${{ matrix.ocaml-compiler }}-${{ runner.os }}.exe ${{ env.workspace }}/elpi-trace-elaborator-${{ matrix.ocaml-compiler }}-${{ runner.os }}.exe' TIME=--time=C:/.opam/.cygwin/root/bin/time.exe
 
 # Artifacts 2 ################################################################
 

--- a/.github/workflows/users.yml
+++ b/.github/workflows/users.yml
@@ -30,18 +30,18 @@ jobs:
           env:
             OPAMWITHTEST: false
             
-        - run: opam pin --ignore-constraints-on elpi            add rocq-elpi              https://github.com/LPCIC/coq-elpi.git#master
-        - run: opam pin --ignore-constraints-on elpi            add coq-elpi               https://github.com/LPCIC/coq-elpi.git#master
+        - run: opam pin --ignore-constraints-on elpi            add rocq-elpi              https://github.com/LPCIC/coq-elpi.git#elpi-3.7
+        - run: opam pin --ignore-constraints-on elpi            add coq-elpi               https://github.com/LPCIC/coq-elpi.git#elpi-3.7
         - run: opam pin --ignore-constraints-on elpi            add rocq-stdlib            https://github.com/rocq-prover/stdlib.git#master
         - run: opam pin --ignore-constraints-on elpi            add coq-stdlib             https://github.com/rocq-prover/stdlib.git#master
-        - run: opam pin --ignore-constraints-on elpi            add rocq-hierarchy-builder https://github.com/math-comp/hierarchy-builder.git#master
-        - run: opam pin --ignore-constraints-on elpi,coq-stdlib add coq-trocq-std          https://github.com/rocq-community/trocq.git#fix-opam-install
+        - run: opam pin --ignore-constraints-on elpi,coq-stdlib add coq-trocq-std          https://github.com/rocq-community/trocq.git#master
+        - run: opam pin --ignore-constraints-on elpi            add rocq-hierarchy-builder https://github.com/math-comp/hierarchy-builder.git#hierarchy-builder.elpi-3.7
         - run: opam pin --ignore-constraints-on elpi            add rocq-mathcomp-boot     https://github.com/math-comp/math-comp.git#master
         - run: opam pin --ignore-constraints-on elpi            add rocq-mathcomp-order    https://github.com/math-comp/math-comp.git#master
         - run: opam pin --ignore-constraints-on elpi            add rocq-mathcomp-fingroup https://github.com/math-comp/math-comp.git#master
         - run: opam pin --ignore-constraints-on elpi            add rocq-mathcomp-algebra  https://github.com/math-comp/math-comp.git#master
         - run: opam pin --ignore-constraints-on elpi            add coq-mathcomp-algebra  https://github.com/math-comp/math-comp.git#master
-        #- run: opam pin --ignore-constraints-on elpi,coq-stdlib add coq-trocq-std-examples https://github.com/rocq-community/trocq.git#fix-opam-install
+        #- run: opam pin --ignore-constraints-on elpi,coq-stdlib add coq-trocq-std-examples https://github.com/rocq-community/trocq.git#master
         - run: opam pin --ignore-constraints-on elpi            add rocq-mathcomp-solvable https://github.com/math-comp/math-comp.git#master
         - run: opam pin --ignore-constraints-on elpi            add rocq-mathcomp-field    https://github.com/math-comp/math-comp.git#master
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 # UNRELEASED
 
 - REPL:
-  - elpi takes zero or one file (not more)
+  - `elpi` takes zero or one file (not more) when executing
+  - `elpi -deps` prints a dot file with the direct dependencies of given files.
+    Example: `elpi -deps *.elpi | xdot -`
 
 - API:
   - separate API for scoping AST or builtins. Scoping AST can return more

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
-# UNRELEASED
+# v3.7.0 (April 2026)
+
+Requires Menhir 20211230 and OCaml 4.14 or above on Linux, Windows and
+MacOS.
 
 - REPL:
   - `elpi` takes zero or one file (not more) when executing
@@ -6,9 +9,13 @@
     Example: `elpi -deps *.elpi | xdot -`
 
 - API:
-  - separate API for scoping AST or builtins. Scoping AST can return more
+  - Change: separate API for scoping AST or builtins. Scoping AST can return more
     than one scoped program, in particular it returns all accumulated code
-    with file name and digest
+    with file name and digest. Incidentally it also computes the dependencies
+    of each file.
+  - New: api to get the dependencies of a scoped program or compilation unit
+  - New: api to map compilation units and apply a substitution on the CData
+    they contain
 
 # v3.6.2 (March 2026)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+# UNRELEASED
+
+- REPL:
+  - elpi takes zero or one file (not more)
+
+- API:
+  - separate API for scoping AST or builtins. Scoping AST can return more
+    than one scoped program, in particular it returns all accumulated code
+    with file name and digest
+
 # v3.6.2 (March 2026)
 
 Requires Menhir 20211230 and OCaml 4.14 or above on Linux, Windows and

--- a/elpi_REPL.ml
+++ b/elpi_REPL.ml
@@ -95,6 +95,7 @@ let _ =
   let extra_paths = ref [] in
   let parse_term = ref false in
   let skip_det_check = ref false in
+  let print_deps = ref false in
   let vars =
     ref API.Compile.(default_flags.defined_variables) in
   let rec eat_options = function
@@ -107,6 +108,7 @@ let _ =
     | "-print-ast" :: rest -> print_ast := true; eat_options rest
     | "-print-units" :: rest -> print_units := true; eat_options rest
     | "-parse-term" :: rest -> parse_term := true; eat_options rest
+    | "-deps" :: rest -> print_deps := true; eat_options rest
     | "-document-builtins" :: rest -> doc_builtins := true; eat_options rest
     | "-document-infix-syntax" :: rest -> doc_infix := true; eat_options rest
     | "-D" :: var :: rest -> vars := API.Compile.StrSet.add var !vars; eat_options rest
@@ -168,6 +170,28 @@ let _ =
   if !doc_builtins then begin
     API.BuiltIn.document_file Builtin.std_builtins;
     exit 0;
+  end;
+  if !print_deps then begin
+    let pl = files |> List.map (fun file ->
+      try API.Parse.program ~elpi ~file
+      with API.Parse.ParseError(loc,err) ->
+        Printf.eprintf "%s\n%s\n" (API.Ast.Loc.show loc) err;
+        exit 1) in
+    let all = List.map (API.Compile.scope_ast ~elpi) pl |> List.concat in
+    let name_of = API.Compile.scoped_program_name in
+    let all = List.sort (fun p1 p2 -> compare (name_of p1) (name_of p2)) all in
+    let all =
+      let rec undup = function
+        | [] -> []
+        | x :: y :: rest when name_of x = name_of y -> undup (y :: rest)
+        | x :: rest -> x :: undup rest in
+      undup all in
+    Printf.printf "digraph deps {\n";
+    all |> List.iter (fun x ->
+      let deps = API.Compile.scoped_program_deps x in
+      deps |> List.iter (fun d -> Printf.printf "%S -> %S;\n" (name_of x) (fst d)));
+    Printf.printf "}\n";
+    exit 0
   end;
   let file =
     match files with

--- a/elpi_REPL.ml
+++ b/elpi_REPL.ml
@@ -52,7 +52,7 @@ let set_terminal_width ?(max_w=
 ;;
 
 let usage =
-  "\nUsage: elpi [OPTION].. [FILE].. [-- ARGS..] \n" ^ 
+  "\nUsage: elpi [OPTION].. [FILE] [-- ARGS..] \n" ^ 
   "\nMain options:\n" ^ 
   "\t-test runs the query \"main\"\n" ^ 
   "\t-exec pred  runs the query \"pred ARGS\"\n" ^ 
@@ -150,8 +150,8 @@ let _ =
       try API.Parse.goal_from ~elpi ~loc:(API.Ast.Loc.initial "(-parse-term)") (Lexing.from_channel stdin)
       with API.Parse.ParseError(loc,msg) -> Format.eprintf "%a@;%s\n" API.Ast.Loc.pp loc msg; exit 1 in
     Format.printf "Raw term: %a\n" API.Pp.Ast.query g;
-    let p = API.Parse.program ~elpi ~files:[] in
-    let prog = API.Compile.program ~flags ~elpi [p] in
+    let p = API.Parse.program_from ~elpi ~loc:(API.Ast.Loc.initial "(parse_term)") ~digest:(Digest.string "")  (Lexing.from_string "") in
+    let prog = API.Compile.program ~flags ~elpi p in
     let query = API.Compile.query prog g in
     Format.printf "Compiled term: %a\n" API.Pp.goal query;
     exit 0;
@@ -169,12 +169,17 @@ let _ =
     API.BuiltIn.document_file Builtin.std_builtins;
     exit 0;
   end;
+  let file =
+    match files with
+    | [] -> "/dev/null"
+    | [x] -> x
+    | _ -> Printf.eprintf "Only one file can be specified"; exit 1 in
   let t0_parsing = Unix.gettimeofday () in
   let p =
-    try API.Parse.program ~elpi ~files
+    try API.Parse.program ~elpi ~file
     with API.Parse.ParseError(loc,err) ->
       Printf.eprintf "%s\n%s\n" (API.Ast.Loc.show loc) err;
-      exit 1;
+      exit 1
   in
   let g =
     if !test then
@@ -203,7 +208,7 @@ let _ =
   let query, prog, exec, (type_checking_time, det_checking_time) =
     let t0_compilation = Unix.gettimeofday () in
     try
-      let prog = API.Compile.program ~flags ~elpi [p] in
+      let prog = API.Compile.program ~flags ~elpi p in
       let query = API.Compile.query prog g in
       let type_checking_time = API.Compile.total_type_checking_time query, API.Compile.total_det_checking_time query in
       let exec = API.Compile.optimize query in

--- a/src/API.ml
+++ b/src/API.ml
@@ -65,7 +65,7 @@ let trace = set_trace
 
 let usage =
   Trace_ppx_runtime.Runtime.usage
-  type warning_id = Util.warning_id = LinearVariable | UndeclaredGlobal | FlexClause | ImplicationPrecedence
+  type warning_id = Util.warning_id = LinearVariable | UndeclaredGlobal | FlexClause | ImplicationPrecedence | NestedAccumulate
 
 let set_warn = Util.set_warn
 let set_error = Util.set_error
@@ -97,13 +97,13 @@ end
 
 module Parse = struct
 
-  let program ~elpi:{ Setup.parser } ~files =
+  let program ~elpi:{ Setup.parser } ~file =
     let module P = (val parser) in
-    List.(concat (map (fun file -> P.program ~file) files))
+    P.program ~file
 
-  let program_from ~elpi:{ Setup.parser } ~loc buf =
+  let program_from ~elpi:{ Setup.parser } ~loc ~digest buf =
     let module P = (val parser) in
-    P.program_from ~loc buf
+    P.program_from ~loc ~digest buf
 
   let goal ~elpi:{ Setup.parser } ~loc ~text =
     let module P = (val parser) in
@@ -146,16 +146,28 @@ module Compile = struct
   type program = Compiler.program
   type query = Compiler.query
   type executable = ED.executable
-  type scoped_program = Compiler.scoped_program * int
+  type scoped_program = Compiler.scoped_program
+  let scoped_program_name = Compiler.scoped_program_name
+  let scoped_program_digest = Compiler.scoped_program_digest
+  let scoped_program_deps = Compiler.scoped_program_deps
+
   type compilation_unit = Compiler.checked_compilation_unit
+  let compilation_unit_name = Compiler.checked_compilation_unit_name
+  let compilation_unit_digest = Compiler.checked_compilation_unit_digest
+  let compilation_unit_deps = Compiler.checked_compilation_unit_deps
   let pp_compilation_unit = Compiler.pp_checked_compilation_unit
+
   type compilation_unit_signature = Compiler.checked_compilation_unit_signature
+
+  let compilation_unit_signature_name = Compiler.checked_compilation_unit_signature_name
+  let compilation_unit_signature_digest = Compiler.checked_compilation_unit_signature_digest
+
   exception CompileError = Compiler_data.CompileError
 
   let to_setup_flags x = x
 
-  let program ?(flags=Compiler.default_flags) ~elpi:{ Setup.header } l =
-    Compiler.program_of_ast ~flags ~header (List.flatten l)
+  let program ?(flags=Compiler.default_flags) ~elpi:{ Setup.header } p =
+    Compiler.program_of_ast ~flags ~header p
 
   let empty_base ~elpi:{ Setup.header } = Compiler.empty_base ~header
 
@@ -175,15 +187,12 @@ module Compile = struct
   }
   let default_flags = Compiler.default_flags
   let optimize = Compiler.optimize_query
-  let scope ?(flags=Compiler.default_flags) ~elpi:{ Setup.header; parser } ?builtins a =
-    let builtins_hash = Hashtbl.hash builtins in
-    let builtins = match builtins with None -> [] | Some x -> [x] in
-    Compiler.scoped_of_ast ~flags ~header ~builtins a, builtins_hash
-  let unit ?(flags=Compiler.default_flags) ~elpi:{ Setup.header } ~base ?builtins (x,builtins_hash) =
-    if builtins_hash <> Hashtbl.hash builtins then
-      Util.error "API: Compile.scope and Compile.unit must take the same ~builtins";
-    let builtins = match builtins with None -> [] | Some x -> [x] in
-    Compiler.unit_of_scoped ~flags ~header ~builtins x |> Compiler.check_unit ~flags ~base
+  let scope_ast ?(flags=Compiler.default_flags) ~elpi:{ Setup.header; parser } a =
+    Compiler.scoped_of_ast ~flags ~header a
+  let scope_builtins ?(flags=Compiler.default_flags) ~elpi:{ Setup.header; parser } builtins =
+    Compiler.scoped_of_builtins ~flags ~header builtins
+  let unit ?(flags=Compiler.default_flags) ~elpi:{ Setup.header } ~base x =
+    Compiler.unit_of_scoped ~flags ~header x |> Compiler.check_unit ~flags ~base
 
   let extend ?(flags=Compiler.default_flags) ~base u = Compiler.append_unit ~flags ~base u
   let signature u = Compiler.signature_of_checked_compilation_unit u
@@ -1341,12 +1350,19 @@ module Utils = struct
         | Some (`Replace,x) -> [Replace x]
         | Some (`Remove,x) -> [Remove x]
         | None -> []) in
-    [Program.Clause {
-      Clause.loc = loc;
-      attributes;
-      body = aux depth Util.IntMap.empty term;
-      needs_spilling = ()
-    }]
+    let body = aux depth Util.IntMap.empty term in
+    let digest = Digest.string (Marshal.to_string body []) in
+    { ast =
+        [Program.Clause {
+          Clause.loc = loc;
+          attributes;
+          body;
+          needs_spilling = ();
+        }];
+      file_name = loc.Util.Loc.source_name;
+      deps = [];
+      digest ;
+    }
 
   let term_to_raw_term s p ?ctx ~depth t =
     Compiler.runtime_hack_term_to_raw_term s p ?ctx ~depth @@

--- a/src/API.mli
+++ b/src/API.mli
@@ -198,7 +198,7 @@ module Setup : sig
   val trace : string list -> string list
 
   (** Override default runtime error functions (they call exit) *)
-  type warning_id = LinearVariable | UndeclaredGlobal | FlexClause | ImplicationPrecedence
+  type warning_id = LinearVariable | UndeclaredGlobal | FlexClause | ImplicationPrecedence | NestedAccumulate
   val set_warn : (?loc:Ast.Loc.t -> id:warning_id -> string -> unit) -> unit
   val set_error : (?loc:Ast.Loc.t -> string -> 'a) -> unit
   val set_anomaly : (?loc:Ast.Loc.t -> string -> 'a) -> unit
@@ -213,9 +213,9 @@ module Parse : sig
   (** [program file_list] parses a list of files,
       Raises Failure if the file does not exist. *)
   val program : elpi:Setup.elpi ->
-    files:string list -> Ast.program
+    file:string -> Ast.program
   val program_from : elpi:Setup.elpi ->
-    loc:Ast.Loc.t -> Lexing.lexbuf -> Ast.program
+    loc:Ast.Loc.t -> digest:Digest.t -> Lexing.lexbuf -> Ast.program
 
   (** [goal file_list] parses the query,
       Raises Failure if the file does not exist.  *)
@@ -276,7 +276,7 @@ module Compile : sig
      - the `accumulate` directive inserts `{` and `}` around the accumulated
        code
    *)
-  val program : ?flags:flags -> elpi:Setup.elpi -> Ast.program list -> program
+  val program : ?flags:flags -> elpi:Setup.elpi -> Ast.program -> program
 
   (* separate compilation API: scoped_programs and units are marshalable and
      closed w.r.t. the host application (eg quotations are desugared).
@@ -290,14 +290,24 @@ module Compile : sig
        merged at assembly time
 *)
   type scoped_program
-  val scope : ?flags:flags -> elpi:Setup.elpi -> ?builtins:Setup.builtins -> Ast.program -> scoped_program
+  val scoped_program_name : scoped_program -> string
+  val scoped_program_digest : scoped_program -> Digest.t
+  val scoped_program_deps : scoped_program -> (string * Digest.t) list
+  val scope_ast : ?flags:flags -> elpi:Setup.elpi -> Ast.program -> scoped_program list
+  val scope_builtins : ?flags:flags -> elpi:Setup.elpi -> Setup.builtins -> scoped_program
   
   type compilation_unit
+  val compilation_unit_name : compilation_unit -> string
+  val compilation_unit_digest : compilation_unit -> Digest.t
+  val compilation_unit_deps : compilation_unit -> (string * Digest.t) list
   val pp_compilation_unit : Format.formatter -> compilation_unit -> unit
   
   type compilation_unit_signature
+  val compilation_unit_signature_name : compilation_unit_signature -> string
+  val compilation_unit_signature_digest : compilation_unit_signature -> Digest.t
+
   val empty_base : elpi:Setup.elpi -> program
-  val unit : ?flags:flags -> elpi:Setup.elpi -> base:program -> ?builtins:Setup.builtins -> scoped_program -> compilation_unit
+  val unit : ?flags:flags -> elpi:Setup.elpi -> base:program -> scoped_program -> compilation_unit
   val extend : ?flags:flags -> base:program -> compilation_unit -> program
 
   (* only adds the types/modes from the compilation unit, not its code *)

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -240,7 +240,7 @@ and block =
   | Namespace of string * pbody
   | Shorten of F.t Ast.Structured.shorthand list * pbody
   | Constraints of (F.t,ScopedTerm.t) Ast.Structured.block_constraint * pbody
-  | Accumulated of pbody
+  | Block of pbody
 [@@deriving show]
 
 end
@@ -299,7 +299,7 @@ let ast_of_builtins ~calc ~(parser: (module Parse.Parser)) ~file_name =
   let lexbuf = Lexing.from_string text in
   let module P = (val parser) in
   try
-    P.program_from ~loc:(Util.Loc.initial file_name) lexbuf
+    P.program_from ~loc:(Util.Loc.initial file_name) ~digest:(Digest.string text) lexbuf
   with Parse.ParseError(loc,msg) ->
     List.iteri (fun i s ->
       Printf.eprintf "%4d: %s\n" (i+1) s)
@@ -324,7 +324,7 @@ type program = {
   signature : unchecked_signature;
   clauses : (ScopedTerm.t,Ast.Structured.attribute,bool,bool) Ast.Clause.t list;
   chr : (F.t,ScopedTerm.t) Ast.Structured.block_constraint list;
-  builtins : declared_builtins list;
+  builtins : declared_builtins option;
 }
 [@@deriving show]
 
@@ -393,7 +393,7 @@ type program = {
   signature : Assembled.signature;
   clauses : (ScopedTerm.t,Ast.Structured.attribute,bool,bool) Ast.Clause.t list;
   chr : (Symbol.t,ScopedTerm.t) Ast.Structured.block_constraint list;
-  builtins : ((Symbol.t * string) list * declared_builtins) list;
+  builtins : ((Symbol.t * string) list * declared_builtins) option;
 }
 [@@deriving show]
 
@@ -402,12 +402,22 @@ end
 type scoped_program = {
   version : string;
   code : Scoped.program;
+  builtins : declared_builtins option;
+  file_name : string;
+  digest : Digest.t;
+  deps : Ast.dependencies;
 }
 [@@deriving show]
+let scoped_program_name x = x.file_name
+let scoped_program_digest x = x.digest
+let scoped_program_deps x = x.deps
 
 type unchecked_compilation_unit = {
   version : string;
   code : Flat.program;
+  file_name : string;
+  digest : Digest.t;
+  deps : Ast.dependencies;
 }
 [@@deriving show]
 
@@ -421,14 +431,28 @@ type checked_compilation_unit = {
   base_hash : string;
   type_checking_time : float;
   det_checking_time : float;
+  file_name : string;
+  digest : Digest.t;
+  deps : Ast.dependencies;
+}
+[@@deriving show]
+let checked_compilation_unit_name x = x.file_name
+let checked_compilation_unit_digest x = x.digest
+let checked_compilation_unit_deps x = x.deps
+
+type checked_compilation_unit_signature = {
+  signature: Assembled.signature;
+  file_name: string;
+  digest: Digest.t;
 }
 [@@deriving show]
 
-type checked_compilation_unit_signature = Assembled.signature
-[@@deriving show]
+let checked_compilation_unit_signature_name x = x.file_name
+let checked_compilation_unit_signature_digest x = x.digest
 
 
-let signature_of_checked_compilation_unit { checked_code = { CheckedFlat.signature } } = signature
+
+let signature_of_checked_compilation_unit { checked_code = { CheckedFlat.signature }; file_name; digest; } = { file_name; signature; digest }
 
 type program = State.t * Assembled.program
 type header = program
@@ -465,7 +489,7 @@ module RecoverStructure : sig
 
   (* Reconstructs the structure of the AST (i.e. matches { with }) *)
 
-  val run : State.t -> Ast.Program.t -> Ast.Structured.program
+  val run : State.t -> Ast.Program.t -> Ast.Structured.t list
   val structure_type_expression : Loc.t -> 'a -> (Ast.raw_attribute list -> 'a option) -> Ast.raw_attribute list Ast.TypeExpression.t -> 'a Ast.TypeExpression.t
 
 end = struct (* {{{ *)
@@ -644,10 +668,10 @@ end = struct (* {{{ *)
   in
   { TypeAbbreviation.name; value = aux value; nparams; loc }
 
-  let run _ dl =
-    let rec aux_run ns blocks clauses macros kinds types tabbrs chr accs = function
+  let run _ { file_name; digest; ast = dl } =
+    let rec aux_run ns blocks clauses macros kinds types tabbrs chr = function
       | Program.Ignored _ :: rest ->
-          aux_run ns blocks clauses macros kinds types tabbrs chr accs rest
+          aux_run ns blocks clauses macros kinds types tabbrs chr rest
       | (Program.End _ :: _ | []) as rest ->
           { body = List.rev (cl2b clauses @ blocks);
             types = (*List.rev*) types; (* we prefer the last one *)
@@ -657,92 +681,96 @@ end = struct (* {{{ *)
           List.rev chr,
           rest
       | Program.Begin loc :: rest ->
-          let p, chr1, rest = aux_run ns [] [] [] [] [] [] [] accs rest in
+          let p, chr1, rest = aux_run ns [] [] [] [] [] [] [] rest in
           if chr1 <> [] then
             error "CHR cannot be declared inside an anonymous block";
-          aux_end_block loc ns (Accumulated p :: cl2b clauses @ blocks)
-            [] macros kinds types tabbrs chr accs rest
+          aux_end_block loc ns (Block p :: cl2b clauses @ blocks)
+            [] macros kinds types tabbrs chr rest
       | Program.Constraint (loc, ctx_filter, clique) :: rest ->
           if chr <> [] then
             error "Constraint blocks cannot be nested";
-          let p, chr, rest = aux_run ns [] [] [] [] [] [] [] accs rest in
+          let p, chr, rest = aux_run ns [] [] [] [] [] [] [] rest in
           aux_end_block loc ns (Constraints({loc;ctx_filter;clique;rules=chr},p) :: cl2b clauses @ blocks)
-            [] macros kinds types tabbrs [] accs rest
+            [] macros kinds types tabbrs [] rest
       | Program.Namespace (loc, n) :: rest ->
-          let p, chr1, rest = aux_run (n::ns) [] [] [] [] [] [] [] StrSet.empty rest in
+          let p, chr1, rest = aux_run (n::ns) [] [] [] [] [] [] [] rest in
           if chr1 <> [] then
             error "CHR cannot be declared inside a namespace block";
           aux_end_block loc ns (Namespace (n,p) :: cl2b clauses @ blocks)
-            [] macros kinds types tabbrs chr accs rest
+            [] macros kinds types tabbrs chr rest
       | Program.Shorten (loc,[]) :: _ ->
           anomaly ~loc "parser returns empty list of shorten directives"
       | Program.Shorten (loc,directives) :: rest ->
           let shorthand (full_name,short_name) = { iloc = loc; full_name; short_name } in
           let shorthands = List.map shorthand directives in
-          let p, chr1, rest = aux_run ns [] [] [] [] [] [] [] accs rest in
+          let p, chr1, rest = aux_run ns [] [] [] [] [] [] [] rest in
           if chr1 <> [] then
             error "CHR cannot be declared after a shorthand";
           aux_run ns ((Shorten(shorthands,p) :: cl2b clauses @ blocks))
-            [] macros kinds types tabbrs chr accs rest
+            [] macros kinds types tabbrs chr rest
 
-      | Program.Accumulated (_,[]) :: rest ->
-          aux_run ns blocks clauses macros kinds types tabbrs chr accs rest
-
-      | Program.Accumulated (loc,{ file_name; digest; ast = a } :: more) :: rest ->
-          let rest = Program.Accumulated (loc, more) :: rest in
-          let digest = String.concat "." (digest :: List.map F.show ns) in
-          if StrSet.mem digest accs then begin
-            (* Printf.eprintf "skip: %s\n%!" filename; *)
-            aux_run ns blocks clauses macros kinds types tabbrs chr accs rest
-          end else begin
-            (* Printf.eprintf "acc: %s -> %d\n%!" filename (List.length a); *)
-            aux_run ns blocks clauses macros kinds types tabbrs chr
-              (StrSet.add digest accs)
-              (Program.Begin loc :: a @ Program.End loc :: rest)
-          end
+      | Program.Accumulated (loc,l) :: rest ->
+          warn ~loc ~id:NestedAccumulate "accumulate outside file header";
+          aux_run ns blocks clauses macros kinds types tabbrs chr
+           (List.concat_map (fun x -> Program.Begin loc :: x.ast @ [Program.End loc]) l @ rest)
 
       | Program.Clause c :: rest ->
           let c = structure_clause_attributes c in
-          aux_run ns blocks (c::clauses) macros kinds types tabbrs chr accs rest
+          aux_run ns blocks (c::clauses) macros kinds types tabbrs chr rest
       | Program.Macro m :: rest ->
-          aux_run ns blocks clauses (m::macros) kinds types tabbrs chr accs rest
+          aux_run ns blocks clauses (m::macros) kinds types tabbrs chr rest
       | Program.Pred t :: rest ->
           let t = structure_type_attributes t in
-          aux_run ns blocks clauses macros kinds (t :: types) tabbrs chr accs rest
+          aux_run ns blocks clauses macros kinds (t :: types) tabbrs chr rest
       | Program.Kind [] :: rest ->
-          aux_run ns blocks clauses macros kinds types tabbrs chr accs rest
+          aux_run ns blocks clauses macros kinds types tabbrs chr rest
       | Program.Kind (k::ks) :: rest ->          
           let k = structure_kind_attributes k in
-          aux_run ns blocks clauses macros (k :: kinds) types tabbrs chr accs (Program.Kind ks :: rest)
+          aux_run ns blocks clauses macros (k :: kinds) types tabbrs chr (Program.Kind ks :: rest)
       | Program.Type [] :: rest ->
-          aux_run ns blocks clauses macros kinds types tabbrs chr accs rest
+          aux_run ns blocks clauses macros kinds types tabbrs chr rest
       | Program.Type (t::ts) :: rest ->          
           if List.mem Functional t.attributes then error ~loc:t.loc "functional attribute only applies to pred";
           let t = structure_type_attributes t in
-          aux_run ns blocks clauses macros kinds (t :: types) tabbrs chr accs (Program.Type ts :: rest)
+          aux_run ns blocks clauses macros kinds (t :: types) tabbrs chr (Program.Type ts :: rest)
       | Program.TypeAbbreviation abbr :: rest ->
           let abbr = structure_type_abbreviation abbr in
-          aux_run ns blocks clauses macros kinds types (abbr :: tabbrs) chr accs rest
+          aux_run ns blocks clauses macros kinds types (abbr :: tabbrs) chr rest
       | Program.Chr r :: rest ->
           let r = structure_chr_attributes r in
-          aux_run ns blocks clauses macros kinds types tabbrs (r::chr) accs rest
+          aux_run ns blocks clauses macros kinds types tabbrs (r::chr) rest
 
-    and aux_end_block loc ns blocks clauses macros kinds types tabbrs chr accs rest =
+    and aux_end_block loc ns blocks clauses macros kinds types tabbrs chr rest =
       match rest with
       | Program.End _ :: rest ->
-          aux_run ns blocks clauses macros kinds types tabbrs chr accs rest
+          aux_run ns blocks clauses macros kinds types tabbrs chr rest
       | _ -> error ~loc "matching } is missing"
 
     in
-    let blocks, chr, rest = aux_run [] [] [] [] [] [] [] [] StrSet.empty dl in
-    begin match rest with
-    | [] -> ()
-    | Program.End loc :: _ -> error ~loc "extra }"
-    | _ -> assert false
-    end;
-    if chr <> [] then
-      error "CHR cannot be declared outside a Constraint block";
-    blocks
+    let rec aux_accumulate file_name digest accs deps = function
+      | Program.Accumulated (_,[]) :: rest -> aux_accumulate file_name digest accs deps rest
+
+      | Program.Accumulated (loc,x :: more) :: rest ->
+          let rest = Program.Accumulated (loc, more) :: rest in
+          if StrSet.mem x.digest accs then
+            aux_accumulate file_name digest accs ((x.file_name,x.digest) :: deps) rest
+          else
+            aux_accumulate x.file_name x.digest accs [] x.ast @ aux_accumulate file_name digest (StrSet.add x.digest accs) ((x.file_name,x.digest) :: deps) rest
+
+      | rest -> [{ file_name; deps = List.rev deps; digest; ast = rest }]
+    in
+
+    let files = aux_accumulate file_name digest StrSet.empty [] dl in
+    files |> List.map (fun x ->
+    let blocks, chr, rest = aux_run [] [] [] [] [] [] [] [] x.ast in
+      begin match rest with
+      | [] -> ()
+      | Program.End loc :: _ -> error ~loc "extra }"
+      | _ -> assert false
+      end;
+      if chr <> [] then
+        error "CHR cannot be declared outside a Constraint block";
+      { x with ast = blocks })
 
 end (* }}} *)
 
@@ -1160,14 +1188,14 @@ end = struct
           F.Set.union defs p.Scoped.pred_symbols,
           F.Set.union ty_defs p.Scoped.ty_symbols,
           Scoped.Constraints({loc;ctx_filter; clique; rules},p) :: compiled_rest
-      | Accumulated p :: rest ->
+      | Block p :: rest ->
           let _, p = compile_program macros state p in
           let kinds, types, type_abbrevs, defs, ty_defs, compiled_rest =
             compile_body macros kinds types type_abbrevs defs ty_defs state rest in
           kinds, types, type_abbrevs,
           F.Set.union defs p.Scoped.pred_symbols,
           F.Set.union ty_defs p.Scoped.ty_symbols,
-          Scoped.Accumulated p :: compiled_rest
+          Scoped.Block p :: compiled_rest
   
     in
     let toplevel_macros, pbody = compile_program toplevel_macros state p in
@@ -1372,7 +1400,7 @@ module Flatten : sig
       let kinds, types, type_abbrevs, clauses, chr =
         compile_block kinds types type_abbrevs clauses chr pred_subst ty_subst body in
       compile_block kinds types type_abbrevs clauses chr pred_subst ty_subst rest
-  | Scoped.Accumulated { kinds=k; types = t; type_abbrevs = ta; body; ty_symbols = _ } :: rest ->
+  | Scoped.Block { kinds=k; types = t; type_abbrevs = ta; body; ty_symbols = _ } :: rest ->
       let kinds = merge_kinds (apply_subst_kinds ty_subst k) kinds in
       let types = merge_types TypingEnv.empty (apply_subst_types ty_subst t) types in
       let type_abbrevs = merge_type_abbrevs type_abbrevs (apply_subst_type_abbrevs ty_subst ta) in
@@ -1386,7 +1414,7 @@ module Flatten : sig
   let run state { Scoped.pbody; toplevel_macros } =
     let kinds, types, type_abbrevs, clauses_rev, chr_rev = compile_body pbody in
     let signature = { Flat.kinds; types; type_abbrevs; toplevel_macros } in
-    { Flat.clauses = List.(flatten (rev clauses_rev)); chr = List.rev chr_rev; builtins = []; signature } (* TODO builtins can be in a unit *)
+    { Flat.clauses = List.(flatten (rev clauses_rev)); chr = List.rev chr_rev; builtins = None; signature } (* TODO builtins can be in a unit *)
 
 
 end
@@ -1497,7 +1525,7 @@ end = struct
     let type_check_time = ref 0.0 in
     let det_check_time = ref 0.0 in
 
-    let builtins = builtins |> List.map (fun file_name -> 
+    let builtins = builtins |> Option.map (fun file_name -> 
       let builtins, _ = declared_builtins ~file_name in
       StrMap.fold (fun _ (BuiltInPredicate.Pred(name,_,_)) acc ->
       let symb =
@@ -1519,11 +1547,11 @@ end = struct
     file_name) in
 
     let types, u_types =
-      List.fold_left (fun (types, u_types) (bl,_) ->
+      Option.fold ~some:(fun (bl,_) ->
         List.fold_left (fun (t,ut) (s,_) ->
           TypingEnv.set_as_implemented_in_ocaml t s, TypingEnv.set_as_implemented_in_ocaml ut s)
           (types, u_types) bl)
-        (types, u_types)
+        ~none:(types, u_types)
       builtins in
 
     TypingEnv.iter_names (fun k -> function
@@ -1578,6 +1606,9 @@ end = struct
   { version; checked_code; base_hash = hash_base base;
     type_checking_time = if flags.time_typechecking then !type_check_time +. check_sig else 0.0;
     det_checking_time = if flags.time_typechecking then !det_check_time else 0.0;
+    file_name = u.file_name;
+    digest = u.digest;
+    deps = u.deps;
 }
 
 end
@@ -2120,7 +2151,7 @@ end = struct
     let chr, clique = CHR.new_clique (SymbolMap.global_name state symbols) ctx_filter clique chr in
     List.fold_left (extend1_chr ~builtins ~types flags state clique) (symbols,chr) rules
 
-let extend1_signature base_signature (signature : checked_compilation_unit_signature) =
+let extend1_signature base_signature ({ signature } : checked_compilation_unit_signature) =
   let { Assembled.kinds = ok; types = ot; type_abbrevs = ota; toplevel_macros = otlm; ty_names = ots } = base_signature in
   let { Assembled.toplevel_macros; kinds; types; type_abbrevs; ty_names } = signature in
   let kinds = Flatten.merge_kinds ok kinds in
@@ -2132,7 +2163,7 @@ let extend1_signature base_signature (signature : checked_compilation_unit_signa
   let ty_names = F.Map.union merge ots ty_names in
   { Assembled.kinds; types; type_abbrevs; toplevel_macros; ty_names }
 
-let new_symbols_of_types ~(base_sig:checked_compilation_unit_signature) new_types =
+let new_symbols_of_types ~(base_sig:Assembled.signature) new_types =
   let symbs = TypingEnv.all_symbols new_types in
   symbs |> List.filter_map (fun (symb,m) -> if TypingEnv.mem_symbol base_sig.types symb then None else Some symb),
   symbs |> List.filter_map (fun (symb, { TypingEnv.indexing } ) -> match indexing with Index m -> Some (symb, m) | _ -> None)
@@ -2153,7 +2184,7 @@ let allocate_new_symbols state ~symbols ~new_defined_symbols =
 
 let extend1 flags (state, base) unit =
 
-  let signature = extend1_signature base.Assembled.signature unit.checked_code.CheckedFlat.signature in
+  let signature = extend1_signature base.Assembled.signature (signature_of_checked_compilation_unit unit) in
 
   let { Assembled.hash; clauses = cl; symbols; prolog_program; indexing; signature = bsig; chr = ochr; builtins = ob; total_type_checking_time; total_det_checking_time } = base in
   let { version; base_hash; checked_code = { CheckedFlat.clauses; chr; builtins; signature = { types = new_types } }; type_checking_time; det_checking_time } = unit in
@@ -2168,14 +2199,14 @@ let extend1 flags (state, base) unit =
   (* Format.eprintf "extended\n%!"; *)
 
   let symbols, builtins =
-    List.fold_left (fun (symbols, ob) (builtins,file_name) ->
+    Option.fold ~some:(fun (builtins,file_name) ->
       let bm, _ = declared_builtins ~file_name in
       List.fold_left (fun (symbols,builtins) (symb, name) ->
         let p = StrMap.find name bm in
         let symbols, (c,_) = SymbolMap.allocate_global_symbol state symbols symb in
         let builtins = Builtins.register builtins p c in
         symbols, builtins) (symbols, ob) builtins)
-      (symbols, ob) builtins
+     ~none:(symbols, ob) builtins
     in
 
   let symbols, chr =
@@ -2223,29 +2254,42 @@ end
   API
  ****************************************************************************)
 
-let scope s ~toplevel_macros p : scoped_program =
-  let p = RecoverStructure.run s p in
-  let p = Scope_Quotation_Macro.run ~toplevel_macros s p in
-  {
-    version = "%%VERSION_NUM%%";
-    code = p;
-  }
+let scope s ~toplevel_macros ~builtins p : scoped_program list =
+  let pl = RecoverStructure.run s p in
+  pl |> List.map (fun { Ast.ast = p; digest; deps; file_name} -> 
+    let p = Scope_Quotation_Macro.run ~toplevel_macros s p in
+    {
+      version = "%%VERSION_NUM%%";
+      code = p;
+      builtins;
+      file_name;
+      digest;
+      deps;
+    })
 
 (* Compiler passes *)
-let unit_or_header_of_scoped s ~builtins (p : scoped_program) : unchecked_compilation_unit =
+let unit_or_header_of_scoped s (p : scoped_program) : unchecked_compilation_unit =
   assert ("%%VERSION_NUM%%" = p.version);
-  let p = Flatten.run s p.code in
+  let f = Flatten.run s p.code in
   {
     version = "%%VERSION_NUM%%";
-    code = { p with builtins };
+    code = { f with builtins = p.builtins };
+    file_name = p.file_name;
+    digest = p.digest;
+    deps = p.deps;
   }
 ;;
 
 let print_unit { print_units } x =
     if print_units then
       let b1 = Marshal.to_bytes x.code [] in
-      Printf.eprintf "== UNIT =================\ncode: %dk (%d clauses)\n\n%!"
+      Printf.eprintf "UNIT %s:\n  size: %5dk clauses: %5d builtins: %5d digest: 0x%s\n  deps: %s\n\n%!"
+        x.file_name
         (Bytes.length b1 / 1024) (List.length x.code.Flat.clauses)
+        (Option.fold ~none:0 ~some:(fun file_name -> List.length (declared_builtins ~file_name |> snd)) x.code.Flat.builtins)
+        (Digest.to_hex x.digest)
+        (if x.deps <> [] then "\n  - " ^ String.concat "\n  - "
+            (List.mapi (fun i (f,d) -> Printf.sprintf "%d: %s, digest: 0x%s" (i+1) f (Digest.to_hex d)) x.deps) else "none")
 ;;
 
 let assemble_unit ~flags ~header:(s,base) units : program =
@@ -2255,10 +2299,16 @@ let assemble_unit ~flags ~header:(s,base) units : program =
  s, p
 ;;
 
-let scoped_of_ast ~flags:_ ~header:(s,u) ?(calc=[]) ?(builtins = []) p =
+let scoped_of_builtins ~flags:_ ~header:(s,u) ?(calc=[]) builtins =
   let parser = Option.get @@ D.State.get parser s in
-  let builtins_src = List.concat @@ List.map (fun file_name -> ast_of_builtins ~calc ~parser ~file_name) builtins in
-  scope ~toplevel_macros:u.Assembled.signature.toplevel_macros s (builtins_src @ p)
+  let builtins_src = ast_of_builtins ~calc ~parser ~file_name:builtins in
+  match scope ~toplevel_macros:u.Assembled.signature.toplevel_macros s ~builtins:(Some builtins) builtins_src with
+  | [x] -> x
+  | _ -> assert false
+
+let scoped_of_ast ~flags:_ ~header:(s,u) ?(calc=[]) p =
+  scope ~toplevel_macros:u.Assembled.signature.toplevel_macros s ~builtins:None p
+
 
 let header_of_ast ~flags ~parser:p state_descriptor quotation_descriptor hoas_descriptor calc_descriptor builtins : header =
   let state = D.State.(init (merge_descriptors D.elpi_state_descriptor state_descriptor)) in
@@ -2282,24 +2332,25 @@ let header_of_ast ~flags ~parser:p state_descriptor quotation_descriptor hoas_de
   let state = D.State.set parser state (Some p) in
   let state = D.State.set D.while_compiling state true in
   let base = Assembled.empty () in
-  let header = state, base in
   (* let state = State.set Symbols.table state (Symbols.global_table ()) in *)
-  let builtins_src = scoped_of_ast ~flags ~calc:calc_descriptor ~header ~builtins [] in
-  let u = unit_or_header_of_scoped state ~builtins builtins_src in
-  print_unit flags u;
-  let u = Check.check ~flags state ~base u in
- (* with toplevel_macros = u.checked_code.signature.toplevel_macros } in *)
-  (* Printf.eprintf "header_of_ast: types u %d\n%!" (F.Map.cardinal u.checked_code.CheckedFlat.signature.types); *)
-  let h = assemble_unit ~flags ~header:(state,base) u in
-  (* Printf.eprintf "header_of_ast: types h %d\n%!" (F.Map.cardinal (snd h).Assembled.signature.types); *)
-  h
+  builtins |> List.fold_left (fun (state,base as header) builtins ->
+    let scoped = scoped_of_builtins ~flags ~calc:calc_descriptor ~header builtins in
+    let u = unit_or_header_of_scoped state scoped in
+    print_unit flags u;
+    let u = Check.check ~flags state ~base u in
+  (* with toplevel_macros = u.checked_code.signature.toplevel_macros } in *)
+    (* Printf.eprintf "header_of_ast: types u %d\n%!" (F.Map.cardinal u.checked_code.CheckedFlat.signature.types); *)
+    let h = assemble_unit ~flags ~header:(state,base) u in
+    (* Printf.eprintf "header_of_ast: types h %d\n%!" (F.Map.cardinal (snd h).Assembled.signature.types); *)
+    h)
+   (state,base)
 
 let check_unit ~flags ~base:(st,base) u = Check.check ~flags st ~base u
 
 let empty_base ~header:b = b
 
-let unit_of_scoped ~flags ~header:(s, u) ?(builtins=[]) p : unchecked_compilation_unit =
-  let u = unit_or_header_of_scoped s ~builtins p in
+let unit_of_scoped ~flags ~header:(s, u) p : unchecked_compilation_unit =
+  let u = unit_or_header_of_scoped s p in
   print_unit flags u;
   u
 
@@ -2309,11 +2360,16 @@ let append_unit ~flags ~base:(s,p) unit : program =
 let append_unit_signature ~flags ~base:(s,p) unit : program =
   Assemble.extend_signature s p unit
   
-let program_of_ast ~flags ~header:((st, base) as header : State.t * Assembled.program) p : program =
-  let p = scoped_of_ast ~flags ~calc:[] ~header p in
-  let u = unit_of_scoped ~flags ~header p in
-  let u = Check.check ~flags st ~base u in
-  assemble_unit ~flags ~header u
+let program_of_ast ~flags ~header:(header : State.t * Assembled.program) p : program =
+  let pl = scoped_of_ast ~flags ~calc:[] ~header p in
+  pl |> List.fold_left (fun ((st, base) as header, seen) (p : scoped_program) ->
+    if StrSet.mem p.digest seen then (header,seen)
+    else
+      let u = unit_of_scoped ~flags ~header p in
+      let u = Check.check ~flags st ~base u in
+      assemble_unit ~flags ~header u,StrSet.add u.digest seen)
+    (header,StrSet.empty)
+    |> fst
 
 let total_type_checking_time { WithMain.total_type_checking_time = x } = x
 let total_det_checking_time { WithMain.total_det_checking_time = x } = x

--- a/src/compiler/compiler.mli
+++ b/src/compiler/compiler.mli
@@ -31,18 +31,28 @@ type program
 val program_of_ast : flags:flags -> header:header -> Ast.Program.t -> program
 
 type scoped_program
-val scoped_of_ast : flags:flags -> header:header -> ?calc:CalcHooks.descriptor -> ?builtins:declared_builtins list -> Ast.Program.t -> scoped_program
+val scoped_program_name : scoped_program -> string
+val scoped_program_digest : scoped_program -> Digest.t
+val scoped_program_deps : scoped_program -> Ast.dependencies
+val scoped_of_builtins : flags:flags -> header:header -> ?calc:CalcHooks.descriptor -> declared_builtins -> scoped_program
+val scoped_of_ast : flags:flags -> header:header -> ?calc:CalcHooks.descriptor -> Ast.Program.t -> scoped_program list
 
 type checked_compilation_unit
 val pp_checked_compilation_unit : Format.formatter -> checked_compilation_unit -> unit
+val checked_compilation_unit_name : checked_compilation_unit -> string
+val checked_compilation_unit_digest : checked_compilation_unit -> Digest.t
+val checked_compilation_unit_deps : checked_compilation_unit -> Ast.dependencies
+
 type unchecked_compilation_unit
 val empty_base : header:header -> program
-val unit_of_scoped : flags:flags -> header:header -> ?builtins:declared_builtins list -> scoped_program -> unchecked_compilation_unit
+val unit_of_scoped : flags:flags -> header:header -> scoped_program -> unchecked_compilation_unit
 val append_unit : flags:flags -> base:program -> checked_compilation_unit -> program
 val check_unit : flags:flags -> base:program -> unchecked_compilation_unit -> checked_compilation_unit
 
 type checked_compilation_unit_signature
 val signature_of_checked_compilation_unit : checked_compilation_unit -> checked_compilation_unit_signature
+val checked_compilation_unit_signature_name : checked_compilation_unit_signature -> string
+val checked_compilation_unit_signature_digest : checked_compilation_unit_signature -> Digest.t
 
 val append_unit_signature : flags:flags -> base:program -> checked_compilation_unit_signature -> program
 

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -300,6 +300,10 @@ module TypeAbbreviation = struct
 
 end
 
+type dependencies = (string * Digest.t) list
+[@@ deriving ord, show]
+type 'a parser_output = { file_name : string; digest : Digest.t; deps : dependencies; ast : 'a }
+[@@ deriving ord, show]
 
 module Program = struct
 
@@ -311,7 +315,7 @@ module Program = struct
     | Shorten of Loc.t * (Func.t * Func.t) list (* prefix suffix *)
     | End of Loc.t
 
-    | Accumulated of Loc.t * parser_output list
+    | Accumulated of Loc.t * decl_list parser_output list
 
     (* data *)
     | Clause of (Term.t, raw_attribute list,unit, unit) Clause.t
@@ -322,11 +326,11 @@ module Program = struct
     | Pred of (raw_attribute list,raw_attribute list) Type.t
     | TypeAbbreviation of (Func.t,raw_attribute list TypeExpression.t) TypeAbbreviation.t
     | Ignored of Loc.t
-  and parser_output = { file_name : string; digest : Digest.t; ast : decl list }
+  and decl_list = decl list
   [@@deriving show]
 
 
-type t = decl list [@@deriving show]
+type t = decl_list parser_output [@@deriving show]
 
 end
 
@@ -402,7 +406,7 @@ and block =
   | Namespace of Func.t * program
   | Shorten of Func.t shorthand list * program
   | Constraints of (Func.t,Term.t) block_constraint * program
-  | Accumulated of program
+  | Block of program
 and attribute = {
   insertion : insertion option;
   id : string option;
@@ -429,6 +433,9 @@ and 'a shorthand = {
 }
 and functionality = Function | Relation
 and variadic = Variadic | NotVariadic
+[@@deriving show, ord]
+
+type t = program parser_output
 [@@deriving show, ord]
 
 end

--- a/src/parser/ast.mli
+++ b/src/parser/ast.mli
@@ -174,6 +174,11 @@ module TypeAbbreviation : sig
 
 end
 
+type dependencies = (string * Digest.t) list
+[@@ deriving ord, show]
+type 'a parser_output = { file_name : string; digest : Digest.t; deps : dependencies; ast : 'a }
+[@@ deriving ord, show]
+
 module Program : sig
 
   type decl =
@@ -184,7 +189,7 @@ module Program : sig
     | Shorten of Loc.t * (Func.t * Func.t) list (* prefix suffix *)
     | End of Loc.t
 
-    | Accumulated of Loc.t * parser_output list
+    | Accumulated of Loc.t * decl_list parser_output list
 
     (* data *)
     | Clause of (Term.t, raw_attribute list, unit,unit) Clause.t
@@ -195,10 +200,10 @@ module Program : sig
     | Pred of (raw_attribute list,raw_attribute list) Type.t
     | TypeAbbreviation of (Func.t,raw_attribute list TypeExpression.t) TypeAbbreviation.t
     | Ignored of Loc.t
-  and parser_output = { file_name : string; digest : Digest.t; ast : decl list }
+  and decl_list = decl list
   [@@ deriving show]
 
-  type t = decl list
+  type t = decl_list parser_output
   [@@ deriving show]
 
 end
@@ -239,7 +244,7 @@ and block =
   | Namespace of Func.t * program
   | Shorten of Func.t shorthand list * program
   | Constraints of (Func.t,Term.t) block_constraint * program
-  | Accumulated of program
+  | Block of program
 and attribute = {
   insertion : insertion option;
   id : string option;
@@ -274,6 +279,9 @@ and provenance =
   | Core (* baked into the elpi runtime *)
   | Builtin of { variant : int } (* buitin or host declared *)
   | File of Loc.t
+[@@deriving show, ord]
+
+type t = program parser_output
 [@@deriving show, ord]
 
 end

--- a/src/parser/grammar.mly
+++ b/src/parser/grammar.mly
@@ -132,7 +132,7 @@ let mode_of_IO io =
 %on_error_reduce term
 
 (* non terminals *)
-%type < Program.t > program
+%type < Program.decl list > program
 %type < Goal.t > goal
 %type < (Term.t, raw_attribute list, unit,unit) Clause.t > clause
 %type < Term.t > term
@@ -178,9 +178,9 @@ decl:
 | LCURLY { Program.Begin (loc $sloc) }
 | RCURLY { Program.End (loc $sloc) }
 | ext = accumulate; l = separated_nonempty_list(CONJ,filename); FULLSTOP {
-    Program.Accumulated(loc $sloc,List.(concat (map (fun x ->
+    Program.Accumulated(loc $sloc,List.(map (fun x ->
       let cwd = Filename.dirname (loc $sloc).source_name in
-      C.parse_file ~cwd (x ^ ext)) l)))
+      C.parse_file ~cwd (x ^ ext)) l))
   }
 | LOCAL; l = separated_nonempty_list(CONJ,constant); option(type_term); FULLSTOP {
     raise (ParseError(loc $loc,"local keyword is no longer supported"))  }

--- a/src/parser/parse.ml
+++ b/src/parser/parse.ml
@@ -8,11 +8,11 @@ open Elpi_lexer_config
 exception ParseError = Parser_config.ParseError
 
 module type Parser = sig
-  val program : file:string -> Ast.Program.decl list
+  val program : file:string -> Ast.Program.t
   val goal : loc:Util.Loc.t -> text:string -> Ast.Goal.t
   
   val goal_from : loc:Util.Loc.t -> Lexing.lexbuf -> Ast.Goal.t
-  val program_from : loc:Util.Loc.t -> Lexing.lexbuf -> Ast.Program.t
+  val program_from : loc:Util.Loc.t -> digest:Digest.t -> Lexing.lexbuf -> Ast.Program.t
 end
 
 module type Parser_w_Internals = sig
@@ -33,7 +33,7 @@ end
 
 module Make(C : Config) = struct
   
-let parse_ref : (?cwd:string -> string -> Ast.Program.parser_output list) ref =
+let parse_ref : (?cwd:string -> string -> Ast.Program.t) ref =
   ref (fun ?cwd:_ _ -> assert false)
   
 
@@ -90,28 +90,34 @@ let already_parsed = Hashtbl.create 11
 
 let cleanup_fname filename = Re.Str.replace_first (Re.Str.regexp "/_build/[^/]+") "" filename
 
+let parse_one_file digest filename =
+  if Hashtbl.mem already_parsed digest then
+    Hashtbl.find already_parsed digest
+  else 
+    let ic = open_in filename in
+    let lexbuf = Lexing.from_channel ic in
+    let dest = cleanup_fname filename in
+    lexbuf.Lexing.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = dest };
+    let ast = parse Grammar.Incremental.program lexbuf in
+    let output = { Ast.file_name = filename; deps = []; digest; ast } in
+    Hashtbl.add already_parsed digest output;
+    close_in ic;
+    output
+
 let () =
   parse_ref := (fun ?cwd filename ->
   let filename = C.resolver ?cwd ~unit:filename () in
   let digest = Digest.file filename in
-  let to_parse =
-    if Filename.extension filename = ".mod" then
-      let sigf = Filename.chop_extension filename ^ ".sig" in
-      if Sys.file_exists sigf then [sigf,Digest.file sigf;filename,digest]
-      else [filename,digest]
-    else [filename,digest] in
-  to_parse |> List.map (fun (filename,digest) ->
-    if Hashtbl.mem already_parsed digest then
-      { Ast.Program.file_name = filename; digest; ast = [] }
-    else
-      let ic = open_in filename in
-      let lexbuf = Lexing.from_channel ic in
-      let dest = cleanup_fname filename in
-      lexbuf.Lexing.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = dest };
-      Hashtbl.add already_parsed digest true;
-      let ast = parse Grammar.Incremental.program lexbuf in
-      close_in ic;
-      { file_name = filename; digest; ast }))
+  if Filename.extension filename = ".mod" then
+    (* Teyjus compatibility *)
+    let sig_filename = Filename.chop_extension filename ^ ".sig" in
+    if Sys.file_exists sig_filename then
+      let ds = Digest.file sig_filename in
+      let s = parse_one_file ds sig_filename in
+      let m = parse_one_file digest filename in
+      { Ast.file_name = filename; digest = Digest.string (ds^digest); deps = []; ast = s.ast @ m.ast  }
+    else parse_one_file digest filename
+  else parse_one_file digest filename)
 
 let to_lexing_loc { Util.Loc.source_name; line; line_starts_at; source_start; _ } =
   { Lexing.pos_fname = source_name;
@@ -135,14 +141,18 @@ let goal ~loc ~text =
   let lexbuf = Lexing.from_string text in
   goal_from ~loc lexbuf
 
-let program_from ~loc lexbuf =
+let program_from ~loc ~digest lexbuf =
   Hashtbl.clear already_parsed;
   lexing_set_position lexbuf loc;
-  parse Grammar.Incremental.program lexbuf
+  let ast = parse Grammar.Incremental.program lexbuf in
+  let filename = let open Util.Loc in
+    Printf.sprintf "%s:%d:%d" loc.source_name loc.source_stop lexbuf.Lexing.lex_curr_pos in
+  { Ast.file_name = filename; deps = []; digest; ast }
+
 
 let program ~file =
   Hashtbl.clear already_parsed;
-  List.(concat (map (fun { Ast.Program.ast = x } -> x) @@ !parse_ref file))
+  !parse_ref file
 
 module Internal = struct
 let infix_SYMB = Grammar.infix_SYMB

--- a/src/parser/parse.mli
+++ b/src/parser/parse.mli
@@ -9,11 +9,11 @@ open Elpi_lexer_config
 exception ParseError of Util.Loc.t * string
 
 module type Parser = sig
-  val program : file:string -> Ast.Program.decl list
+  val program : file:string -> Ast.Program.t
   val goal : loc:Util.Loc.t -> text:string -> Ast.Goal.t
   
   val goal_from : loc:Util.Loc.t -> Lexing.lexbuf -> Ast.Goal.t
-  val program_from : loc:Util.Loc.t -> Lexing.lexbuf -> Ast.Program.t
+  val program_from : loc:Util.Loc.t -> digest:Digest.t -> Lexing.lexbuf -> Ast.Program.t
 end
 
 module type Parser_w_Internals = sig

--- a/src/parser/parser_config.ml
+++ b/src/parser/parser_config.ml
@@ -12,7 +12,7 @@ exception ParseError of Util.Loc.t * string
    resolution is not a parser business *)
 
 module type ParseFile = sig
-  val parse_file : ?cwd:string -> string -> Ast.Program.parser_output list
+  val parse_file : ?cwd:string -> string -> Ast.Program.t
   val get_current_client_loc_payload : unit -> Obj.t option
   val set_current_clent_loc_pyload : Obj.t -> unit
 end

--- a/src/parser/test_parser.ml
+++ b/src/parser/test_parser.ml
@@ -14,7 +14,7 @@ let error s a1 a2 =
   output_string oc1 "\nnew:\n";
   output_string oc1 (Program.show a1);
   output_string oc2 "\nreference:\n";
-  output_string oc2 (Program.show a2);
+  output_string oc2 (Program.show_decl_list a2);
   flush_all ();
   close_out oc1;
   close_out oc2;
@@ -44,8 +44,8 @@ let test s x y w z att ?warns b =
   let lexbuf = Lexing.from_string s in
   warn := None;
   try
-    let p = Parser.program_from ~loc lexbuf in
-    if p <> exp then error s p exp;
+    let { ast } as p = Parser.program_from ~loc ~digest:(Digest.string s) lexbuf in
+    if ast <> exp then error s p exp;
     match !warn, warns with
     | None, None -> ()
     | Some w, None -> Printf.eprintf "parsing '%s': unexpected warning:\n%s\n" s w; exit 1
@@ -61,8 +61,8 @@ let testR s x y w z attributes to_match to_remove guard new_goal =
   let lexbuf = Lexing.from_string s in
   let loc = Loc.initial "(input)" in
   try
-    let p = Parser.program_from ~loc lexbuf in
-    if p <> exp then
+    let { ast } as p = Parser.program_from ~loc ~digest:(Digest.string s) lexbuf in
+    if ast <> exp then
       error s p exp
   with Parse.ParseError(loc,message) ->
     Printf.eprintf "error parsing '%s' at %s\n%s%!" s (Loc.show loc) message;
@@ -72,8 +72,8 @@ let testT s () =
   let lexbuf = Lexing.from_string s in
   let loc = Loc.initial "(input)" in
   try
-    let p = Parser.program_from ~loc lexbuf in
-    match p with
+    let { ast } as p = Parser.program_from ~loc ~digest:(Digest.string s) lexbuf in
+    match ast with
     | [Program.Pred _] -> ()
     | [Program.Type _] -> ()
     | _ -> 
@@ -87,7 +87,7 @@ let testF s i msg =
   let lexbuf = Lexing.from_string s in
   let loc = Loc.initial "(input)" in
   try
-    let _ = Parser.program_from ~loc lexbuf in
+    let _ = Parser.program_from ~loc ~digest:(Digest.string s) lexbuf in
     Printf.eprintf "error, '%s' should not parse\n%!" s;
     exit 1
   with Parse.ParseError(loc,message) ->

--- a/src/runtime/data.ml
+++ b/src/runtime/data.ml
@@ -668,8 +668,8 @@ end = struct
 
   end
 
-  let equal ~uf x y = compare (UF.find uf x) (UF.find uf y) = 0
-  let compare ~uf x y = compare (UF.find uf x) (UF.find uf y)
+  let equal ~uf x y = Stdlib.compare (UF.find uf x) (UF.find uf y) = 0
+  let compare ~uf x y = Stdlib.compare (UF.find uf x) (UF.find uf y)
 
   let rec undup ~uf = function
   | [] -> []

--- a/src/utils/util.ml
+++ b/src/utils/util.ml
@@ -323,7 +323,7 @@ let rec for_all23 ~argsdepth (p : argsdepth:int -> matching:bool -> 'a) x1 x2 x3
 let pp_loc_opt = function
   | None -> ""
   | Some loc -> Loc.show loc
-type warning_id = LinearVariable | UndeclaredGlobal | FlexClause | ImplicationPrecedence
+type warning_id = LinearVariable | UndeclaredGlobal | FlexClause | ImplicationPrecedence | NestedAccumulate
 let default_warn ?loc ~id:_ s =
   Format.eprintf "@[<hv>Warning: %s@,%s@]\n%!" (pp_loc_opt loc) s
 let default_error ?loc s =

--- a/src/utils/util.mli
+++ b/src/utils/util.mli
@@ -250,7 +250,7 @@ val anomaly : ?loc:Loc.t -> string -> 'a
 (* If we type check the program, then these are anomalies *)
 val type_error : ?loc:Loc.t -> string -> 'a
 (* A non fatal warning *)
-type warning_id = LinearVariable | UndeclaredGlobal | FlexClause | ImplicationPrecedence
+type warning_id = LinearVariable | UndeclaredGlobal | FlexClause | ImplicationPrecedence | NestedAccumulate
 val warn : ?loc:Loc.t -> id:warning_id -> string -> unit
 (* Indirection for standard print functions *)
 val printf : ('a, Format.formatter, unit) format -> 'a

--- a/tests/sources/sepcomp10.ml
+++ b/tests/sources/sepcomp10.ml
@@ -1,10 +1,16 @@
 open Elpi.API
 
-let cc ~elpi ~flags ~base ?builtins i u =
-    Compile.unit ~elpi ~flags ~base ?builtins
-     (Compile.scope ~elpi ~flags ?builtins
+let cc ~elpi ~flags ~base i u =
+    Compile.unit ~elpi ~flags ~base
+     (match
+     (Compile.scope_ast ~elpi ~flags
       (Parse.program_from ~elpi ~loc:(Ast.Loc.initial (Printf.sprintf "<u%d>" i))
-        (Lexing.from_string u)))
+        ~digest:(Digest.string u) (Lexing.from_string u)))
+      with [x] -> x | _ -> assert false)
+
+  let ccb ~elpi ~flags ~base builtins i  =
+    Compile.unit ~elpi ~flags ~base
+     (Compile.scope_builtins ~elpi ~flags builtins)
 
 let u1 = {| pred p. p. |}
 
@@ -33,7 +39,7 @@ let main =
 
   let u1 = cc ~elpi ~flags ~base 1 u1 in
 
-  let u2 = cc ~elpi ~flags ~base ~builtins:b2 2 "" in
+  let u2 = ccb ~elpi ~flags ~base b2 2 in
 
   let base = Compile.extend ~base u1 in
 

--- a/tests/sources/sepcomp_template.ml
+++ b/tests/sources/sepcomp_template.ml
@@ -6,9 +6,11 @@ let init () =
 let cc ~elpi ~flags ~base i u =
   let u =
     Compile.unit ~elpi ~flags ~base
-     (Compile.scope ~elpi ~flags
-      (Parse.program_from ~elpi ~loc:(Ast.Loc.initial (Printf.sprintf "<u%d>" i))
-        (Lexing.from_string u))) in
+    (match
+     (Compile.scope_ast ~elpi ~flags
+      (Parse.program_from ~elpi ~digest:(Digest.string u) ~loc:(Ast.Loc.initial (Printf.sprintf "<u%d>" i))
+        (Lexing.from_string u)))
+    with [x] -> x | _ -> assert false) in
   Compile.extend ~flags ~base u, u
 
 let signature_of u = Compile.signature u

--- a/tests/sources/shorten2.elpi
+++ b/tests/sources/shorten2.elpi
@@ -1,6 +1,6 @@
+pred foo.
 accumulate shorten_aux, shorten_aux2.
 
-pred foo.
 foo :- true.
 
 main :-


### PR DESCRIPTION
The APIs return all files recursively accumulated.

- [x] use parser output everywhere
- [x] RecoverStructure gives a list of programs
- [x] fix API: parse 1 file, get many units, deduplicate later if needed

Fix: #401 