### PR TITLE
qname keyword

### DIFF
--- a/src/builtin.elpi
+++ b/src/builtin.elpi
@@ -50,6 +50,8 @@ external symbol (,)   : variadic (func) (func).
 
 external symbol uvar  : A = "core".
 
+external symbol qname : A = "core".
+
 external symbol (as)  : A -> A -> A = "core".
 
 external symbol (=>)  : (pred) -> (func) -> (func) = "core".

--- a/src/builtin.ml
+++ b/src/builtin.ml
@@ -244,6 +244,7 @@ external func pattern_match A -> A.|};
   LPCode "external symbol (:-)  : (func) -> list (pred) -> (func) = \"core\".";
   LPCode "external symbol (,)   : variadic (func) (func).";
   LPCode "external symbol uvar  : A = \"core\".";
+  LPCode "external symbol qname : A = \"core\".";
   LPCode "external symbol (as)  : A -> A -> A = \"core\".";
   LPCode "external symbol (=>)  : (pred) -> (func) -> (func) = \"core\".";
   LPCode "external symbol (=>)  : list (pred) -> (func) -> (func) = \"core\"."; (* HACK in TC to handle this*)

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -1801,6 +1801,7 @@ end = struct
     (!symb, !amap), t
 
   let check_mut_excl state symbols ~loc pred_info cl cl_st (oc: overlap_clause option) p amap : pred_info C.Map.t =
+    (* Printf.printf "Checking %s\n ov_l %s\n" (Loc.show loc) (match oc with Some {overlap_loc} -> (match overlap_loc with | Some x -> Loc.show x | _ -> "Some") | _ -> "None"); *)
     let pp_global_predicate fmt p =
       let f = SymbolMap.global_name state symbols p in
       Format.fprintf fmt "predicate %a" F.pp f in
@@ -1904,8 +1905,12 @@ end = struct
       b
     in *)
     let is_eigen_variable ~min_depth ~depth = function
-      | Const b -> min_depth <= b && b < depth
+      | (Const k | App(k,_,_)) -> (min_depth <= k && k < depth)
       | _ -> false
+    in
+    let is_qname = function
+    | (Const k | App(k,_,_)) -> k == Global_symbols.namec
+    | _ -> false
     in
     let rec is_unif_var = function
       | AppUVar _ | UVar (_, _) | Discard | Arg (_, _)|AppArg (_, _) -> true
@@ -1924,8 +1929,10 @@ end = struct
       let rig_occ = ref true in
       let has_input = ref false in
       let is_catchall = ref true in
+      let has_qname = ref false in
       let update_bools m t =
         has_input := !has_input || m;
+        has_qname := !has_qname || is_qname t;
         rig_occ := !rig_occ && (is_eigen_variable ~min_depth ~depth t);
         is_catchall := !is_catchall && is_unif_var t
       in
@@ -1942,26 +1949,28 @@ end = struct
         | (([] as is) | (_::is)), _::args, [] -> mkDiscard :: mkpats is args mode
         | _ -> assert false
       in
-      (not !has_input || !rig_occ), (not !has_input || !is_catchall), R.mkAppL p @@ mkpats indexed_args args mode 
+      (not !has_input || !rig_occ), (not !has_input || !is_catchall), (!has_input && !has_qname), R.mkAppL p @@ mkpats indexed_args args mode 
     in
 
-    (* Returns if the clause has a bang *)
     let check_overlaps ~is_local ~loc ~min_depth ~depth (cl:clause) h (cl_overlap:overlap_clause option) p args (index : int * pred_info) =
       match cl_overlap with
         | None -> ()
         | Some cl_overlap ->
-          let rec filter_overlaps (arg_nb:int) has_cut : overlap_clause list -> 'a list = function
-            | [] -> []
-            | x::xs when x.timestamp = cl.timestamp -> if x.has_cut then [] else filter_overlaps arg_nb has_cut xs
+          let rec filter_overlaps : overlap_clause list -> 'a list = function
+            | [] -> anomaly ~loc "clause should be in the filtered list"
+            (* we find the current clause --> if it has a cut, then it discards xs else xs are kept as alternatives *)
+            | x::xs when x.timestamp = cl.timestamp ->
+              if x.has_cut then [] else xs
+            (* x has higher prio then cl, then if it has a cut, then does not overlap with cl, otherwise yes *)
             | x::xs ->
-              if not x.has_cut && arg_nb = x.arg_nb then (x::filter_overlaps arg_nb has_cut xs)
-              else filter_overlaps arg_nb has_cut xs
+              let tl = filter_overlaps xs in
+              if x.has_cut then tl else x :: tl
           in
-          let all_input_eigen_vars, all_input_catchall, hd = hd_query ~loc ~min_depth ~depth p args in
+          let all_input_eigen_vars, all_input_catchall, has_qname, hd = hd_query ~loc ~min_depth ~depth p args in
           (* Format.eprintf "Is_local:%b -- Has bang? %b -- rig_occ:%b -- is_chatchall:%b@." is_local cl_overlap.has_cut has_input_w_eigen_var is_catchall; *)
           if is_local && not cl_overlap.has_cut && not all_input_eigen_vars then (
             error_overlapping_eigen_variables ~loc p h);
-          if not is_local && all_input_catchall then
+          if (not is_local && all_input_catchall) || has_qname then
             (* We check if there is a local clause for p loading a local clause without cut, if this is the case,
                we throw an error, the catchall make $p$ non functional *)
             (match get_opt p with
@@ -1972,9 +1981,14 @@ end = struct
             (* Here we have a local clause with all input vars being eigenvars + the has no cut in the body, we add the info to the pred *)
             add_pred_w_eigen_var_no_cut p loc;
           if not is_local || (is_local && not cl_overlap.has_cut) then
+            (
+              (* Format.printf "==============================================================================================\n"; *)
+            (* Format.printf "Qui checking %a\n" pp_overlap_clause cl_overlap; *)
             let all_overlapping = get_overlapping index p hd in
-            let overlapping =  filter_overlaps cl_overlap.arg_nb cl_overlap.has_cut all_overlapping in
-            if overlapping <> [] then error_overlapping ~loc ~is_local p overlapping h
+            (* Format.printf "Overlapping list is %a\n" (pplist pp_overlap_clause "\n\t\t\t") all_overlapping; *)
+            let overlapping =  filter_overlaps all_overlapping in
+            (* Format.printf "Overlapping list is %a" (pplist pp_overlap_clause "\n\t\t\t") overlapping; *)
+            if overlapping <> [] then error_overlapping ~loc ~is_local p overlapping h)
     in
 
     (* Inspect the a local premise. If a local clause is found
@@ -2025,8 +2039,8 @@ end = struct
 (* state symbols ~loc pred_info cl body overlap_clause p amap *)
     check_clause ~min_depth:0 ~loc ~is_local:false ~lcs:0 ~depth:0 pred_info cl cl_st oc p amap;
     let pred_info = C.Map.fold (fun k v -> C.Map.add k {(C.Map.find k pred_info) with has_local_without_cut = Some v}) !preds_w_eigen_var_no_cut pred_info in
+    (* Format.eprintf "The predicates with local clauses are :@ @[%a@]@." (C.Map.pp (Loc.pp)) !preds_w_eigen_var_no_cut; *)
     pred_info 
-    (* Format.eprintf "The predicates with local clauses bla is :@ @[%a@]@." (C.Map.pp (Loc.pp)) !preds_w_eigen_var_no_cut *)
 
   let spill_todbl ?(ctx=Scope.Map.empty) ~builtins ~needs_spilling ~type_abbrevs ~types state symb ?(depth=0) ?(amap = F.Map.empty) t =
     let t = if needs_spilling then Spilling.main ~types ~type_abbrevs t else t in

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -1956,20 +1956,24 @@ end = struct
       match cl_overlap with
         | None -> ()
         | Some cl_overlap ->
-          let rec filter_overlaps : overlap_clause list -> 'a list = function
+          (* arg_nb is for variadic implementataions *)
+          let rec filter_overlaps arg_nb : overlap_clause list -> 'a list = function
             | [] -> anomaly ~loc "clause should be in the filtered list"
             (* we find the current clause --> if it has a cut, then it discards xs else xs are kept as alternatives *)
             | x::xs when x.timestamp = cl.timestamp ->
               if x.has_cut then [] else xs
             (* x has higher prio then cl, then if it has a cut, then does not overlap with cl, otherwise yes *)
             | x::xs ->
-              let tl = filter_overlaps xs in
-              if x.has_cut then tl else x :: tl
+              let tl = filter_overlaps arg_nb xs in
+              if x.has_cut || x.arg_nb <> arg_nb then tl else x :: tl
           in
           let all_input_eigen_vars, all_input_catchall, has_qname, hd = hd_query ~loc ~min_depth ~depth p args in
           (* Format.eprintf "Is_local:%b -- Has bang? %b -- rig_occ:%b -- is_chatchall:%b@." is_local cl_overlap.has_cut has_input_w_eigen_var is_catchall; *)
-          if is_local && not cl_overlap.has_cut && not all_input_eigen_vars then (
-            error_overlapping_eigen_variables ~loc p h);
+          if is_local && not cl_overlap.has_cut then (
+            if all_input_eigen_vars then 
+              (* Here we have a local clause with all input vars being eigenvars + the has no cut in the body, we add the info to the pred *)
+              add_pred_w_eigen_var_no_cut p loc
+            else error_overlapping_eigen_variables ~loc p h);
           if (not is_local && all_input_catchall) || has_qname then
             (* We check if there is a local clause for p loading a local clause without cut, if this is the case,
                we throw an error, the catchall make $p$ non functional *)
@@ -1977,16 +1981,13 @@ end = struct
             | None | Some {has_local_without_cut = None} -> ()
             | Some {has_local_without_cut = (Some _) as loc1} ->
               error_overlapping ~is_local ~loc p [{ overlap_loc = loc1; timestamp =[]; has_cut = false; arg_nb = 0 }] h);
-          if is_local && not cl_overlap.has_cut && all_input_eigen_vars then
-            (* Here we have a local clause with all input vars being eigenvars + the has no cut in the body, we add the info to the pred *)
-            add_pred_w_eigen_var_no_cut p loc;
           if not is_local || (is_local && not cl_overlap.has_cut) then
             (
               (* Format.printf "==============================================================================================\n"; *)
             (* Format.printf "Qui checking %a\n" pp_overlap_clause cl_overlap; *)
             let all_overlapping = get_overlapping index p hd in
             (* Format.printf "Overlapping list is %a\n" (pplist pp_overlap_clause "\n\t\t\t") all_overlapping; *)
-            let overlapping =  filter_overlaps all_overlapping in
+            let overlapping =  filter_overlaps cl_overlap.arg_nb all_overlapping in
             (* Format.printf "Overlapping list is %a" (pplist pp_overlap_clause "\n\t\t\t") overlapping; *)
             if overlapping <> [] then error_overlapping ~loc ~is_local p overlapping h)
     in

--- a/src/runtime/data.ml
+++ b/src/runtime/data.ml
@@ -527,8 +527,9 @@ end
 
 let elpi_state_descriptor = State.new_descriptor ()
 
-type core_symbol = As | Uv | ECons | ENil [@@deriving enum, ord, show]
+type core_symbol = Name | As | Uv | ECons | ENil [@@deriving enum, ord, show]
 let func_of_core_symbol = function
+  | Name  -> F.from_string "qname"
   | As    -> F.asf
   | Uv    -> F.from_string "uvar"
   | ECons  -> F.consf
@@ -746,6 +747,7 @@ module Global_symbols : sig
   val delay : symbol
 
   (* core symbols *)
+  val name : symbol
   val as_      : symbol
   val uvar    : symbol
   val nil    : symbol
@@ -753,6 +755,7 @@ module Global_symbols : sig
 
   (* internal *)
   val uvarc : constant (* needed by runtime/unif *)
+  val namec : constant (* needed by runtime/unif *)
   val asc : constant (* needed by runtime/unif *)
   val orc      : constant (* needed by coq-elpi *)
   val nilc     : constant (* needed by indexing *)
@@ -803,6 +806,7 @@ let uvarc, uvar = declare_core_symbol Uv
 let asc, as_ = declare_core_symbol As
 let nilc, nil = declare_core_symbol ENil
 let consc, cons = declare_core_symbol ECons
+let namec, name = declare_core_symbol Name
 
 let declare_overloaded_global_symbol str =
   let symb, variant = Symbol.make_variant_builtin (Ast.Func.from_string str) in
@@ -1438,7 +1442,7 @@ let do_allocate_constructors ty l =
   if StrSet.cardinal names <> List.length l then
     anomaly ("Duplicate constructors name in ADT: " ^ Conversion.show_ty_ast ty);
   List.fold_left (fun vacc (K(name,_,a,b,m)) ->
-    if name = "uvar" then
+    if name = "uvar" || name = "qname" then
       vacc
     else
       let c_variant = Global_symbols.declare_overloaded_global_symbol name in
@@ -1450,6 +1454,10 @@ let compile_constructors allocated ty self self_name l =
     if name = "uvar" then
       let args = compile_arguments a self in
       let acc = Constants.Map.add Global_symbols.uvarc (XK(args,compile_builder a b,compile_matcher a m)) acc in
+      (acc, sacc)
+    else if name = "qname" then
+      let args = compile_arguments a self in
+      let acc = Constants.Map.add Global_symbols.namec (XK(args,compile_builder a b,compile_matcher a m)) acc in
       (acc, sacc)
     else
       let c =
@@ -1477,7 +1485,7 @@ let document_adt doc ty ks cks vks fmt () =
     begin pp_comment fmt ("% " ^ doc); Fmt.fprintf fmt "@\n" end;
   document_kind fmt ty;
   List.iter (fun (K(name,doc,_,_,_)) ->
-    if name <> "uvar" then
+    if name <> "uvar" && name <> "qname" then
       let argsdoc = StrMap.find name cks in
       document_constructor fmt name (StrMap.find name vks |> snd) doc argsdoc) ks
 

--- a/src/runtime/discrimination_tree.ml
+++ b/src/runtime/discrimination_tree.ml
@@ -210,18 +210,18 @@ module Trie = struct
         }
 
   let add (a : Path.t) v t =
-    let add_opt f n pos = Some (f ~pos (Option.value ~default:empty n)) in
-    let add_map f pos x map = Ptmap.add x (f ~pos (try Ptmap.find x map with Not_found -> empty)) map in
+    let add_opt f n ~pos = Some (f ~pos:(pos+1) (Option.value ~default:empty n)) in
+    let add_map f ~pos x map = Ptmap.add x (f ~pos:(pos+1) (try Ptmap.find x map with Not_found -> empty)) map in
     let max = ref 0 in
     let rec ins ~pos = let x = Path.get a pos in function
       | Node ({ data } as t) when isPathEnd x -> max := pos; Node { t with data = v :: data }
       | Node ({ other } as t) when isVariable x || isAny x ->
-          Node { t with other = add_opt ins other (pos + 1) }
+          Node { t with other = add_opt ins other ~pos }
       | Node ({ listTailVariable } as t) when isListTailVariable x || isListTailVariableUnif x ->
-          Node { t with listTailVariable = add_opt ins listTailVariable (pos + 1) }
+          Node { t with listTailVariable = add_opt ins listTailVariable ~pos }
       | Node ({ map; names } as t) ->
-          let names: 'a t option = if isNameConst x then add_opt ins names (pos+1) else names in
-          Node { t with map = add_map ins (pos+1) x map; names }
+          let names: 'a t option = if isNameConst x then add_opt ins names ~pos else names in
+          Node { t with map = add_map ins ~pos x map; names }
     in
     let t = ins ~pos:0 t in
     t, !max

--- a/src/runtime/discrimination_tree.ml
+++ b/src/runtime/discrimination_tree.ml
@@ -8,7 +8,7 @@ open Elpi_util.Util
 let kConstant = 0  (* p, q *)
 let kPrimitive = 1 (* 3, "foo" *)
 let kVariable = 2  (* X1, _ *)
-let kOther = 3     (* names + Lam + internal tags for list-begin/end, input, output, list-tail-variable *)
+let kOther = 3     (* qname + Lam + internal tags for list-begin/end, input, output, list-tail-variable *)
 
 (* 4 constructors encoded as: kno, arity, arg_value *)
 let arity_bits = 4
@@ -46,9 +46,8 @@ let check_data ~data =
 
 
 let mkConstant ~safe ~data ~arity =
-  let rc = encode ~k:kConstant ~data ~arity in
   if safe then (check_data ~data; check_arity ~arity);
-  rc
+  encode ~k:kConstant ~data ~arity
 
 let mkPrimitive c = encode ~k:kPrimitive ~data:(CData.hash c lsl k_bits) ~arity:0
 
@@ -67,7 +66,6 @@ let mkListTailVariableUnif = encode ~k:kOther ~data:8 ~arity:0
 let mkUvarConstant = encode ~k:kVariable ~data:9 ~arity:0
 let mkName = encode ~k:kOther ~data:10 ~arity:0
 
-
 let isVariable x = x == mkVariable
 let isAny x = x == mkAny
 let isInput x = x == mkInputMode
@@ -79,6 +77,18 @@ let isListTailVariable x = x == mkListTailVariable
 let isListTailVariableUnif x = x == mkListTailVariableUnif
 let isPathEnd x = x == mkPathEnd
 let isUvarConstant x = x == mkUvarConstant
+let isName x = x == mkName
+let isNameConst = 
+  (* this keeps the constructor and the strongest bit of data *)
+  (* a name has the bit shapre "000...."
+     where the first two bits indicates that it is a constant
+     and the third that it is a name: 
+      names are positives, therefore, their bit encoding has a leading 0
+      global constant, instead, are negative, and therefore, have a leading 1
+  *)
+  let kn_lshift = k_lshift-1 in
+  fun x -> x lsr kn_lshift == 0
+  
 
 type cell = int
 
@@ -101,6 +111,7 @@ let pp_cell fmt n =
        else if isListTailVariableUnif n then "ListTailVariableUnif"
        else if isAny n then "Other"
        else if isUvarConstant n then "uvar"
+       else if isName n then "qname"
        else failwith "Invalid path construct...")
   else if k == kPrimitive then Format.fprintf fmt "Primitive"
   else Format.fprintf fmt "%o" k
