### PR TITLE
Update Cygwin setup in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,8 @@ jobs:
         run: |
           opam exec -- cygpath -m ${{ github.workspace }} | % {$_ -replace "^","workspace=" }  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           opam exec -- sed -i ' ' tests/sources/*.elpi
-          & "C:/.opam/.cygwin/setup-x86_64.exe" -s https://mirrors.kernel.org/sourceware/cygwin/ -v -q -P time,which,wdiff
+          opam init --reinit --cygwin-extra-packages=time,which,wdiff
+#          & "C:/.opam/.cygwin/setup-x86_64.exe" -s https://mirrors.kernel.org/sourceware/cygwin/ -v -q -P time,which,wdiff
 
 # Build ######################################################################
 #


### PR DESCRIPTION
Replaced Cygwin setup command with opam init for package installation.