@@ -170,47 +181,47 @@ module Trie = struct
     (* children *)
     other : 'a t option;             (* for Other, Variable *)
     listTailVariable : 'a t option;  (* for ListTailVariable *)
+    names : 'a t option;             (* for names *)
     map : 'a t Ptmap.t;              (* for Constant, Primitive, ListHead, ListEnd *)
   }
 
-  let empty = Node { data = []; other = None; listTailVariable = None; map = Ptmap.empty }
+  let empty = Node { data = []; other = None; names = None; listTailVariable = None; map = Ptmap.empty }
 
   let is_empty x = x == empty
 
   let rec replace p x = function
-    | Node { data; other; listTailVariable; map } ->
+    | Node { data; other; listTailVariable; map; names } ->
         Node {
           data = data |> List.map (fun y -> if p y then x else y);
           other = other |> Option.map (replace p x);
           listTailVariable = listTailVariable |> Option.map (replace p x);
           map = map |> Ptmap.map (replace p x);
+          names = names |> Option.map (replace p x);
         }
       
   let rec remove f = function
-    | Node { data; other; listTailVariable; map } ->
+    | Node { data; other; listTailVariable; map; names } ->
         Node {
           data = data |> List.filter (fun x -> not (f x));
           other = other |> Option.map (remove f);
+          names = names |> Option.map (remove f);
           listTailVariable = listTailVariable |> Option.map (remove f);
           map = map |> Ptmap.map (remove f);
         }
 
   let add (a : Path.t) v t =
+    let add_opt f n pos = Some (f ~pos (Option.value ~default:empty n)) in
+    let add_map f pos x map = Ptmap.add x (f ~pos (try Ptmap.find x map with Not_found -> empty)) map in
     let max = ref 0 in
     let rec ins ~pos = let x = Path.get a pos in function
       | Node ({ data } as t) when isPathEnd x -> max := pos; Node { t with data = v :: data }
       | Node ({ other } as t) when isVariable x || isAny x ->
-          let t' = match other with None -> empty | Some x -> x in
-          let t'' = ins ~pos:(pos+1) t' in
-          Node { t with other = Some t'' }
+          Node { t with other = add_opt ins other (pos + 1) }
       | Node ({ listTailVariable } as t) when isListTailVariable x || isListTailVariableUnif x ->
-          let t' = match listTailVariable with None -> empty | Some x -> x in
-          let t'' = ins ~pos:(pos+1) t' in
-          Node { t with listTailVariable = Some t'' }
-      | Node ({ map } as t) ->
-          let t' = try Ptmap.find x map with Not_found -> empty in
-          let t'' = ins ~pos:(pos+1) t' in
-          Node { t with map = Ptmap.add x t'' map }
+          Node { t with listTailVariable = add_opt ins listTailVariable (pos + 1) }
+      | Node ({ map; names } as t) ->
+          let names: 'a t option = if isNameConst x then add_opt ins names (pos+1) else names in
+          Node { t with map = add_map ins (pos+1) x map; names }
     in
     let t = ins ~pos:0 t in
     t, !max
@@ -356,7 +367,7 @@ let get_all_children v mode = isAny v || (isVariable v && isOutput mode)
 
 let rec retrieve ~pos ~add_result mode path tree : unit =
   let hd = Path.get path pos in
-  let Trie.Node {data; map; other; listTailVariable} = tree in
+  let Trie.Node {data; map; other; listTailVariable; names} = tree in
   (* Format.eprintf "%d %a\n%!" pos pp_cell hd; *)
   if Trie.is_empty tree then ()
   else if isPathEnd hd then List.iter add_result data
@@ -380,6 +391,12 @@ let rec retrieve ~pos ~add_result mode path tree : unit =
           try retrieve ~pos:(pos+1) ~add_result mode path (Ptmap.find hd map)
           with Not_found -> ()
     end;
+    (if isNameConst hd then
+      begin try retrieve ~pos:(pos+1) ~add_result mode path (Ptmap.find mkName map)
+      with Not_found -> () end
+    else if hd == mkName then
+      Option.iter (fun a -> retrieve ~pos:(pos+1) ~add_result mode path a) names);
+
     (* moreover, we have to take into account other and listTailVariable since they represent UVar in the tree,
        therefore they can be unified with the hd *)
     if not(isListEnd hd) then Option.iter (fun a -> retrieve ~pos:(skip ~pos path) ~add_result mode path a) other;
@@ -450,4 +467,5 @@ module Internal = struct
 
   let isUvarConstant = isUvarConstant
   let isListNil = isListNil
+  let isNameConst = isNameConst
 end

--- a/src/runtime/discrimination_tree.ml
+++ b/src/runtime/discrimination_tree.ml
@@ -8,7 +8,7 @@ open Elpi_util.Util
 let kConstant = 0  (* p, q *)
 let kPrimitive = 1 (* 3, "foo" *)
 let kVariable = 2  (* X1, _ *)
-let kOther = 3     (* Lam + internal tags for list-begin/end, input, output, list-tail-variable *)
+let kOther = 3     (* names + Lam + internal tags for list-begin/end, input, output, list-tail-variable *)
 
 (* 4 constructors encoded as: kno, arity, arg_value *)
 let arity_bits = 4
@@ -36,10 +36,18 @@ let arity_of n =
 let data_of n =
   (n land data_mask)
 
+let check_arity ~arity =
+  if arity >= 1 lsl arity_bits then
+    anomaly (Printf.sprintf "Indexing at depth > 1 is unsupported since constant arity is too big (received %d; max := %d)" arity (1 lsl arity_bits))
+
+let check_data ~data =
+  if abs data > data_mask then
+    anomaly (Printf.sprintf "Indexing at depth > 1 is unsupported since constant %d/%d is too large or wide" data (data_mask))
+
+
 let mkConstant ~safe ~data ~arity =
   let rc = encode ~k:kConstant ~data ~arity in
-  if safe && (abs data > data_mask || arity >= 1 lsl arity_bits) then
-    anomaly (Printf.sprintf "Indexing at depth > 1 is unsupported since constant %d/%d is too large or wide" data arity);
+  if safe then (check_data ~data; check_arity ~arity);
   rc
 
 let mkPrimitive c = encode ~k:kPrimitive ~data:(CData.hash c lsl k_bits) ~arity:0
@@ -57,6 +65,7 @@ let mkListNil = encode ~k:kOther ~data:6 ~arity:0
 let mkPathEnd = encode ~k:kOther ~data:7 ~arity:0
 let mkListTailVariableUnif = encode ~k:kOther ~data:8 ~arity:0
 let mkUvarConstant = encode ~k:kVariable ~data:9 ~arity:0
+let mkName = encode ~k:kOther ~data:10 ~arity:0
 
 
 let isVariable x = x == mkVariable

--- a/src/runtime/discrimination_tree.ml
+++ b/src/runtime/discrimination_tree.ml
@@ -96,7 +96,7 @@ let pp_cell fmt n =
   if k == kConstant then
     let data = data_mask land n in
     let arity = (arity_mask land n) lsr ka_lshift in
-    Format.fprintf fmt "Constant(%d,%d)" data arity
+    Format.fprintf fmt "Constant(%d,%d,%b)" data arity (isNameConst n)
   else if k == kVariable then Format.fprintf fmt "Variable"
   else if k == kOther then
     Format.fprintf fmt
@@ -180,11 +180,11 @@ module Trie = struct
     (* children *)
     other : 'a t option;             (* for Other, Variable *)
     listTailVariable : 'a t option;  (* for ListTailVariable *)
-    names : 'a t option;             (* for names *)
+    names : 'a t Ptmap.t;             (* for names *)
     map : 'a t Ptmap.t;              (* for Constant, Primitive, ListHead, ListEnd *)
   }
 
-  let empty = Node { data = []; other = None; names = None; listTailVariable = None; map = Ptmap.empty }
+  let empty = Node { data = []; other = None; names = Ptmap.empty; listTailVariable = None; map = Ptmap.empty }
 
   let is_empty x = x == empty
 
@@ -195,7 +195,7 @@ module Trie = struct
           other = other |> Option.map (replace p x);
           listTailVariable = listTailVariable |> Option.map (replace p x);
           map = map |> Ptmap.map (replace p x);
-          names = names |> Option.map (replace p x);
+          names = names |> Ptmap.map (replace p x);
         }
       
   let rec remove f = function
@@ -203,7 +203,7 @@ module Trie = struct
         Node {
           data = data |> List.filter (fun x -> not (f x));
           other = other |> Option.map (remove f);
-          names = names |> Option.map (remove f);
+          names = names |> Ptmap.map (remove f);
           listTailVariable = listTailVariable |> Option.map (remove f);
           map = map |> Ptmap.map (remove f);
         }
@@ -218,29 +218,26 @@ module Trie = struct
           Node { t with other = add_opt ins other ~pos }
       | Node ({ listTailVariable } as t) when isListTailVariable x || isListTailVariableUnif x ->
           Node { t with listTailVariable = add_opt ins listTailVariable ~pos }
-      | Node ({ map; names } as t) ->
-          let names: 'a t option = if isNameConst x then add_opt ins names ~pos else names in
-          Node { t with map = add_map ins ~pos x map; names }
+      | Node ({ names } as t) when isNameConst x -> Node { t with names = add_map ins ~pos x names }
+      | Node ({ map } as t) -> Node { t with map = add_map ins ~pos x map }
     in
     let t = ins ~pos:0 t in
     t, !max
 
   let rec pp (ppelem : Format.formatter -> 'a -> unit) (fmt : Format.formatter)
-      (Node { data; other; listTailVariable; map } : 'a t) : unit =
+      (Node { data; other; listTailVariable; map; names } : 'a t) : unit =
+    let ppt_help = (fun fmt (k, v) ->
+          Format.fprintf fmt "@[<hov 2> %a@ %a@]" pp_cell k (pp ppelem) v) in
     Format.fprintf fmt "@[<v>[@[<hov 2>values:{@ ";
     pplist ppelem "; " fmt data;
     Format.fprintf fmt "}@ @]@ @[<hov 2> other:{@ ";
-    (match other with None -> () | Some m -> pp ppelem fmt m);
+    Option.iter (pp ppelem fmt) other;
+    Format.fprintf fmt "}@ @]@ @[<hov 2> names:{@ ";
+    Ptmap.to_list names |> pplist ppt_help ";@ " fmt;
     Format.fprintf fmt "}@ @]@ @[<hov 2> listTailVariable:{@ ";
-    (match listTailVariable with None -> () | Some m -> pp ppelem fmt m);
+    Option.iter (pp ppelem fmt) listTailVariable;
     Format.fprintf fmt "}@ @]@ @[<hov 2> key:{@ @[<hov 2>";
-    Ptmap.to_list map
-    |> pplist
-         (fun fmt (k, v) ->
-          Format.fprintf fmt "@[<hov 2> %a@ %a@]"
-           pp_cell k
-           (pp ppelem) v)
-         ";@ " fmt;
+    Ptmap.to_list map |> pplist ppt_help ";@ " fmt;
     Format.fprintf fmt "@]}@]]@]"
 
   let show (fmt : Format.formatter -> 'a -> unit) (n : 'a t) : string =
@@ -337,19 +334,20 @@ let call f =
   let add_result x = res := x :: !res in
   f ~add_result; !res
   
-let skip_to_listEnd ~add_result mode (Trie.Node { other; map; listTailVariable }) =
+let skip_to_listEnd ~add_result mode (Trie.Node { other; map; listTailVariable; names }) =
   let rec get_from_list n = function
-    | Trie.Node { other; map; listTailVariable } as tree ->
+    | Trie.Node { other; map; listTailVariable; names } as tree ->
         if n = 0 then (add_result tree; Option.iter add_result other)
         else
           (Option.iter (get_from_list n) other;
           Ptmap.iter (fun k -> get_from_list (update_par_count n k)) map;
-            match listTailVariable with None -> () | Some a -> add_result a)
+          Ptmap.iter (fun k -> get_from_list (update_par_count n k)) names;
+          Option.iter add_result listTailVariable)
   in
-  let some_to_list = function Some x -> add_result x | None -> () in
-  (match other with None -> () | Some a -> get_from_list 1 a);
+  (Option.iter (get_from_list 1) other);
   if isOutput mode then Ptmap.iter (fun k v -> get_from_list (update_par_count 1 k) v) map;
-  some_to_list listTailVariable
+  if isOutput mode then Ptmap.iter (fun k v -> get_from_list (update_par_count 1 k) v) names;
+  Option.iter add_result listTailVariable
 
 let skip_to_listEnd mode t = call (skip_to_listEnd mode t)
 
@@ -360,7 +358,8 @@ let rec retrieve ~pos ~add_result mode path tree : unit =
   let Trie.Node {data; map; other; listTailVariable; names} = tree in
   let retrieveNF ~pos mode path v m=
     try retrieve ~pos:(pos+1) ~add_result mode path (Ptmap.find v m)
-    with Not_found -> () in
+    with Not_found -> ()
+  in
   (* Format.eprintf "%d %a\n%!" pos pp_cell hd; *)
   if Trie.is_empty tree then ()
   else if isPathEnd hd then List.iter add_result data
@@ -375,17 +374,19 @@ let rec retrieve ~pos ~add_result mode path tree : unit =
     begin
       if get_all_children hd mode then 
         (* we take all the children in the map *)
-        on_all_children ~pos:(pos+1) ~add_result mode path map
+        (on_all_children ~pos:(pos+1) ~add_result mode path map;
+        on_all_children ~pos:(pos+1) ~add_result mode path names)
       else if isInput mode && isVariable hd then
         retrieveNF ~pos mode path mkUvarConstant map
+      else if isNameConst hd then 
+        (retrieveNF ~pos mode path mkName map; retrieveNF ~pos mode path hd names)
+      else if isName hd then
+        (on_all_children ~pos:(pos+1) ~add_result mode path names;
+        retrieveNF ~pos mode path mkName map)
       else
           (* we have a Constant, Primitive, ListHead, ListNil or ListEnd and look for the key in the map *)
           retrieveNF ~pos mode path hd map
     end;
-    (if isNameConst hd then (retrieveNF ~pos mode path mkName map; retrieveNF ~pos mode path hd map)
-    else if hd == mkName then
-      (retrieveNF ~pos mode path mkName map;
-       Option.iter (fun a -> retrieve ~pos:(pos+1) ~add_result mode path a) names));
 
     (* moreover, we have to take into account other and listTailVariable since they represent UVar in the tree,
        therefore they can be unified with the hd *)
@@ -395,23 +396,28 @@ let rec retrieve ~pos ~add_result mode path tree : unit =
 
 and on_all_children ~pos ~add_result mode path map =
   let rec skip_list par_count arity = function
-    | Trie.Node { other; map; listTailVariable } as tree ->
+    | Trie.Node { other; map; listTailVariable; names } as tree ->
         if par_count = 0 then begin
           skip_functor arity tree
         end else begin
           Ptmap.iter (fun k v -> skip_list (update_par_count par_count k) arity v) map;
+          Ptmap.iter (fun k v -> skip_list (update_par_count par_count k) arity v) names;
           Option.iter (skip_list par_count arity) other;
           Option.iter (skip_list (par_count - 1) arity) listTailVariable
         end
   and skip_functor arity = function
-    | Trie.Node { other; map } as tree ->
+    | Trie.Node { other; map; names } as tree ->
       if arity = 0 then retrieve ~pos ~add_result mode path tree
       else begin
         Option.iter (skip_functor (arity-1)) other;
         Ptmap.iter (fun k v ->
             if isListHead k then skip_list 1 (arity - 1) v
             else skip_functor (arity - 1 + arity_of k) v)
-          map
+          map;
+        Ptmap.iter (fun k v ->
+            if isListHead k then skip_list 1 (arity - 1) v
+            else skip_functor (arity - 1 + arity_of k) v)
+          names
       end
   in
   Ptmap.iter (fun k v ->
@@ -430,6 +436,8 @@ let retrieve ~pos ~add_result path index =
   
 let retrieve cmp_data path { t } = 
   let r = call (retrieve ~pos:0 path t) in
+  (* Format.printf "Path : %a\n@." Path.pp path; *)
+  (* Format.printf "Trie : %a\n@." (Trie.pp (fun f _ -> Format.fprintf f "xx")) t; *)
   Bl.of_list @@ List.sort cmp_data r
 
 let replace p x i = { i with t = Trie.replace p x i.t }

--- a/src/runtime/discrimination_tree.ml
+++ b/src/runtime/discrimination_tree.ml
@@ -86,8 +86,7 @@ let isNameConst =
       names are positives, therefore, their bit encoding has a leading 0
       global constant, instead, are negative, and therefore, have a leading 1
   *)
-  let kn_lshift = k_lshift-1 in
-  fun x -> x lsr kn_lshift == 0
+  fun x -> k_of x == kConstant && ((data_of x) lsr (ka_lshift - 1)) == 0
   
 
 type cell = int

--- a/src/runtime/discrimination_tree.ml
+++ b/src/runtime/discrimination_tree.ml
@@ -339,20 +339,11 @@ let call f =
   
 let skip_to_listEnd ~add_result mode (Trie.Node { other; map; listTailVariable }) =
   let rec get_from_list n = function
-    | Trie.Node { other = None; map; listTailVariable } as tree ->
-        if n = 0 then add_result tree
+    | Trie.Node { other; map; listTailVariable } as tree ->
+        if n = 0 then (add_result tree; Option.iter add_result other)
         else
-          (Ptmap.iter
-            (fun k v -> get_from_list (update_par_count n k) v)
-            map;
-            match listTailVariable with None -> () | Some a -> add_result a)
-    | Trie.Node { other = Some other; map; listTailVariable } as tree ->
-        if n = 0 then (add_result tree; add_result other)
-        else
-          (get_from_list n other;
-          Ptmap.iter
-              (fun k v -> get_from_list (update_par_count n k) v)
-              map;
+          (Option.iter (get_from_list n) other;
+          Ptmap.iter (fun k -> get_from_list (update_par_count n k)) map;
             match listTailVariable with None -> () | Some a -> add_result a)
   in
   let some_to_list = function Some x -> add_result x | None -> () in

--- a/src/runtime/discrimination_tree.ml
+++ b/src/runtime/discrimination_tree.ml
@@ -367,6 +367,9 @@ let get_all_children v mode = isAny v || (isVariable v && isOutput mode)
 let rec retrieve ~pos ~add_result mode path tree : unit =
   let hd = Path.get path pos in
   let Trie.Node {data; map; other; listTailVariable; names} = tree in
+  let retrieveNF ~pos mode path v m=
+    try retrieve ~pos:(pos+1) ~add_result mode path (Ptmap.find v m)
+    with Not_found -> () in
   (* Format.eprintf "%d %a\n%!" pos pp_cell hd; *)
   if Trie.is_empty tree then ()
   else if isPathEnd hd then List.iter add_result data
@@ -383,18 +386,15 @@ let rec retrieve ~pos ~add_result mode path tree : unit =
         (* we take all the children in the map *)
         on_all_children ~pos:(pos+1) ~add_result mode path map
       else if isInput mode && isVariable hd then
-        try retrieve ~pos:(pos+1) ~add_result mode path (Ptmap.find mkUvarConstant map)
-        with Not_found -> ()
+        retrieveNF ~pos mode path mkUvarConstant map
       else
           (* we have a Constant, Primitive, ListHead, ListNil or ListEnd and look for the key in the map *)
-          try retrieve ~pos:(pos+1) ~add_result mode path (Ptmap.find hd map)
-          with Not_found -> ()
+          retrieveNF ~pos mode path hd map
     end;
-    (if isNameConst hd then
-      begin try retrieve ~pos:(pos+1) ~add_result mode path (Ptmap.find mkName map)
-      with Not_found -> () end
+    (if isNameConst hd then (retrieveNF ~pos mode path mkName map; retrieveNF ~pos mode path hd map)
     else if hd == mkName then
-      Option.iter (fun a -> retrieve ~pos:(pos+1) ~add_result mode path a) names);
+      (retrieveNF ~pos mode path mkName map;
+       Option.iter (fun a -> retrieve ~pos:(pos+1) ~add_result mode path a) names));
 
     (* moreover, we have to take into account other and listTailVariable since they represent UVar in the tree,
        therefore they can be unified with the hd *)

--- a/src/runtime/discrimination_tree.ml
+++ b/src/runtime/discrimination_tree.ml
@@ -409,15 +409,12 @@ and on_all_children ~pos ~add_result mode path map =
     | Trie.Node { other; map; names } as tree ->
       if arity = 0 then retrieve ~pos ~add_result mode path tree
       else begin
+        let fm k v =
+          if isListHead k then skip_list 1 (arity - 1) v
+          else skip_functor (arity - 1 + arity_of k) v in
         Option.iter (skip_functor (arity-1)) other;
-        Ptmap.iter (fun k v ->
-            if isListHead k then skip_list 1 (arity - 1) v
-            else skip_functor (arity - 1 + arity_of k) v)
-          map;
-        Ptmap.iter (fun k v ->
-            if isListHead k then skip_list 1 (arity - 1) v
-            else skip_functor (arity - 1 + arity_of k) v)
-          names
+        Ptmap.iter fm map;
+        Ptmap.iter fm names
       end
   in
   Ptmap.iter (fun k v ->

--- a/src/runtime/discrimination_tree.mli
+++ b/src/runtime/discrimination_tree.mli
@@ -12,6 +12,7 @@ module Path : sig
 end
 
 val mkConstant : safe:bool -> data:int -> arity:int -> cell
+val mkName : cell
 val mkPrimitive : Elpi_util.Util.CData.t -> cell
 
 (** This is for: unification variables, discard *)

--- a/src/runtime/discrimination_tree.mli
+++ b/src/runtime/discrimination_tree.mli
@@ -135,4 +135,5 @@ module Internal: sig
   val isListTailVariableUnif : cell -> bool
   val isPathEnd : cell -> bool
   val isUvarConstant : cell -> bool
+  val isNameConst : cell -> bool
 end

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -2754,7 +2754,6 @@ let arg_to_trie_path ~check_mut_excl ~safe ~depth ~is_goal args arg_depths args_
     else
       let path_depth = path_depth - 1 in 
       match deref_head ~depth t with 
-      (* TODO: namec *)
       | (Const k | App (k,_,_)) when k == Global_symbols.uvarc -> Path.emit path mkUvarConstant; update_current_min_depth path_depth
       | (Const k | App (k,_,_)) when k == Global_symbols.namec -> Path.emit path mkName; update_current_min_depth path_depth
       | Const k when safe -> Path.emit path @@ mkConstant ~safe ~data:k ~arity:0; update_current_min_depth path_depth

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -2756,7 +2756,7 @@ let arg_to_trie_path ~check_mut_excl ~safe ~depth ~is_goal args arg_depths args_
       match deref_head ~depth t with 
       (* TODO: namec *)
       | (Const k | App (k,_,_)) when k == Global_symbols.uvarc -> Path.emit path mkUvarConstant; update_current_min_depth path_depth
-      | (Const k | App (k,_,_)) when k == Global_symbols.namec || k >= 0 -> Path.emit path mkName; update_current_min_depth path_depth
+      | (Const k | App (k,_,_)) when k == Global_symbols.namec -> Path.emit path mkName; update_current_min_depth path_depth
       | Const k when safe -> Path.emit path @@ mkConstant ~safe ~data:k ~arity:0; update_current_min_depth path_depth
       | Const k -> Path.emit path @@ mkConstant ~safe ~data:k ~arity:0; update_current_min_depth path_depth
       | CData d -> Path.emit path @@ mkPrimitive d; update_current_min_depth path_depth

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -1770,6 +1770,8 @@ let eta_contract_flex depth xdepth ~argsdepth e t =
 let uvar_uvar_assignment_order r1 r2 = uvar_id r1 > uvar_id r2
 
 let isLam = function Lam _ -> true | _ -> false
+
+let is_eigen_variable ~depth b = b <= depth
   
 let rec unif ~oc argsdepth matching depth adepth a bdepth b e =
    [%trace "unif" ~rid ("@[<hov 2>^%d:%a@ =%d%s= ^%d:%a@]%!"
@@ -1838,6 +1840,14 @@ let rec unif ~oc argsdepth matching depth adepth a bdepth b e =
       unif ~oc argsdepth matching depth adepth a adepth
         (deref_apparg ~from:argsdepth ~to_:(adepth+depth) e.(i) args) empty_env
 
+   (* matching names *)
+   | Const cx, Const c when c == Global_symbols.namec && matching ->
+      is_eigen_variable ~depth cx
+   | Const cx, App(c,hd,[]) when c == Global_symbols.namec && matching ->
+      is_eigen_variable ~depth cx && 
+      unif ~oc argsdepth matching depth adepth (Const cx) bdepth hd e
+   | (App _ | Const _ | Builtin _ | Nil | Cons _ | CData _), (Const c | App(c,_,[])) when c == Global_symbols.namec && matching -> false
+        
    (* UVar introspection (matching) *)
    | (UVar _ | AppUVar _), Const c when c == Global_symbols.uvarc && matching -> true
    | UVar(r,ano), App(c,hd,[]) when c == Global_symbols.uvarc && matching ->
@@ -2484,6 +2494,7 @@ let lex_insertion l1 l2 =
   in
   lex_insertion true l1 l2
 let mustbevariablec = min_int (* uvar or uvar t or uvar l t *)
+let mustbenamec = min_int+1 (* uvar or uvar t or uvar l t *)
 
 let ppclause f ~hd { depth; args = args; hyps = hyps } =
   Fmt.fprintf f "@[<hov 1>%a :- %a.@]"
@@ -2502,16 +2513,19 @@ let hd_opt = function
 type clause_arg_classification =
   | Variable
   | MustBeVariable
+  | MustBeName
   | Rigid of constant * Mode.t
 
 let rec classify_clause_arg ~depth matching t =
   (* Format.eprintf "index %a\n%!" (ppterm depth [] ~argsdepth:depth empty_env) t; *)
   match deref_head ~depth t with
   | Const k when k == Global_symbols.uvarc -> MustBeVariable
+  | Const k when k == Global_symbols.namec -> MustBeName
   | Const k -> Rigid(k,matching)
   | Nil -> Rigid (Global_symbols.nilc,matching)
   | Cons _ -> Rigid (Global_symbols.consc,matching)
   | App (k,_,_) when k == Global_symbols.uvarc -> MustBeVariable
+  | App (k,_,_) when k == Global_symbols.namec -> MustBeName
   | App (k,a,_) when k == Global_symbols.asc -> classify_clause_arg ~depth matching a
   | App (k,_,_) -> Rigid (k,matching)
   | Builtin (k,_) -> Rigid (const_of_builtin_predicate k,matching)
@@ -2575,6 +2589,10 @@ let hash_arg_list is_goal hd ~depth args mode spec =
           hash size mustbevariablec
       | App(k,_,_) when k == Global_symbols.uvarc && deep = 1 ->
           hash size mustbevariablec
+      | Const k when k == Global_symbols.namec ->
+          hash size mustbenamec
+      | App(k,_,_) when k == Global_symbols.namec && deep = 1 ->
+          hash size mustbenamec
       | Const k -> hash size k
       | App(k,_,_) when deep = 1 -> hash size k
       | App(k,x,xs) ->
@@ -2734,6 +2752,7 @@ let arg_to_trie_path ~check_mut_excl ~safe ~depth ~is_goal args arg_depths args_
     else
       let path_depth = path_depth - 1 in 
       match deref_head ~depth t with 
+      (* TODO: namec *)
       | (Const k | App (k,_,_)) when k == Global_symbols.uvarc -> Path.emit path mkUvarConstant; update_current_min_depth path_depth
       | Const k when safe -> Path.emit path @@ mkConstant ~safe ~data:k ~arity:0; update_current_min_depth path_depth
       | Const k -> Path.emit path @@ mkConstant ~safe ~data:k ~arity:0; update_current_min_depth path_depth
@@ -2829,6 +2848,18 @@ let add_clause_to_snd_lvl_idx ~depth ~insert predicate clause = function
         all_clauses = insert clause all_clauses;
         flex_arg_clauses;
         arg_idx = Ptmap.add mustbevariablec (insert clause clauses) arg_idx;
+      }
+    | MustBeName ->
+      (* TODO: this is wrong *)
+      (* qname: matches only eigenvariable (or itself at the meta level) *)
+      let clauses =
+        try Ptmap.find mustbenamec arg_idx
+        with Not_found -> Bl.empty () in
+      TwoLevelIndex {
+        argno; mode;
+        all_clauses = insert clause all_clauses;
+        flex_arg_clauses;
+        arg_idx = Ptmap.add mustbenamec (insert clause clauses) arg_idx;
       }
     | Rigid (arg_hd,arg_mode) ->
       (* t: a rigid term matches flexible terms only in unification mode *)
@@ -3054,10 +3085,12 @@ let rec classify_goal_arg ~depth t =
   (* Format.eprintf "goal %a\n%!" (ppterm depth [] ~argsdepth:depth empty_env) t; *)
   match deref_head ~depth t with
   | Const k when k == Global_symbols.uvarc -> Rigid mustbevariablec
+  | Const k when k == Global_symbols.namec -> Rigid mustbenamec
   | Const k -> Rigid(k)
   | Nil -> Rigid (Global_symbols.nilc)
   | Cons _ -> Rigid (Global_symbols.consc)
   | App (k,_,_) when k == Global_symbols.uvarc -> Rigid mustbevariablec
+  | App (k,_,_) when k == Global_symbols.uvarc -> Rigid mustbenamec
   | App (k,a,_) when k == Global_symbols.asc -> classify_goal_arg ~depth a
   | App (k,_,_) -> Rigid (k)
   | Builtin (k,_) -> Rigid (const_of_builtin_predicate k)
@@ -3065,7 +3098,7 @@ let rec classify_goal_arg ~depth t =
   | Arg _ | UVar _ | AppArg _ | AppUVar _ | Discard -> Variable
   | CData d -> 
      let hash = -(CData.hash d) in
-     if hash > mustbevariablec then Rigid (hash)
+     if hash > mustbenamec then Rigid (hash)
      else Rigid (hash+1)
 
 let classify_goal_argno ~depth argno = function

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -1771,7 +1771,9 @@ let uvar_uvar_assignment_order r1 r2 = uvar_id r1 > uvar_id r2
 
 let isLam = function Lam _ -> true | _ -> false
 
-let is_eigen_variable ~depth b = b <= depth
+let is_eigen_variable ~depth b =
+    (* Format.printf "b is %d - depth is %d \n@." b depth; *)
+    b >= 0
   
 let rec unif ~oc argsdepth matching depth adepth a bdepth b e =
    [%trace "unif" ~rid ("@[<hov 2>^%d:%a@ =%d%s= ^%d:%a@]%!"
@@ -1779,6 +1781,7 @@ let rec unif ~oc argsdepth matching depth adepth a bdepth b e =
        depth (if matching then "m" else "")
        bdepth (ppterm (bdepth+depth) [] ~argsdepth:bdepth e) b)
    begin
+  Format.printf "Tm A - %a -- B - %a\n@." pp_term a pp_term b;
    let delta = adepth - bdepth in
          
    (delta = 0 && a == b) || match a,b with
@@ -1841,11 +1844,20 @@ let rec unif ~oc argsdepth matching depth adepth a bdepth b e =
         (deref_apparg ~from:argsdepth ~to_:(adepth+depth) e.(i) args) empty_env
 
    (* matching names *)
-   | Const cx, Const c when c == Global_symbols.namec && matching ->
+   | (Const cx | App(cx, _, _)), Const nc when nc == Global_symbols.namec && matching ->
       is_eigen_variable ~depth cx
-   | Const cx, App(c,hd,[]) when c == Global_symbols.namec && matching ->
+   | (Const cx | App(cx, _, _)), App(c,hd,[]) when c == Global_symbols.namec && matching ->
       is_eigen_variable ~depth cx && 
-      unif ~oc argsdepth matching depth adepth (Const cx) bdepth hd e
+      unif ~oc argsdepth matching depth adepth a bdepth hd e
+   | Const cx, App(c,hd,[arg]) when c == Global_symbols.namec && matching ->
+      is_eigen_variable ~depth cx && 
+      unif ~oc argsdepth matching depth adepth (Const cx) bdepth hd e &&
+      unif ~oc argsdepth matching depth adepth Nil bdepth arg e
+   | App(cx,h,ag), App(c,hd,[arg]) when c == Global_symbols.namec && matching ->
+      is_eigen_variable ~depth cx && 
+      unif ~oc argsdepth matching depth adepth (Const cx) bdepth hd e &&
+      unif ~oc argsdepth matching depth adepth (list_to_lp_list (h::ag)) bdepth arg e
+
    | (App _ | Const _ | Builtin _ | Nil | Cons _ | CData _), (Const c | App(c,_,[])) when c == Global_symbols.namec && matching -> false
         
    (* UVar introspection (matching) *)

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -1770,10 +1770,6 @@ let eta_contract_flex depth xdepth ~argsdepth e t =
 let uvar_uvar_assignment_order r1 r2 = uvar_id r1 > uvar_id r2
 
 let isLam = function Lam _ -> true | _ -> false
-
-let is_eigen_variable ~depth b =
-    (* Format.printf "b is %d - depth is %d \n@." b depth; *)
-    b >= 0
   
 let rec unif ~oc argsdepth matching depth adepth a bdepth b e =
    [%trace "unif" ~rid ("@[<hov 2>^%d:%a@ =%d%s= ^%d:%a@]%!"
@@ -1781,7 +1777,7 @@ let rec unif ~oc argsdepth matching depth adepth a bdepth b e =
        depth (if matching then "m" else "")
        bdepth (ppterm (bdepth+depth) [] ~argsdepth:bdepth e) b)
    begin
-  Format.printf "Tm A - %a -- B - %a\n@." pp_term a pp_term b;
+    (* Format.printf "Tm A - %a -- B - %a\n@." pp_term a pp_term b; *)
    let delta = adepth - bdepth in
          
    (delta = 0 && a == b) || match a,b with
@@ -1845,16 +1841,16 @@ let rec unif ~oc argsdepth matching depth adepth a bdepth b e =
 
    (* matching names *)
    | (Const cx | App(cx, _, _)), Const nc when nc == Global_symbols.namec && matching ->
-      is_eigen_variable ~depth cx
+      cx >= 0
    | (Const cx | App(cx, _, _)), App(c,hd,[]) when c == Global_symbols.namec && matching ->
-      is_eigen_variable ~depth cx && 
+      cx >= 0 && 
       unif ~oc argsdepth matching depth adepth a bdepth hd e
    | Const cx, App(c,hd,[arg]) when c == Global_symbols.namec && matching ->
-      is_eigen_variable ~depth cx && 
+      cx >= 0 && 
       unif ~oc argsdepth matching depth adepth (Const cx) bdepth hd e &&
       unif ~oc argsdepth matching depth adepth Nil bdepth arg e
    | App(cx,h,ag), App(c,hd,[arg]) when c == Global_symbols.namec && matching ->
-      is_eigen_variable ~depth cx && 
+      cx >= 0 && 
       unif ~oc argsdepth matching depth adepth (Const cx) bdepth hd e &&
       unif ~oc argsdepth matching depth adepth (list_to_lp_list (h::ag)) bdepth arg e
 
@@ -2525,19 +2521,16 @@ let hd_opt = function
 type clause_arg_classification =
   | Variable
   | MustBeVariable
-  | MustBeName
   | Rigid of constant * Mode.t
 
 let rec classify_clause_arg ~depth matching t =
   (* Format.eprintf "index %a\n%!" (ppterm depth [] ~argsdepth:depth empty_env) t; *)
   match deref_head ~depth t with
-  | Const k when k == Global_symbols.uvarc -> MustBeVariable
-  | Const k when k == Global_symbols.namec -> MustBeName
+  | (Const k | App(k,_,_)) when k == Global_symbols.uvarc -> MustBeVariable
+  | (Const k | App(k,_,_)) when k == Global_symbols.namec || k >= 0 -> Rigid(mustbenamec,matching)
   | Const k -> Rigid(k,matching)
   | Nil -> Rigid (Global_symbols.nilc,matching)
   | Cons _ -> Rigid (Global_symbols.consc,matching)
-  | App (k,_,_) when k == Global_symbols.uvarc -> MustBeVariable
-  | App (k,_,_) when k == Global_symbols.namec -> MustBeName
   | App (k,a,_) when k == Global_symbols.asc -> classify_clause_arg ~depth matching a
   | App (k,_,_) -> Rigid (k,matching)
   | Builtin (k,_) -> Rigid (const_of_builtin_predicate k,matching)
@@ -2545,7 +2538,7 @@ let rec classify_clause_arg ~depth matching t =
   | Arg _ | UVar _ | AppArg _ | AppUVar _ | Discard -> Variable
   | CData d ->
      let hash = -(CData.hash d) in
-     if hash > mustbevariablec then Rigid (hash,matching)
+     if hash > mustbenamec then Rigid (hash,matching)
      else Rigid (hash+1,matching)
 
 (** 
@@ -2601,10 +2594,7 @@ let hash_arg_list is_goal hd ~depth args mode spec =
           hash size mustbevariablec
       | App(k,_,_) when k == Global_symbols.uvarc && deep = 1 ->
           hash size mustbevariablec
-      | Const k when k == Global_symbols.namec ->
-          hash size mustbenamec
-      | App(k,_,_) when k == Global_symbols.namec && deep = 1 ->
-          hash size mustbenamec
+      | (Const k | App (k,_,_)) when k == Global_symbols.namec || k >= 0 -> hash size mustbenamec
       | Const k -> hash size k
       | App(k,_,_) when deep = 1 -> hash size k
       | App(k,x,xs) ->
@@ -2766,6 +2756,7 @@ let arg_to_trie_path ~check_mut_excl ~safe ~depth ~is_goal args arg_depths args_
       match deref_head ~depth t with 
       (* TODO: namec *)
       | (Const k | App (k,_,_)) when k == Global_symbols.uvarc -> Path.emit path mkUvarConstant; update_current_min_depth path_depth
+      | (Const k | App (k,_,_)) when k == Global_symbols.namec || k >= 0 -> Path.emit path mkName; update_current_min_depth path_depth
       | Const k when safe -> Path.emit path @@ mkConstant ~safe ~data:k ~arity:0; update_current_min_depth path_depth
       | Const k -> Path.emit path @@ mkConstant ~safe ~data:k ~arity:0; update_current_min_depth path_depth
       | CData d -> Path.emit path @@ mkPrimitive d; update_current_min_depth path_depth
@@ -2860,18 +2851,6 @@ let add_clause_to_snd_lvl_idx ~depth ~insert predicate clause = function
         all_clauses = insert clause all_clauses;
         flex_arg_clauses;
         arg_idx = Ptmap.add mustbevariablec (insert clause clauses) arg_idx;
-      }
-    | MustBeName ->
-      (* TODO: this is wrong *)
-      (* qname: matches only eigenvariable (or itself at the meta level) *)
-      let clauses =
-        try Ptmap.find mustbenamec arg_idx
-        with Not_found -> Bl.empty () in
-      TwoLevelIndex {
-        argno; mode;
-        all_clauses = insert clause all_clauses;
-        flex_arg_clauses;
-        arg_idx = Ptmap.add mustbenamec (insert clause clauses) arg_idx;
       }
     | Rigid (arg_hd,arg_mode) ->
       (* t: a rigid term matches flexible terms only in unification mode *)
@@ -3096,15 +3075,13 @@ type goal_arg_classification =
 let rec classify_goal_arg ~depth t =
   (* Format.eprintf "goal %a\n%!" (ppterm depth [] ~argsdepth:depth empty_env) t; *)
   match deref_head ~depth t with
-  | Const k when k == Global_symbols.uvarc -> Rigid mustbevariablec
-  | Const k when k == Global_symbols.namec -> Rigid mustbenamec
-  | Const k -> Rigid(k)
+  | (Const k | App(k,_,_)) when k == Global_symbols.uvarc -> Rigid mustbevariablec
+  | (Const k | App(k,_,_)) when k == Global_symbols.namec || k >= 0 -> Rigid mustbenamec
+  | Const k -> Rigid k
   | Nil -> Rigid (Global_symbols.nilc)
   | Cons _ -> Rigid (Global_symbols.consc)
-  | App (k,_,_) when k == Global_symbols.uvarc -> Rigid mustbevariablec
-  | App (k,_,_) when k == Global_symbols.uvarc -> Rigid mustbenamec
   | App (k,a,_) when k == Global_symbols.asc -> classify_goal_arg ~depth a
-  | App (k,_,_) -> Rigid (k)
+  | App (k,_,_) -> Rigid k
   | Builtin (k,_) -> Rigid (const_of_builtin_predicate k)
   | Lam t -> classify_goal_arg ~depth:(depth+1) t (* eta *)
   | Arg _ | UVar _ | AppArg _ | AppUVar _ | Discard -> Variable

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -2527,7 +2527,7 @@ let rec classify_clause_arg ~depth matching t =
   (* Format.eprintf "index %a\n%!" (ppterm depth [] ~argsdepth:depth empty_env) t; *)
   match deref_head ~depth t with
   | (Const k | App(k,_,_)) when k == Global_symbols.uvarc -> MustBeVariable
-  | (Const k | App(k,_,_)) when k == Global_symbols.namec || k >= 0 -> Rigid(mustbenamec,matching)
+  | (Const k | App(k,_,_)) when k == Global_symbols.namec -> Rigid(mustbenamec,matching)
   | Const k -> Rigid(k,matching)
   | Nil -> Rigid (Global_symbols.nilc,matching)
   | Cons _ -> Rigid (Global_symbols.consc,matching)
@@ -3075,7 +3075,7 @@ let rec classify_goal_arg ~depth t =
   (* Format.eprintf "goal %a\n%!" (ppterm depth [] ~argsdepth:depth empty_env) t; *)
   match deref_head ~depth t with
   | (Const k | App(k,_,_)) when k == Global_symbols.uvarc -> Rigid mustbevariablec
-  | (Const k | App(k,_,_)) when k == Global_symbols.namec || k >= 0 -> Rigid mustbenamec
+  | (Const k | App(k,_,_)) when k == Global_symbols.namec -> Rigid mustbenamec
   | Const k -> Rigid k
   | Nil -> Rigid (Global_symbols.nilc)
   | Cons _ -> Rigid (Global_symbols.consc)
@@ -3087,7 +3087,7 @@ let rec classify_goal_arg ~depth t =
   | CData d -> 
      let hash = -(CData.hash d) in
      if hash > mustbenamec then Rigid (hash)
-     else Rigid (hash+1)
+     else Rigid (hash+2)
 
 let classify_goal_argno ~depth argno = function
   | Const _ -> Variable

--- a/src/runtime/test_discrimination_tree.ml
+++ b/src/runtime/test_discrimination_tree.ml
@@ -106,3 +106,7 @@ let () =
   Printf.printf "Test remove 4\n";
   remove dt 200;
   test ~expected:0 (get_length dt p1Retr)
+
+let () = 
+  let n : cell = mkConstant ~safe:true ~data:10 ~arity:0 in
+  assert (isNameConst n)

--- a/src/runtime/test_discrimination_tree.ml
+++ b/src/runtime/test_discrimination_tree.ml
@@ -110,3 +110,7 @@ let () =
 let () = 
   let n : cell = mkConstant ~safe:true ~data:10 ~arity:0 in
   assert (isNameConst n)
+
+let () = 
+  let n : cell = mkConstant ~safe:true ~data:~-10 ~arity:0 in
+  assert (not (isNameConst n))

--- a/test.elpi
+++ b/test.elpi
@@ -1,0 +1,8 @@
+pred p int -> int.
+
+% p uvar.
+p (qname X) X.
+
+
+main :- 
+  (pi x\ p x (R x), std.assert!(R x = x) "Err").

--- a/test.elpi
+++ b/test.elpi
@@ -1,20 +1,23 @@
-pred check0 int, int.
-check0 _ qname.
+:index (1) "Hash"
+pred check0 int.
+check0 qname.
 
-pred check1 int, int -> int.
-check1 _ (qname X) X.
 
-pred check2 int, int -> any, list any.
-check2 _ (qname X L) X L.
+:index (1) "DTree"
+pred check1 int -> int.
+check1 (qname X) X.
+
+pred check2 int -> any, list any.
+check2 (qname X L) X L.
 
 pred t0 int.
-t0 T1 :- check0 0 T1.
+t0 T1 :- check0 T1.
 
 pred t1 int.
-t1 T1 :- check1 0 T1 T2, T1 == T2.
+t1 T1 :- check1 T1 T2, T1 == T2.
 
 pred t2 int, any, list any.
-t2 T1 T2 T3 :- check2 0 T1 T2' T3', T2' == T2, T3' == T3.
+t2 T1 T2 T3 :- check2 T1 T2' T3', T2' == T2, T3' == T3.
 
 main :- 
   % std.spy-do![

--- a/test.elpi
+++ b/test.elpi
@@ -1,8 +1,29 @@
-pred p int -> int.
+pred check0 int, int.
+check0 _ qname.
 
-% p uvar.
-p (qname X) X.
+pred check1 int, int -> int.
+check1 _ (qname X) X.
 
+pred check2 int, int -> any, list any.
+check2 _ (qname X L) X L.
+
+pred t0 int.
+t0 T1 :- check0 0 T1.
+
+pred t1 int.
+t1 T1 :- check1 0 T1 T2, T1 == T2.
+
+pred t2 int, any, list any.
+t2 T1 T2 T3 :- check2 0 T1 T2' T3', T2' == T2, T3' == T3.
 
 main :- 
-  (pi x\ p x (R x), std.assert!(R x = x) "Err").
+  % std.spy-do![
+    (pi x\ t0 x),
+    (pi x\ t1 x),
+    (pi x\ t2 x x []),
+    (pi x y\ t0 (x y)),
+    (pi x y\ t1 (x y)),
+    (pi x y\ t2 (x y) x [y])
+  % ]
+  .
+  

--- a/tests/sources/functionality/test120.elpi
+++ b/tests/sources/functionality/test120.elpi
@@ -1,0 +1,14 @@
+% YES
+kind term type.
+type lam (term -> term) -> term.
+type app term -> term -> term.
+
+% ugly-copy: no load rules for name, but catchall for names using qname
+func copy term -> term.
+copy (qname X) X.
+copy (app X Y) (app X' Y') :- copy X X', copy Y Y'.
+copy (lam B) (lam B') :- pi x\ copy (B x) (B' x).
+
+main :-
+  T = lam (x\ app(lam y\ x) x),
+  copy T R.

--- a/tests/sources/functionality/test121.elpi
+++ b/tests/sources/functionality/test121.elpi
@@ -1,0 +1,11 @@
+% NO
+kind term type.
+type lam (term -> term) -> term.
+
+% ugly-copy: no load rules for name, but catchall for names using qname
+func copy term -> term.
+copy (qname X) X.
+% this fails since the local copy overlap with rule above
+copy (lam B) (lam B') :- pi x\ copy x x => copy (B x) (B' x).
+
+main.

--- a/tests/sources/functionality/test122.elpi
+++ b/tests/sources/functionality/test122.elpi
@@ -1,0 +1,11 @@
+% NO
+kind term type.
+type lam (term -> term) -> term.
+
+% ugly-copy: no load rules for name, but catchall for names using qname
+func copy term -> term.
+copy (lam B) (lam B') :- pi x\ copy x x => copy (B x) (B' x).
+% this fails since overlapping with the local copy rule above
+copy (qname X) X.
+
+main.

--- a/tests/sources/functionality/test123.elpi
+++ b/tests/sources/functionality/test123.elpi
@@ -1,0 +1,10 @@
+% NO
+kind term type.
+type lam (term -> term) -> term.
+
+% ugly-copy: no load rules for name, but catchall for names using qname
+func copy term -> term.
+copy X X :- !.
+copy (lam B) (lam B') :- pi x\ (copy x x) => copy (B x) (B' x).
+
+main.

--- a/tests/sources/qname.elpi
+++ b/tests/sources/qname.elpi
@@ -1,0 +1,32 @@
+:index (1) "Hash"
+pred check0 int.
+check0 qname.
+
+
+:index (1) "DTree"
+pred check1 int -> int.
+check1 (qname X) X.
+
+pred check2 int -> any, list any.
+check2 (qname X L) X L.
+
+pred t0 int.
+t0 T1 :- check0 T1.
+
+pred t1 int.
+t1 T1 :- check1 T1 T2, T1 == T2.
+
+pred t2 int, any, list any.
+t2 T1 T2 T3 :- check2 T1 T2' T3', T2' == T2, T3' == T3.
+
+main :- 
+  % std.spy-do![
+    (pi x\ t0 x),
+    (pi x\ t1 x),
+    (pi x\ t2 x x []),
+    (pi x y\ t0 (x y)),
+    (pi x y\ t1 (x y)),
+    (pi x y\ t2 (x y) x [y])
+  % ]
+  .
+  

--- a/tests/sources/trace.elab.json
+++ b/tests/sources/trace.elab.json
@@ -263,9 +263,9 @@
                     "File",
                     {
                       "filename": "builtin.elpi",
-                      "line": 91,
+                      "line": 93,
                       "column": 0,
-                      "character": 1631
+                      "character": 1668
                     }
                   ]
                 }
@@ -289,9 +289,9 @@
                   "File",
                   {
                     "filename": "builtin.elpi",
-                    "line": 91,
+                    "line": 93,
                     "column": 0,
-                    "character": 1631
+                    "character": 1668
                   }
                 ]
               }
@@ -397,9 +397,9 @@
                   "File",
                   {
                     "filename": "builtin.elpi",
-                    "line": 91,
+                    "line": 93,
                     "column": 0,
-                    "character": 1631
+                    "character": 1668
                   }
                 ]
               }
@@ -506,9 +506,9 @@
                   "File",
                   {
                     "filename": "builtin.elpi",
-                    "line": 91,
+                    "line": 93,
                     "column": 0,
-                    "character": 1631
+                    "character": 1668
                   }
                 ]
               }

--- a/tests/sources/trace.json
+++ b/tests/sources/trace.json
@@ -24,8 +24,8 @@
 {"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["is","1 is 2 + 3"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 91, column 0, characters 1631-1649:"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 91, column 0, characters 1631-1649:","(A1 is A0) :- (calc A0 A1)."]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 93, column 0, characters 1668-1686:"]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 93, column 0, characters 1668-1686:","(A1 is A0) :- (calc A0 A1)."]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := 1"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := 2 + 3"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["8"]}

--- a/tests/sources/trace_chr.elab.json
+++ b/tests/sources/trace_chr.elab.json
@@ -772,9 +772,9 @@
                     "File",
                     {
                       "filename": "builtin.elpi",
-                      "line": 69,
+                      "line": 71,
                       "column": 0,
-                      "character": 1189
+                      "character": 1226
                     }
                   ]
                 }
@@ -800,9 +800,9 @@
                   "File",
                   {
                     "filename": "builtin.elpi",
-                    "line": 69,
+                    "line": 71,
                     "column": 0,
-                    "character": 1189
+                    "character": 1226
                   }
                 ]
               }
@@ -903,9 +903,9 @@
                   "File",
                   {
                     "filename": "builtin.elpi",
-                    "line": 69,
+                    "line": 71,
                     "column": 0,
-                    "character": 1189
+                    "character": 1226
                   }
                 ]
               }
@@ -980,9 +980,9 @@
                   "File",
                   {
                     "filename": "builtin.elpi",
-                    "line": 69,
+                    "line": 71,
                     "column": 0,
-                    "character": 1189
+                    "character": 1226
                   }
                 ]
               }
@@ -1307,9 +1307,9 @@
                     "File",
                     {
                       "filename": "builtin.elpi",
-                      "line": 71,
+                      "line": 73,
                       "column": 0,
-                      "character": 1211
+                      "character": 1248
                     }
                   ]
                 }
@@ -1331,9 +1331,9 @@
                   "File",
                   {
                     "filename": "builtin.elpi",
-                    "line": 71,
+                    "line": 73,
                     "column": 0,
-                    "character": 1211
+                    "character": 1248
                   }
                 ]
               }

--- a/tests/sources/trace_chr.json
+++ b/tests/sources/trace_chr.json
@@ -71,8 +71,8 @@
 {"step" : 10,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["not","not (even X1)"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","(not A0) :- A0, !, fail."]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1226-1245:","File \"builtin.elpi\", line 73, column 0, characters 1248-1253:"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1226-1245:","(not A0) :- A0, !, fail."]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := even X1"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["15"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["even X1"]}
@@ -96,7 +96,7 @@
 {"step" : 13,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["even X1"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:CHR:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 1, column 21, characters 21-66:"," \\ (even A0) (odd A0) | (odd z) <=> (true)"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--420 []"]}
+{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--421 []"]}
 {"step" : 0,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["odd z"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["odd","odd z"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
@@ -104,7 +104,7 @@
 {"step" : 1,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:CHR:rule-failed","payload" : []}
 {"step" : 14,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:CHR:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 2, column 45, characters 67-116:"," \\ (even A0) (odd A0) | (odd (s z)) <=> (fail)"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 2,"name" : "user:assign","payload" : ["A0 := uvar frozen--421 []"]}
+{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 2,"name" : "user:assign","payload" : ["A0 := uvar frozen--422 []"]}
 {"step" : 0,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:newgoal","payload" : ["odd (s z)"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:curgoal","payload" : ["odd","odd (s z)"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:rule","payload" : ["backchain"]}
@@ -137,6 +137,6 @@
 {"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["not","not (even X1)"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:","(not _) :- ."]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 73, column 0, characters 1248-1253:"]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 73, column 0, characters 1248-1253:","(not _) :- ."]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}

--- a/tests/sources/trace_w.elab.json
+++ b/tests/sources/trace_w.elab.json
@@ -1988,7 +1988,7 @@
                   "step": [
                     "Init",
                     {
-                      "goal_text": "generalize [] [] (mono (uvar frozen--451 [] ===> uvar frozen--451 [])) X3",
+                      "goal_text": "generalize [] [] (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) X3",
                       "goal_id": 26
                     }
                   ],
@@ -2001,7 +2001,7 @@
                     "Inference",
                     {
                       "current_goal_id": 26,
-                      "current_goal_text": "generalize [] [] (mono (uvar frozen--451 [] ===> uvar frozen--451 [])) X3",
+                      "current_goal_text": "generalize [] [] (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) X3",
                       "current_goal_predicate": "generalize",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -2027,14 +2027,14 @@
                               [ "Assign", "A2 := []" ],
                               [
                                 "Assign",
-                                "A0 := uvar frozen--451 [] ===> uvar frozen--451 []"
+                                "A0 := uvar frozen--452 [] ===> uvar frozen--452 []"
                               ],
                               [ "Assign", "A6 := X3" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "free-ty (mono (uvar frozen--451 [] ===> uvar frozen--451 [])) [] X4",
+                              "goal_text": "free-ty (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) [] X4",
                               "goal_id": 27
                             },
                             {
@@ -2046,7 +2046,7 @@
                               "goal_id": 29
                             },
                             {
-                              "goal_text": "bind X6 [] (uvar frozen--451 [] ===> uvar frozen--451 []) X3",
+                              "goal_text": "bind X6 [] (uvar frozen--452 [] ===> uvar frozen--452 []) X3",
                               "goal_id": 30
                             }
                           ],
@@ -2086,7 +2086,7 @@
                     "Inference",
                     {
                       "current_goal_id": 27,
-                      "current_goal_text": "free-ty (mono (uvar frozen--451 [] ===> uvar frozen--451 [])) [] X4",
+                      "current_goal_text": "free-ty (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) [] X4",
                       "current_goal_predicate": "free-ty",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -2110,7 +2110,7 @@
                             "events": [
                               [
                                 "Assign",
-                                "A0 := uvar frozen--451 [] ===> uvar frozen--451 []"
+                                "A0 := uvar frozen--452 [] ===> uvar frozen--452 []"
                               ],
                               [ "Assign", "A1 := []" ],
                               [ "Assign", "A2 := X4" ]
@@ -2118,7 +2118,7 @@
                           },
                           "siblings": [
                             {
-                              "goal_text": "free (uvar frozen--451 [] ===> uvar frozen--451 []) [] X4",
+                              "goal_text": "free (uvar frozen--452 [] ===> uvar frozen--452 []) [] X4",
                               "goal_id": 31
                             }
                           ],
@@ -2177,7 +2177,7 @@
                     "Inference",
                     {
                       "current_goal_id": 31,
-                      "current_goal_text": "free (uvar frozen--451 [] ===> uvar frozen--451 []) [] X4",
+                      "current_goal_text": "free (uvar frozen--452 [] ===> uvar frozen--452 []) [] X4",
                       "current_goal_predicate": "free",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -2199,19 +2199,19 @@
                               }
                             ],
                             "events": [
-                              [ "Assign", "A0 := uvar frozen--451 []" ],
-                              [ "Assign", "A3 := uvar frozen--451 []" ],
+                              [ "Assign", "A0 := uvar frozen--452 []" ],
+                              [ "Assign", "A3 := uvar frozen--452 []" ],
                               [ "Assign", "A1 := []" ],
                               [ "Assign", "A4 := X4" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "free (uvar frozen--451 []) [] X7",
+                              "goal_text": "free (uvar frozen--452 []) [] X7",
                               "goal_id": 32
                             },
                             {
-                              "goal_text": "free (uvar frozen--451 []) X7 X4",
+                              "goal_text": "free (uvar frozen--452 []) X7 X4",
                               "goal_id": 33
                             }
                           ],
@@ -2289,7 +2289,7 @@
                     "Inference",
                     {
                       "current_goal_id": 32,
-                      "current_goal_text": "free (uvar frozen--451 []) [] X7",
+                      "current_goal_text": "free (uvar frozen--452 []) [] X7",
                       "current_goal_predicate": "free",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -2311,14 +2311,14 @@
                               }
                             ],
                             "events": [
-                              [ "Assign", "A1 := uvar frozen--451 []" ],
+                              [ "Assign", "A1 := uvar frozen--452 []" ],
                               [ "Assign", "A0 := []" ],
                               [ "Assign", "A2 := X7" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "if (mem [] (uvar frozen--451 [])) (X7 = []) (X7 = [uvar frozen--451 []])",
+                              "goal_text": "if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])",
                               "goal_id": 34
                             }
                           ],
@@ -2415,7 +2415,7 @@
                     "Inference",
                     {
                       "current_goal_id": 34,
-                      "current_goal_text": "if (mem [] (uvar frozen--451 [])) (X7 = []) (X7 = [uvar frozen--451 []])",
+                      "current_goal_text": "if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])",
                       "current_goal_predicate": "if",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -2429,9 +2429,9 @@
                                   "File",
                                   {
                                     "filename": "builtin.elpi",
-                                    "line": 536,
+                                    "line": 538,
                                     "column": 0,
-                                    "character": 13939
+                                    "character": 13976
                                   }
                                 ]
                               }
@@ -2439,14 +2439,14 @@
                             "events": [
                               [
                                 "Assign",
-                                "A0 := mem [] (uvar frozen--451 [])"
+                                "A0 := mem [] (uvar frozen--452 [])"
                               ],
                               [ "Assign", "A1 := X7 = []" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "mem [] (uvar frozen--451 [])",
+                              "goal_text": "mem [] (uvar frozen--452 [])",
                               "goal_id": 35
                             },
                             { "goal_text": "!", "goal_id": 36 },
@@ -2466,9 +2466,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 536,
+                                  "line": 538,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13976
                                 }
                               ]
                             }
@@ -2564,7 +2564,7 @@
                     "Inference",
                     {
                       "current_goal_id": 35,
-                      "current_goal_text": "mem [] (uvar frozen--451 [])",
+                      "current_goal_text": "mem [] (uvar frozen--452 [])",
                       "current_goal_predicate": "mem",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -2587,12 +2587,12 @@
                             ],
                             "events": [
                               [ "Assign", "A0 := []" ],
-                              [ "Assign", "A1 := frozen--451" ]
+                              [ "Assign", "A1 := frozen--452" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "mem! [] (uvar frozen--451 X8)",
+                              "goal_text": "mem! [] (uvar frozen--452 X8)",
                               "goal_id": 38
                             }
                           ],
@@ -2629,9 +2629,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 536,
+                                  "line": 538,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13976
                                 }
                               ]
                             }
@@ -2727,7 +2727,7 @@
                     "Inference",
                     {
                       "current_goal_id": 38,
-                      "current_goal_text": "mem! [] (uvar frozen--451 X8)",
+                      "current_goal_text": "mem! [] (uvar frozen--452 X8)",
                       "current_goal_predicate": "mem!",
                       "failed_attempts": [],
                       "successful_attempts": [],
@@ -2761,9 +2761,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 536,
+                                  "line": 538,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13976
                                 }
                               ]
                             }
@@ -2859,7 +2859,7 @@
                     "Inference",
                     {
                       "current_goal_id": 34,
-                      "current_goal_text": "if (mem [] (uvar frozen--451 [])) (X7 = []) (X7 = [uvar frozen--451 []])",
+                      "current_goal_text": "if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])",
                       "current_goal_predicate": "if",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -2873,22 +2873,22 @@
                                   "File",
                                   {
                                     "filename": "builtin.elpi",
-                                    "line": 537,
+                                    "line": 539,
                                     "column": 0,
-                                    "character": 13960
+                                    "character": 13997
                                   }
                                 ]
                               }
                             ],
                             "events": [
                               [
-                                "Assign", "A0 := X7 = [uvar frozen--451 []]"
+                                "Assign", "A0 := X7 = [uvar frozen--452 []]"
                               ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "X7 = [uvar frozen--451 []]",
+                              "goal_text": "X7 = [uvar frozen--452 []]",
                               "goal_id": 39
                             }
                           ],
@@ -2906,9 +2906,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 537,
+                                  "line": 539,
                                   "column": 0,
-                                  "character": 13960
+                                  "character": 13997
                                 }
                               ]
                             }
@@ -3004,7 +3004,7 @@
                     "Inference",
                     {
                       "current_goal_id": 39,
-                      "current_goal_text": "X7 = [uvar frozen--451 []]",
+                      "current_goal_text": "X7 = [uvar frozen--452 []]",
                       "current_goal_predicate": "=",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -3012,7 +3012,7 @@
                           "attempt": {
                             "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
                             "events": [
-                              [ "Assign", "X7 := [uvar frozen--451 []]" ]
+                              [ "Assign", "X7 := [uvar frozen--452 []]" ]
                             ]
                           },
                           "siblings": [],
@@ -3035,9 +3035,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 537,
+                                  "line": 539,
                                   "column": 0,
-                                  "character": 13960
+                                  "character": 13997
                                 }
                               ]
                             }
@@ -3133,7 +3133,7 @@
                     "Inference",
                     {
                       "current_goal_id": 33,
-                      "current_goal_text": "free (uvar frozen--451 []) [uvar frozen--451 []] X4",
+                      "current_goal_text": "free (uvar frozen--452 []) [uvar frozen--452 []] X4",
                       "current_goal_predicate": "free",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -3155,14 +3155,14 @@
                               }
                             ],
                             "events": [
-                              [ "Assign", "A1 := uvar frozen--451 []" ],
-                              [ "Assign", "A0 := [uvar frozen--451 []]" ],
+                              [ "Assign", "A1 := uvar frozen--452 []" ],
+                              [ "Assign", "A0 := [uvar frozen--452 []]" ],
                               [ "Assign", "A2 := X4" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "if (mem [uvar frozen--451 []] (uvar frozen--451 [])) \n (X4 = [uvar frozen--451 []]) \n (X4 = [uvar frozen--451 [], uvar frozen--451 []])",
+                              "goal_text": "if (mem [uvar frozen--452 []] (uvar frozen--452 [])) \n (X4 = [uvar frozen--452 []]) \n (X4 = [uvar frozen--452 [], uvar frozen--452 []])",
                               "goal_id": 40
                             }
                           ],
@@ -3259,7 +3259,7 @@
                     "Inference",
                     {
                       "current_goal_id": 40,
-                      "current_goal_text": "if (mem [uvar frozen--451 []] (uvar frozen--451 [])) \n (X4 = [uvar frozen--451 []]) \n (X4 = [uvar frozen--451 [], uvar frozen--451 []])",
+                      "current_goal_text": "if (mem [uvar frozen--452 []] (uvar frozen--452 [])) \n (X4 = [uvar frozen--452 []]) \n (X4 = [uvar frozen--452 [], uvar frozen--452 []])",
                       "current_goal_predicate": "if",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -3273,9 +3273,9 @@
                                   "File",
                                   {
                                     "filename": "builtin.elpi",
-                                    "line": 536,
+                                    "line": 538,
                                     "column": 0,
-                                    "character": 13939
+                                    "character": 13976
                                   }
                                 ]
                               }
@@ -3283,21 +3283,21 @@
                             "events": [
                               [
                                 "Assign",
-                                "A0 := mem [uvar frozen--451 []] (uvar frozen--451 [])"
+                                "A0 := mem [uvar frozen--452 []] (uvar frozen--452 [])"
                               ],
                               [
-                                "Assign", "A1 := X4 = [uvar frozen--451 []]"
+                                "Assign", "A1 := X4 = [uvar frozen--452 []]"
                               ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "mem [uvar frozen--451 []] (uvar frozen--451 [])",
+                              "goal_text": "mem [uvar frozen--452 []] (uvar frozen--452 [])",
                               "goal_id": 41
                             },
                             { "goal_text": "!", "goal_id": 42 },
                             {
-                              "goal_text": "X4 = [uvar frozen--451 []]",
+                              "goal_text": "X4 = [uvar frozen--452 []]",
                               "goal_id": 43
                             }
                           ],
@@ -3315,9 +3315,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 536,
+                                  "line": 538,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13976
                                 }
                               ]
                             }
@@ -3413,7 +3413,7 @@
                     "Inference",
                     {
                       "current_goal_id": 41,
-                      "current_goal_text": "mem [uvar frozen--451 []] (uvar frozen--451 [])",
+                      "current_goal_text": "mem [uvar frozen--452 []] (uvar frozen--452 [])",
                       "current_goal_predicate": "mem",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -3435,13 +3435,13 @@
                               }
                             ],
                             "events": [
-                              [ "Assign", "A0 := [uvar frozen--451 []]" ],
-                              [ "Assign", "A1 := frozen--451" ]
+                              [ "Assign", "A0 := [uvar frozen--452 []]" ],
+                              [ "Assign", "A1 := frozen--452" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "mem! [uvar frozen--451 []] (uvar frozen--451 X9)",
+                              "goal_text": "mem! [uvar frozen--452 []] (uvar frozen--452 X9)",
                               "goal_id": 44
                             }
                           ],
@@ -3478,9 +3478,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 536,
+                                  "line": 538,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13976
                                 }
                               ]
                             }
@@ -3576,7 +3576,7 @@
                     "Inference",
                     {
                       "current_goal_id": 44,
-                      "current_goal_text": "mem! [uvar frozen--451 []] (uvar frozen--451 X9)",
+                      "current_goal_text": "mem! [uvar frozen--452 []] (uvar frozen--452 X9)",
                       "current_goal_predicate": "mem!",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -3598,7 +3598,7 @@
                               }
                             ],
                             "events": [
-                              [ "Assign", "A0 := uvar frozen--451 []" ],
+                              [ "Assign", "A0 := uvar frozen--452 []" ],
                               [ "Assign", "X9 := []" ]
                             ]
                           },
@@ -3655,9 +3655,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 536,
+                                  "line": 538,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13976
                                 }
                               ]
                             }
@@ -3756,7 +3756,7 @@
                       "cut_victims": [
                         {
                           "cut_branch_for_goal": {
-                            "goal_text": "mem! [uvar frozen--451 []] (uvar frozen--451 X9)",
+                            "goal_text": "mem! [uvar frozen--452 []] (uvar frozen--452 X9)",
                             "goal_id": 44
                           },
                           "cut_branch": {
@@ -3787,7 +3787,7 @@
                       "cut_victims": [
                         {
                           "cut_branch_for_goal": {
-                            "goal_text": "if (mem [uvar frozen--451 []] (uvar frozen--451 [])) \n (X4 = [uvar frozen--451 []]) \n (X4 = [uvar frozen--451 [], uvar frozen--451 []])",
+                            "goal_text": "if (mem [uvar frozen--452 []] (uvar frozen--452 [])) \n (X4 = [uvar frozen--452 []]) \n (X4 = [uvar frozen--452 [], uvar frozen--452 []])",
                             "goal_id": 40
                           },
                           "cut_branch": {
@@ -3796,9 +3796,9 @@
                               "File",
                               {
                                 "filename": "builtin.elpi",
-                                "line": 537,
+                                "line": 539,
                                 "column": 0,
-                                "character": 13960
+                                "character": 13997
                               }
                             ]
                           }
@@ -3815,7 +3815,7 @@
                     "Inference",
                     {
                       "current_goal_id": 43,
-                      "current_goal_text": "X4 = [uvar frozen--451 []]",
+                      "current_goal_text": "X4 = [uvar frozen--452 []]",
                       "current_goal_predicate": "=",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -3823,7 +3823,7 @@
                           "attempt": {
                             "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
                             "events": [
-                              [ "Assign", "X4 := [uvar frozen--451 []]" ]
+                              [ "Assign", "X4 := [uvar frozen--452 []]" ]
                             ]
                           },
                           "siblings": [],
@@ -3846,9 +3846,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 536,
+                                  "line": 538,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13976
                                 }
                               ]
                             }
@@ -4026,7 +4026,7 @@
                     "Inference",
                     {
                       "current_goal_id": 29,
-                      "current_goal_text": "filter [uvar frozen--451 []] (c0 \\ not (mem [] c0)) X6",
+                      "current_goal_text": "filter [uvar frozen--452 []] (c0 \\ not (mem [] c0)) X6",
                       "current_goal_predicate": "filter",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -4048,17 +4048,17 @@
                               }
                             ],
                             "events": [
-                              [ "Assign", "A0 := uvar frozen--451 []" ],
+                              [ "Assign", "A0 := uvar frozen--452 []" ],
                               [ "Assign", "A2 := []" ],
                               [ "Assign", "A1 := c0 \\\nnot (mem [] c0)" ],
                               [
-                                "Assign", "X6 := [uvar frozen--451 [] | X10]"
+                                "Assign", "X6 := [uvar frozen--452 [] | X10]"
                               ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "not (mem [] (uvar frozen--451 []))",
+                              "goal_text": "not (mem [] (uvar frozen--452 []))",
                               "goal_id": 46
                             },
                             { "goal_text": "!", "goal_id": 47 },
@@ -4122,7 +4122,7 @@
                     "Inference",
                     {
                       "current_goal_id": 46,
-                      "current_goal_text": "not (mem [] (uvar frozen--451 []))",
+                      "current_goal_text": "not (mem [] (uvar frozen--452 []))",
                       "current_goal_predicate": "not",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -4136,9 +4136,9 @@
                                   "File",
                                   {
                                     "filename": "builtin.elpi",
-                                    "line": 69,
+                                    "line": 71,
                                     "column": 0,
-                                    "character": 1189
+                                    "character": 1226
                                   }
                                 ]
                               }
@@ -4146,13 +4146,13 @@
                             "events": [
                               [
                                 "Assign",
-                                "A0 := mem [] (uvar frozen--451 [])"
+                                "A0 := mem [] (uvar frozen--452 [])"
                               ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "mem [] (uvar frozen--451 [])",
+                              "goal_text": "mem [] (uvar frozen--452 [])",
                               "goal_id": 49
                             },
                             { "goal_text": "!", "goal_id": 50 },
@@ -4172,9 +4172,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 69,
+                                  "line": 71,
                                   "column": 0,
-                                  "character": 1189
+                                  "character": 1226
                                 }
                               ]
                             }
@@ -4232,7 +4232,7 @@
                     "Inference",
                     {
                       "current_goal_id": 49,
-                      "current_goal_text": "mem [] (uvar frozen--451 [])",
+                      "current_goal_text": "mem [] (uvar frozen--452 [])",
                       "current_goal_predicate": "mem",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -4255,12 +4255,12 @@
                             ],
                             "events": [
                               [ "Assign", "A0 := []" ],
-                              [ "Assign", "A1 := frozen--451" ]
+                              [ "Assign", "A1 := frozen--452" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "mem! [] (uvar frozen--451 X11)",
+                              "goal_text": "mem! [] (uvar frozen--452 X11)",
                               "goal_id": 52
                             }
                           ],
@@ -4297,9 +4297,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 69,
+                                  "line": 71,
                                   "column": 0,
-                                  "character": 1189
+                                  "character": 1226
                                 }
                               ]
                             }
@@ -4357,7 +4357,7 @@
                     "Inference",
                     {
                       "current_goal_id": 52,
-                      "current_goal_text": "mem! [] (uvar frozen--451 X11)",
+                      "current_goal_text": "mem! [] (uvar frozen--452 X11)",
                       "current_goal_predicate": "mem!",
                       "failed_attempts": [],
                       "successful_attempts": [],
@@ -4391,9 +4391,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 69,
+                                  "line": 71,
                                   "column": 0,
-                                  "character": 1189
+                                  "character": 1226
                                 }
                               ]
                             }
@@ -4451,7 +4451,7 @@
                     "Inference",
                     {
                       "current_goal_id": 46,
-                      "current_goal_text": "not (mem [] (uvar frozen--451 []))",
+                      "current_goal_text": "not (mem [] (uvar frozen--452 []))",
                       "current_goal_predicate": "not",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -4465,9 +4465,9 @@
                                   "File",
                                   {
                                     "filename": "builtin.elpi",
-                                    "line": 71,
+                                    "line": 73,
                                     "column": 0,
-                                    "character": 1211
+                                    "character": 1248
                                   }
                                 ]
                               }
@@ -4489,9 +4489,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 71,
+                                  "line": 73,
                                   "column": 0,
-                                  "character": 1211
+                                  "character": 1248
                                 }
                               ]
                             }
@@ -4678,7 +4678,7 @@
                     "Inference",
                     {
                       "current_goal_id": 30,
-                      "current_goal_text": "bind [uvar frozen--451 []] [] (uvar frozen--451 [] ===> uvar frozen--451 []) \n X3",
+                      "current_goal_text": "bind [uvar frozen--452 []] [] (uvar frozen--452 [] ===> uvar frozen--452 []) \n X3",
                       "current_goal_predicate": "bind",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -4700,23 +4700,23 @@
                               }
                             ],
                             "events": [
-                              [ "Assign", "A1 := uvar frozen--451 []" ],
+                              [ "Assign", "A1 := uvar frozen--452 []" ],
                               [ "Assign", "A3 := []" ],
                               [ "Assign", "A0 := []" ],
                               [
                                 "Assign",
-                                "A4 := uvar frozen--451 [] ===> uvar frozen--451 []"
+                                "A4 := uvar frozen--452 [] ===> uvar frozen--452 []"
                               ],
                               [ "Assign", "X3 := all X12 c0 \\ X13 c0" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "if (mem [] (uvar frozen--451 [])) (X12 = eqt) (X12 = any)",
+                              "goal_text": "if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)",
                               "goal_id": 53
                             },
                             {
-                              "goal_text": "pi c0 \\\n copy (uvar frozen--451 []) c0 =>\n  bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)",
+                              "goal_text": "pi c0 \\\n copy (uvar frozen--452 []) c0 =>\n  bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)",
                               "goal_id": 54
                             }
                           ],
@@ -4775,7 +4775,7 @@
                     "Inference",
                     {
                       "current_goal_id": 53,
-                      "current_goal_text": "if (mem [] (uvar frozen--451 [])) (X12 = eqt) (X12 = any)",
+                      "current_goal_text": "if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)",
                       "current_goal_predicate": "if",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -4789,9 +4789,9 @@
                                   "File",
                                   {
                                     "filename": "builtin.elpi",
-                                    "line": 536,
+                                    "line": 538,
                                     "column": 0,
-                                    "character": 13939
+                                    "character": 13976
                                   }
                                 ]
                               }
@@ -4799,14 +4799,14 @@
                             "events": [
                               [
                                 "Assign",
-                                "A0 := mem [] (uvar frozen--451 [])"
+                                "A0 := mem [] (uvar frozen--452 [])"
                               ],
                               [ "Assign", "A1 := X12 = eqt" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "mem [] (uvar frozen--451 [])",
+                              "goal_text": "mem [] (uvar frozen--452 [])",
                               "goal_id": 55
                             },
                             { "goal_text": "!", "goal_id": 56 },
@@ -4826,9 +4826,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 536,
+                                  "line": 538,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13976
                                 }
                               ]
                             }
@@ -4886,7 +4886,7 @@
                     "Inference",
                     {
                       "current_goal_id": 55,
-                      "current_goal_text": "mem [] (uvar frozen--451 [])",
+                      "current_goal_text": "mem [] (uvar frozen--452 [])",
                       "current_goal_predicate": "mem",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -4909,12 +4909,12 @@
                             ],
                             "events": [
                               [ "Assign", "A0 := []" ],
-                              [ "Assign", "A1 := frozen--451" ]
+                              [ "Assign", "A1 := frozen--452" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "mem! [] (uvar frozen--451 X14)",
+                              "goal_text": "mem! [] (uvar frozen--452 X14)",
                               "goal_id": 58
                             }
                           ],
@@ -4951,9 +4951,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 536,
+                                  "line": 538,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13976
                                 }
                               ]
                             }
@@ -5011,7 +5011,7 @@
                     "Inference",
                     {
                       "current_goal_id": 58,
-                      "current_goal_text": "mem! [] (uvar frozen--451 X14)",
+                      "current_goal_text": "mem! [] (uvar frozen--452 X14)",
                       "current_goal_predicate": "mem!",
                       "failed_attempts": [],
                       "successful_attempts": [],
@@ -5045,9 +5045,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 536,
+                                  "line": 538,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13976
                                 }
                               ]
                             }
@@ -5105,7 +5105,7 @@
                     "Inference",
                     {
                       "current_goal_id": 53,
-                      "current_goal_text": "if (mem [] (uvar frozen--451 [])) (X12 = eqt) (X12 = any)",
+                      "current_goal_text": "if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)",
                       "current_goal_predicate": "if",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -5119,9 +5119,9 @@
                                   "File",
                                   {
                                     "filename": "builtin.elpi",
-                                    "line": 537,
+                                    "line": 539,
                                     "column": 0,
-                                    "character": 13960
+                                    "character": 13997
                                   }
                                 ]
                               }
@@ -5145,9 +5145,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 537,
+                                  "line": 539,
                                   "column": 0,
-                                  "character": 13960
+                                  "character": 13997
                                 }
                               ]
                             }
@@ -5234,9 +5234,9 @@
                                 "File",
                                 {
                                   "filename": "builtin.elpi",
-                                  "line": 537,
+                                  "line": 539,
                                   "column": 0,
-                                  "character": 13960
+                                  "character": 13997
                                 }
                               ]
                             }
@@ -5294,7 +5294,7 @@
                     "Inference",
                     {
                       "current_goal_id": 54,
-                      "current_goal_text": "pi c0 \\\n copy (uvar frozen--451 []) c0 =>\n  bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)",
+                      "current_goal_text": "pi c0 \\\n copy (uvar frozen--452 []) c0 =>\n  bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)",
                       "current_goal_predicate": "pi",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -5305,7 +5305,7 @@
                           },
                           "siblings": [
                             {
-                              "goal_text": "copy (uvar frozen--451 []) c0 =>\n bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)",
+                              "goal_text": "copy (uvar frozen--452 []) c0 =>\n bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)",
                               "goal_id": 60
                             }
                           ],
@@ -5369,7 +5369,7 @@
                     "Inference",
                     {
                       "current_goal_id": 60,
-                      "current_goal_text": "copy (uvar frozen--451 []) c0 =>\n bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)",
+                      "current_goal_text": "copy (uvar frozen--452 []) c0 =>\n bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)",
                       "current_goal_predicate": "=>",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -5382,7 +5382,7 @@
                           },
                           "siblings": [
                             {
-                              "goal_text": "bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)",
+                              "goal_text": "bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)",
                               "goal_id": 61
                             }
                           ],
@@ -5453,7 +5453,7 @@
                     "Inference",
                     {
                       "current_goal_id": 61,
-                      "current_goal_text": "bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)",
+                      "current_goal_text": "bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)",
                       "current_goal_predicate": "bind",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -5477,7 +5477,7 @@
                             "events": [
                               [
                                 "Assign",
-                                "A0 := uvar frozen--451 [] ===> uvar frozen--451 []"
+                                "A0 := uvar frozen--452 [] ===> uvar frozen--452 []"
                               ],
                               [ "Assign", "X13 := c0 \\\nX15 c0" ],
                               [ "Assign", "X15^1 := mono X16^1" ]
@@ -5485,7 +5485,7 @@
                           },
                           "siblings": [
                             {
-                              "goal_text": "copy (uvar frozen--451 [] ===> uvar frozen--451 []) X16^1",
+                              "goal_text": "copy (uvar frozen--452 [] ===> uvar frozen--452 []) X16^1",
                               "goal_id": 62
                             }
                           ],
@@ -5575,7 +5575,7 @@
                     "Inference",
                     {
                       "current_goal_id": 62,
-                      "current_goal_text": "copy (uvar frozen--451 [] ===> uvar frozen--451 []) X16^1",
+                      "current_goal_text": "copy (uvar frozen--452 [] ===> uvar frozen--452 []) X16^1",
                       "current_goal_predicate": "copy",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -5597,18 +5597,18 @@
                               }
                             ],
                             "events": [
-                              [ "Assign", "A0 := uvar frozen--451 []" ],
-                              [ "Assign", "A2 := uvar frozen--451 []" ],
+                              [ "Assign", "A0 := uvar frozen--452 []" ],
+                              [ "Assign", "A2 := uvar frozen--452 []" ],
                               [ "Assign", "X16^1 := X17^1 ===> X18^1" ]
                             ]
                           },
                           "siblings": [
                             {
-                              "goal_text": "copy (uvar frozen--451 []) X17^1",
+                              "goal_text": "copy (uvar frozen--452 []) X17^1",
                               "goal_id": 63
                             },
                             {
-                              "goal_text": "copy (uvar frozen--451 []) X18^1",
+                              "goal_text": "copy (uvar frozen--452 []) X18^1",
                               "goal_id": 64
                             }
                           ],
@@ -5717,7 +5717,7 @@
                     "Inference",
                     {
                       "current_goal_id": 63,
-                      "current_goal_text": "copy (uvar frozen--451 []) X17^1",
+                      "current_goal_text": "copy (uvar frozen--452 []) X17^1",
                       "current_goal_predicate": "copy",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -5726,7 +5726,7 @@
                             "rule": [
                               "UserRule",
                               {
-                                "rule_text": "(copy (uvar frozen--451 []) c0) :- .",
+                                "rule_text": "(copy (uvar frozen--452 []) c0) :- .",
                                 "rule_loc": [ "Context", 32 ]
                               }
                             ],
@@ -5742,7 +5742,7 @@
                           "rule": [
                             "UserRule",
                             {
-                              "rule_text": "(copy (uvar frozen--451 []) c0) :- .",
+                              "rule_text": "(copy (uvar frozen--452 []) c0) :- .",
                               "rule_loc": [ "Context", 32 ]
                             }
                           ],
@@ -5849,7 +5849,7 @@
                     "Inference",
                     {
                       "current_goal_id": 64,
-                      "current_goal_text": "copy (uvar frozen--451 []) X18^1",
+                      "current_goal_text": "copy (uvar frozen--452 []) X18^1",
                       "current_goal_predicate": "copy",
                       "failed_attempts": [],
                       "successful_attempts": [
@@ -5858,7 +5858,7 @@
                             "rule": [
                               "UserRule",
                               {
-                                "rule_text": "(copy (uvar frozen--451 []) c0) :- .",
+                                "rule_text": "(copy (uvar frozen--452 []) c0) :- .",
                                 "rule_loc": [ "Context", 32 ]
                               }
                             ],
@@ -5874,7 +5874,7 @@
                           "rule": [
                             "UserRule",
                             {
-                              "rule_text": "(copy (uvar frozen--451 []) c0) :- .",
+                              "rule_text": "(copy (uvar frozen--452 []) c0) :- .",
                               "rule_loc": [ "Context", 32 ]
                             }
                           ],

--- a/tests/sources/trace_w.json
+++ b/tests/sources/trace_w.json
@@ -133,136 +133,136 @@
 {"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:CHR:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 85, column 36, characters 2027-2199:","(theta A0) \\ (A1 ?- gammabar A2 A3) | (generalize A0 A1 A2 A4) <=> (A3 = A4)"]}
 {"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X0 := []"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X1 := mono (uvar frozen--451 [] ===> uvar frozen--451 [])"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A3 := uvar frozen--452 []"]}
+{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X1 := mono (uvar frozen--452 [] ===> uvar frozen--452 [])"]}
+{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A3 := uvar frozen--453 []"]}
 {"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X2 := []"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["generalize [] [] (mono (uvar frozen--451 [] ===> uvar frozen--451 [])) X3"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["generalize","generalize [] [] (mono (uvar frozen--451 [] ===> uvar frozen--451 [])) X3"]}
+{"step" : 0,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["generalize [] [] (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) X3"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["generalize","generalize [] [] (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) X3"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 97, column 0, characters 2346-2521:"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 97, column 0, characters 2346-2521:","(generalize A5 A2 (mono A0) A6) :- (free-ty (mono A0) [] A1), \n (free-gamma A2 [] A3), (filter A1 (c0 \\ (not (mem A3 c0))) A4), \n (bind A4 A5 A0 A6)."]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A5 := []"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := []"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--451 [] ===> uvar frozen--451 []"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A6 := X3"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["27"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free-ty (mono (uvar frozen--451 [] ===> uvar frozen--451 [])) [] X4"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free-ty (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) [] X4"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["28"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free-gamma [] [] X5"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["29"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["filter X4 (c0 \\ not (mem X5 c0)) X6"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["30"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["bind X6 [] (uvar frozen--451 [] ===> uvar frozen--451 []) X3"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["bind X6 [] (uvar frozen--452 [] ===> uvar frozen--452 []) X3"]}
 {"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free-ty","free-ty (mono (uvar frozen--451 [] ===> uvar frozen--451 [])) [] X4"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free-ty","free-ty (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) [] X4"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 105, column 0, characters 2637-2673:"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 105, column 0, characters 2637-2673:","(free-ty (mono A0) A1 A2) :- (free A0 A1 A2)."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--451 [] ===> uvar frozen--451 []"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := []"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := X4"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["31"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free (uvar frozen--451 [] ===> uvar frozen--451 []) [] X4"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free (uvar frozen--452 [] ===> uvar frozen--452 []) [] X4"]}
 {"step" : 2,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--451 [] ===> uvar frozen--451 []) [] X4"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--452 [] ===> uvar frozen--452 []) [] X4"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 117, column 0, characters 3023-3072:"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 117, column 0, characters 3023-3072:","(free (A0 ===> A3) A1 A4) :- (free A0 A1 A2), (free A3 A2 A4)."]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--451 []"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A3 := uvar frozen--451 []"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 []"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A3 := uvar frozen--452 []"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := []"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A4 := X4"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["32"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free (uvar frozen--451 []) [] X7"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free (uvar frozen--452 []) [] X7"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["33"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free (uvar frozen--451 []) X7 X4"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free (uvar frozen--452 []) X7 X4"]}
 {"step" : 3,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--451 []) [] X7"]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--452 []) [] X7"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:","(free (as (uvar _ _) A1) A0 A2) :- (if (mem A0 A1) (A2 = A0) (A2 = [A1 | A0]))."]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--451 []"]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--452 []"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := X7"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["34"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["if (mem [] (uvar frozen--451 [])) (X7 = []) (X7 = [uvar frozen--451 []])"]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])"]}
 {"step" : 4,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--451 [])) (X7 = []) (X7 = [uvar frozen--451 []])"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","File \"builtin.elpi\", line 537, column 0, characters 13960-13973:"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","(if A0 A1 _) :- A0, !, A1."]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--451 [])"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 538, column 0, characters 13976-13995:","File \"builtin.elpi\", line 539, column 0, characters 13997-14010:"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 538, column 0, characters 13976-13995:","(if A0 A1 _) :- A0, !, A1."]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--452 [])"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X7 = []"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["35"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [] (uvar frozen--451 [])"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [] (uvar frozen--452 [])"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["36"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 36,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["37"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 37,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X7 = []"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--451 [])"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--452 [])"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--451"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--452"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["38"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [] (uvar frozen--451 X8)"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [] (uvar frozen--452 X8)"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [] (uvar frozen--451 X8)"]}
+{"step" : 7,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [] (uvar frozen--452 X8)"]}
 {"step" : 7,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 7,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : []}
 {"step" : 7,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--451 [])) (X7 = []) (X7 = [uvar frozen--451 []])"]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13960-13973:"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13960-13973:","(if _ _ A0) :- A0."]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := X7 = [uvar frozen--451 []]"]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 539, column 0, characters 13997-14010:"]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 539, column 0, characters 13997-14010:","(if _ _ A0) :- A0."]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := X7 = [uvar frozen--452 []]"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["39"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X7 = [uvar frozen--451 []]"]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X7 = [uvar frozen--452 []]"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=","X7 = [uvar frozen--451 []]"]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=","X7 = [uvar frozen--452 []]"]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:rule","payload" : ["eq"]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:rule:builtin:name","payload" : ["="]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X7 := [uvar frozen--451 []]"]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X7 := [uvar frozen--452 []]"]}
 {"step" : 9,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:rule:eq","payload" : ["success"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--451 []) [uvar frozen--451 []] X4"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--452 []) [uvar frozen--452 []] X4"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:","(free (as (uvar _ _) A1) A0 A2) :- (if (mem A0 A1) (A2 = A0) (A2 = [A1 | A0]))."]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--451 []"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := [uvar frozen--451 []]"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--452 []"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := [uvar frozen--452 []]"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := X4"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["40"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["if (mem [uvar frozen--451 []] (uvar frozen--451 [])) \n (X4 = [uvar frozen--451 []]) \n (X4 = [uvar frozen--451 [], uvar frozen--451 []])"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["if (mem [uvar frozen--452 []] (uvar frozen--452 [])) \n (X4 = [uvar frozen--452 []]) \n (X4 = [uvar frozen--452 [], uvar frozen--452 []])"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [uvar frozen--451 []] (uvar frozen--451 [])) \n (X4 = [uvar frozen--451 []]) \n (X4 = [uvar frozen--451 [], uvar frozen--451 []])"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [uvar frozen--452 []] (uvar frozen--452 [])) \n (X4 = [uvar frozen--452 []]) \n (X4 = [uvar frozen--452 [], uvar frozen--452 []])"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","File \"builtin.elpi\", line 537, column 0, characters 13960-13973:"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","(if A0 A1 _) :- A0, !, A1."]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [uvar frozen--451 []] (uvar frozen--451 [])"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X4 = [uvar frozen--451 []]"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 538, column 0, characters 13976-13995:","File \"builtin.elpi\", line 539, column 0, characters 13997-14010:"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 538, column 0, characters 13976-13995:","(if A0 A1 _) :- A0, !, A1."]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [uvar frozen--452 []] (uvar frozen--452 [])"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X4 = [uvar frozen--452 []]"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["41"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [uvar frozen--451 []] (uvar frozen--451 [])"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [uvar frozen--452 []] (uvar frozen--452 [])"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["42"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["43"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X4 = [uvar frozen--451 []]"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X4 = [uvar frozen--452 []]"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [uvar frozen--451 []] (uvar frozen--451 [])"]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [uvar frozen--452 []] (uvar frozen--452 [])"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := [uvar frozen--451 []]"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--451"]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := [uvar frozen--452 []]"]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--452"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["44"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [uvar frozen--451 []] (uvar frozen--451 X9)"]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [uvar frozen--452 []] (uvar frozen--452 X9)"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [uvar frozen--451 []] (uvar frozen--451 X9)"]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [uvar frozen--452 []] (uvar frozen--452 X9)"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 143, column 0, characters 3903-3920:","File \"tests/sources/trace-w/main.elpi\", line 144, column 0, characters 3922-3948:"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 143, column 0, characters 3903-3920:","(mem! [A0 | _] A0) :- !."]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--451 []"]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 []"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X9 := []"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["45"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
@@ -273,12 +273,12 @@
 {"step" : 14,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:rule:cut","payload" : ["success"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["!","!"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["40","File \"builtin.elpi\", line 537, column 0, characters 13960-13973:","(if _ _ A0) :- A0."]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["40","File \"builtin.elpi\", line 539, column 0, characters 13997-14010:","(if _ _ A0) :- A0."]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:rule:cut","payload" : ["success"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=","X4 = [uvar frozen--451 []]"]}
+{"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=","X4 = [uvar frozen--452 []]"]}
 {"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:rule","payload" : ["eq"]}
 {"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:rule:builtin:name","payload" : ["="]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X4 := [uvar frozen--451 []]"]}
+{"step" : 16,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X4 := [uvar frozen--452 []]"]}
 {"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:rule:eq","payload" : ["success"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free-gamma","free-gamma [] [] X5"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
@@ -287,50 +287,50 @@
 {"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X5 := []"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["filter","filter [uvar frozen--451 []] (c0 \\ not (mem [] c0)) X6"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["filter","filter [uvar frozen--452 []] (c0 \\ not (mem [] c0)) X6"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 139, column 0, characters 3789-3837:","File \"tests/sources/trace-w/main.elpi\", line 140, column 0, characters 3839-3875:"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 139, column 0, characters 3789-3837:","(filter [A0 | A2] A1 [A0 | A3]) :- (A1 A0), !, (filter A2 A1 A3)."]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--451 []"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 []"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := []"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := c0 \\\nnot (mem [] c0)"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X6 := [uvar frozen--451 [] | X10]"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X6 := [uvar frozen--452 [] | X10]"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["46"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["not (mem [] (uvar frozen--451 []))"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["not (mem [] (uvar frozen--452 []))"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["47"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 47,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["48"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["filter [] (c0 \\ not (mem [] c0)) X10"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["not","not (mem [] (uvar frozen--451 []))"]}
+{"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["not","not (mem [] (uvar frozen--452 []))"]}
 {"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","(not A0) :- A0, !, fail."]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--451 [])"]}
+{"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1226-1245:","File \"builtin.elpi\", line 73, column 0, characters 1248-1253:"]}
+{"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1226-1245:","(not A0) :- A0, !, fail."]}
+{"step" : 19,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--452 [])"]}
 {"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["49"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [] (uvar frozen--451 [])"]}
+{"step" : 19,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [] (uvar frozen--452 [])"]}
 {"step" : 19,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["50"]}
 {"step" : 19,"kind" : ["Info"],"goal_id" : 50,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
 {"step" : 19,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["51"]}
 {"step" : 19,"kind" : ["Info"],"goal_id" : 51,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["fail"]}
 {"step" : 19,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--451 [])"]}
+{"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--452 [])"]}
 {"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
 {"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
 {"step" : 20,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--451"]}
+{"step" : 20,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--452"]}
 {"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["52"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [] (uvar frozen--451 X11)"]}
+{"step" : 20,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [] (uvar frozen--452 X11)"]}
 {"step" : 20,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [] (uvar frozen--451 X11)"]}
+{"step" : 21,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [] (uvar frozen--452 X11)"]}
 {"step" : 21,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 21,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : []}
 {"step" : 21,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["not","not (mem [] (uvar frozen--451 []))"]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["not","not (mem [] (uvar frozen--452 []))"]}
 {"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:","(not _) :- ."]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 73, column 0, characters 1248-1253:"]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 73, column 0, characters 1248-1253:","(not _) :- ."]}
 {"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 23,"kind" : ["Info"],"goal_id" : 47,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["!","!"]}
 {"step" : 23,"kind" : ["Info"],"goal_id" : 47,"runtime_id" : 1,"name" : "user:rule","payload" : ["cut"]}
@@ -342,50 +342,50 @@
 {"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 138, column 0, characters 3773-3787:","(filter [] _ []) :- ."]}
 {"step" : 24,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X10 := []"]}
 {"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["bind","bind [uvar frozen--451 []] [] (uvar frozen--451 [] ===> uvar frozen--451 []) \n X3"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["bind","bind [uvar frozen--452 []] [] (uvar frozen--452 [] ===> uvar frozen--452 []) \n X3"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 123, column 0, characters 3297-3418:"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 123, column 0, characters 3297-3418:","(bind [A1 | A3] A0 A4 (all A2 (c0 \\ (A5 c0)))) :- (if (mem A0 A1) (A2 = eqt) \n                                                    (A2 = any)), \n (pi c0 \\ (copy A1 c0 => bind A3 A0 A4 (A5 c0)))."]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--451 []"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--452 []"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A3 := []"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A4 := uvar frozen--451 [] ===> uvar frozen--451 []"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A4 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X3 := all X12 c0 \\ X13 c0"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["53"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["if (mem [] (uvar frozen--451 [])) (X12 = eqt) (X12 = any)"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["54"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 54,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["pi c0 \\\n copy (uvar frozen--451 []) c0 =>\n  bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 54,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["pi c0 \\\n copy (uvar frozen--452 []) c0 =>\n  bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
 {"step" : 25,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--451 [])) (X12 = eqt) (X12 = any)"]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","File \"builtin.elpi\", line 537, column 0, characters 13960-13973:"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","(if A0 A1 _) :- A0, !, A1."]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--451 [])"]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 538, column 0, characters 13976-13995:","File \"builtin.elpi\", line 539, column 0, characters 13997-14010:"]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 538, column 0, characters 13976-13995:","(if A0 A1 _) :- A0, !, A1."]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--452 [])"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X12 = eqt"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["55"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [] (uvar frozen--451 [])"]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [] (uvar frozen--452 [])"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["56"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 56,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["57"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 57,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X12 = eqt"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--451 [])"]}
+{"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--452 [])"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--451"]}
+{"step" : 27,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--452"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["58"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [] (uvar frozen--451 X14)"]}
+{"step" : 27,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [] (uvar frozen--452 X14)"]}
 {"step" : 27,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [] (uvar frozen--451 X14)"]}
+{"step" : 28,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [] (uvar frozen--452 X14)"]}
 {"step" : 28,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 28,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : []}
 {"step" : 28,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--451 [])) (X12 = eqt) (X12 = any)"]}
+{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)"]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13960-13973:"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13960-13973:","(if _ _ A0) :- A0."]}
+{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 539, column 0, characters 13997-14010:"]}
+{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 539, column 0, characters 13997-14010:","(if _ _ A0) :- A0."]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := X12 = any"]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["59"]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 59,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X12 = any"]}
@@ -395,48 +395,48 @@
 {"step" : 30,"kind" : ["Info"],"goal_id" : 59,"runtime_id" : 1,"name" : "user:rule:builtin:name","payload" : ["="]}
 {"step" : 30,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X12 := any"]}
 {"step" : 30,"kind" : ["Info"],"goal_id" : 59,"runtime_id" : 1,"name" : "user:rule:eq","payload" : ["success"]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 54,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["pi","pi c0 \\\n copy (uvar frozen--451 []) c0 =>\n  bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)"]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 54,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["pi","pi c0 \\\n copy (uvar frozen--452 []) c0 =>\n  bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 54,"runtime_id" : 1,"name" : "user:rule","payload" : ["pi"]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 54,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["60"]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--451 []) c0 =>\n bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)"]}
+{"step" : 31,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--452 []) c0 =>\n bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
 {"step" : 31,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:rule:pi","payload" : ["success"]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=>","copy (uvar frozen--451 []) c0 =>\n bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)"]}
+{"step" : 32,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=>","copy (uvar frozen--452 []) c0 =>\n bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
 {"step" : 32,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:rule","payload" : ["implication"]}
 {"step" : 32,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["61"]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)"]}
+{"step" : 32,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
 {"step" : 32,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["bind","bind [] [] (uvar frozen--451 [] ===> uvar frozen--451 []) (X13 c0)"]}
+{"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["bind","bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, characters 3261-3295:"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, characters 3261-3295:","(bind [] _ A0 (mono A1)) :- (copy A0 A1)."]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--451 [] ===> uvar frozen--451 []"]}
+{"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign:simplify:heap","payload" : ["X13 := c0 \\\nX15 c0"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X15^1 := mono X16^1"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["62"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--451 [] ===> uvar frozen--451 []) X16^1"]}
+{"step" : 33,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--452 [] ===> uvar frozen--452 []) X16^1"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--451 [] ===> uvar frozen--451 []) X16^1"]}
+{"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--452 [] ===> uvar frozen--452 []) X16^1"]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 130, column 0, characters 3475-3527:"]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 130, column 0, characters 3475-3527:","(copy (A0 ===> A2) (A1 ===> A3)) :- (copy A0 A1), (copy A2 A3)."]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--451 []"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := uvar frozen--451 []"]}
+{"step" : 34,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 []"]}
+{"step" : 34,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := uvar frozen--452 []"]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X16^1 := X17^1 ===> X18^1"]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["63"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--451 []) X17^1"]}
+{"step" : 34,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--452 []) X17^1"]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["64"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--451 []) X18^1"]}
+{"step" : 34,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--452 []) X18^1"]}
 {"step" : 34,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--451 []) X17^1"]}
+{"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--452 []) X17^1"]}
 {"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/main.elpi\", line 133, column 0, characters 3621-3647:"]}
-{"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","(copy (uvar frozen--451 []) c0) :- ."]}
+{"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","(copy (uvar frozen--452 []) c0) :- ."]}
 {"step" : 35,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X17^1 := c0"]}
 {"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--451 []) X18^1"]}
+{"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--452 []) X18^1"]}
 {"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
 {"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/main.elpi\", line 133, column 0, characters 3621-3647:"]}
-{"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","(copy (uvar frozen--451 []) c0) :- ."]}
+{"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","(copy (uvar frozen--452 []) c0) :- ."]}
 {"step" : 36,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X18^1 := c0"]}
 {"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["65"]}

--- a/tests/suite/correctness_FO.ml
+++ b/tests/suite/correctness_FO.ml
@@ -222,6 +222,11 @@ let () = declare "trie"
   ~description:"discrimination_tree on trees"
   ()
 
+let () = declare "qname"
+  ~source_elpi:"qname.elpi"
+  ~description:"discrimination_tree with qname"
+  ()
+
 let () =
   let (!) x = Test.FailureOutput (Str.regexp x) in
   let mut_excl l1 l2 = !(Format.asprintf "line %d.*\n.*\n.*\n.*\n+.*line %d" l1 l2) in
@@ -256,7 +261,8 @@ let () =
       (*101*) Success; mut_excl_eigen 5 "f";  duplicate_err 2 1; Success; Success;(*105*)
       (*106*) Success; constr_error 14 13; constr_error 14 13; mut_excl_eigen 9 "f"; Success; (*110*)
       (*111*) mut_excl_eigen 5 "foo"; Success; mut_excl_no_loc "f"; Success; det_check 5 19;
-      (*116*) Success; det_check 5 2; det_check 7 2; Success
+      (*116*) Success; det_check 5 2; det_check 7 2; Success; Success; (*120*)
+      (*121*) mut_excl_eigen 9 "copy"; mut_excl 9 7; mut_excl_eigen 8 "copy"
     |] in
   for i = 0 to Array.length status - 1 do
     let name = Printf.sprintf "functionality/test%d.elpi" (i+1) in


### PR DESCRIPTION
the goal is to extend the syntax with a qname keyword
this keyword works similarly to uvar during matching
the idea is shortcut:
`p X :- name X` into `p (qname X)`
this also gives benefit to mutual exclusion checker: 
qname is different from any other rigid constructors
- [ ] fix all 3 indexes with qname
- [ ] fix mut-excl checker
- [ ] in rocq-elpi refactor copy, fold-map etc..
- [ ] check is_eigen_variable