### PR TITLE
Add information about clauses to implication cards

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# UNRELEASED
+
+- Trace:
+  - Add information about added clauses to Implication cards
+
 # v3.7.2 (July 2026)
 
 Requires Menhir 20211230 and OCaml 4.14 or above on Linux, Windows and

--- a/src/elpi_trace_elaborator.ml
+++ b/src/elpi_trace_elaborator.ml
@@ -297,9 +297,20 @@ let gstacks : frame list GoalMap.t ref = ref GoalMap.empty (* goal_id -> stack *
 let fstacks : frame list StepMap.t ref = ref StepMap.empty (* step_id -> stack *)
 
 let push_stack (step,rid) goal_id rule siblings =
-  let this_stack = try GoalMap.find goal_id !gstacks with Not_found -> [] in
+  (* If a step pushes multiple frames, such as an implication with
+     multiple clauses on the LHS, then a stack for this step already
+     exists; we need to make sure to properly push to it, instead of
+     overriding *)
+  let this_stack =
+    try StepMap.find (step,rid) !fstacks
+    with Not_found ->
+      try GoalMap.find goal_id !gstacks
+      with Not_found -> [] in
   let stack = { rule; step_id = step; runtime_id = rid } :: this_stack in
   fstacks := StepMap.add (step,rid) stack !fstacks;
+  (* We assume that a step pushes all its frames before we start
+     processing siblings, so we can safely override the siblings'
+     stacks *)
   List.iter (fun g -> gstacks := GoalMap.add g stack !gstacks) siblings
 
 let update_stack (step,rid) goal_id rule =
@@ -382,6 +393,20 @@ try
           assert(List.length events = 1);
           let _, events = List.hd events in
           Builtin { name; outcome; events = List.map decode_infer_event events  }
+        else if name = "implication" then
+          let new_hyps = match has "user:new-hyps" items with
+            | Some ({ payload = hyps },_) -> hyps
+            (* Backwards compatibility: treat a missing new-hyps item
+               as empty, which renders as before *)
+            | _ -> [] in
+          let () = new_hyps |> List.iter (fun hyp ->
+            push_stack (step,rid) goal_id (`BuiltinRule (`Logic (name ^ "\n" ^ hyp))) siblings
+          ) in
+          let name = `Logic name in
+          (* Every step needs to push a stack, even a degenerate ([] => P) *)
+          if new_hyps = [] then
+            push_stack (step,rid) goal_id (`BuiltinRule name) siblings;
+          Builtin { name; outcome; events = [] }
         else
           let name = `Logic name in
           let () = push_stack (step,rid) goal_id (`BuiltinRule name) siblings in

--- a/src/elpi_trace_elaborator.ml
+++ b/src/elpi_trace_elaborator.ml
@@ -71,7 +71,7 @@ module Elaborate : sig
     type chr_attempt = { loc : location; code: string; events : event list; timestamp : timestamp; removed : goal_id list; resumed : goal_id list;  }
     
     type action =
-      | Builtin of { name : builtin_name; outcome : step_outcode; events : event list }
+      | Builtin of { name : builtin_rule; outcome : step_outcode; events : event list }
       | Backchain of { trylist : attempt list; outcome : step_outcode }
     
     type step =
@@ -117,7 +117,7 @@ end = struct
     type chr_attempt = { loc : location; code: string; events : event list; timestamp : timestamp; removed : goal_id list; resumed : goal_id list;  }
     
     type action =
-      | Builtin of { name : builtin_name; outcome : step_outcode; events : event list }
+      | Builtin of { name : builtin_rule; outcome : step_outcode; events : event list }
       | Backchain of { trylist : attempt list; outcome : step_outcode }
     
     type step =
@@ -288,10 +288,10 @@ let decode_cut = function
   | { payload = [g;r;t] }, _ -> int_of_string g, decode_loc r, t
   | _ -> assert false
 
-let get_builtin_name l : builtin_name =
+let get_builtin_name l : builtin_rule =
   match has "user:rule:builtin:name" l with
   | None -> assert false
-  | Some x -> `FFI (decode_string x)
+  | Some x -> { kind = `FFI; name = decode_string x; payload = [] }
 
 let gstacks : frame list GoalMap.t ref = ref GoalMap.empty (* goal_id -> stack *)
 let fstacks : frame list StepMap.t ref = ref StepMap.empty (* step_id -> stack *)
@@ -336,7 +336,7 @@ try
   timestamp,match decode_step items with
   | `Findall (({ goal_id; payload = [pred;goal] },_),start) ->
       let result = all "user:assign" decode_string items in
-      let () = push_stack (step,rid) goal_id (`BuiltinRule (`FFI "findall")) [] in
+      let () = push_stack (step,rid) goal_id (`BuiltinRule ({ kind = `FFI; name = "findall"; payload = [] })) [] in
       let stop =
         match has "user:assign" items with
         | None -> assert false
@@ -345,15 +345,15 @@ try
   | `Suspend ({ goal_id; payload = [pred;goal] },_) ->
        let sibling = all "user:subgoal" decode_int items in
        assert(List.length sibling = 1);
-       let () = push_stack (step,rid) goal_id (`BuiltinRule (`Logic "suspend")) sibling in
+       let () = push_stack (step,rid) goal_id (`BuiltinRule ({ kind = `Logic; name = "suspend"; payload = [] })) sibling in
        Suspend {goal_id;goal;sibling = List.hd sibling} 
   | `Cut ({ goal_id; payload = [pred;goal] },_) ->
-      let () = push_stack (step,rid) goal_id (`BuiltinRule (`FFI "!")) [] in
+      let () = push_stack (step,rid) goal_id (`BuiltinRule ({ kind = `FFI; name = "!"; payload = []})) [] in
       let cutted = all "user:rule:cut:branch" decode_cut items in
       Cut (goal_id,cutted)
   | `Resumption l ->
       let resumed = List.map (fun ({ goal_id; payload },_ as x) ->
-        let () = update_stack (step,rid) goal_id (`BuiltinRule (`Logic "resume")) in
+        let () = update_stack (step,rid) goal_id (`BuiltinRule ({ kind = `Logic; name = "resume"; payload = [] })) in
         goal_id, decode_string x) l in
       Resume resumed
   | `CHR(chr_store_before,chr_store_after) ->
@@ -399,16 +399,16 @@ try
             (* Backwards compatibility: treat a missing new-hyps item
                as empty, which renders as before *)
             | _ -> [] in
-          let () = new_hyps |> List.iter (fun hyp ->
-            push_stack (step,rid) goal_id (`BuiltinRule (`Logic (name ^ "\n" ^ hyp))) siblings
-          ) in
-          let name = `Logic name in
+          let () =
+            push_stack (step,rid) goal_id (`BuiltinRule ({ kind = `Logic; name = name; payload = new_hyps })) siblings
+          in
+          let name = { kind = `Logic; name = name; payload = [] } in
           (* Every step needs to push a stack, even a degenerate ([] => P) *)
           if new_hyps = [] then
             push_stack (step,rid) goal_id (`BuiltinRule name) siblings;
           Builtin { name; outcome; events = [] }
         else
-          let name = `Logic name in
+          let name = { kind = `Logic; name = name; payload = [] } in
           let () = push_stack (step,rid) goal_id (`BuiltinRule name) siblings in
           let events = all_infer_event_chains "user:rule:builtin:name" items in (* ??? *)
           let events =

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -4109,6 +4109,8 @@ let make_runtime : ?max_steps: int -> ?delay_outside_fragment: bool -> executabl
        let clauses, pdiff, lcs = clausify ~tail_cut:(ik = ImplBang) ~loc p ~depth g1 in
        let g2 = hmove ~from:depth ~to_:(depth+lcs) g2 in
        let gid[@trace] = make_subgoal_id gid ((depth,g2)[@trace]) in
+       (* clausify returns the clauses right-to-left, but we want to report them left-to-right *)
+       [%spyl "user:new-hyps" ~rid ~gid (fun f (hd,c) -> ppclause f ~hd c) (List.rev clauses)];
        [%spy "user:rule:implication" ~rid ~gid pp_string "success"];
        [%tcall run (depth+lcs) (add_clauses ~depth clauses pdiff p) g2 (gid[@trace]) gs next alts cutto_alts]
     | Builtin(Pi, [arg]) -> [%spy "user:rule" ~rid ~gid pp_string "pi"];

--- a/src/trace.atd
+++ b/src/trace.atd
@@ -64,9 +64,10 @@ type attempt = {
   rule : rule;
   events : event list;
 }
-type rule = [ BuiltinRule of builtin_name | UserRule of user_rule ]
+type rule = [ BuiltinRule of builtin_rule | UserRule of user_rule ]
 type user_rule = { rule_text : rule_text; rule_loc : location }
-type builtin_name = [ Logic of string | FFI of string ]
+type builtin_kind = [ Logic | FFI ]
+type builtin_rule = { name : string; kind : builtin_kind; payload : string list }
 type location = [ File of file_location | Context of step_id ]
 type file_location = { filename : string; line : int; column : int; character : int }
 type event = [ Assign of string | Fail of string | ResumeGoal of goal_id list]

--- a/src/trace_atd.ts
+++ b/src/trace_atd.ts
@@ -77,7 +77,7 @@ export type Attempt = {
 }
 
 export type Rule =
-| { kind: 'BuiltinRule'; value: BuiltinName }
+| { kind: 'BuiltinRule'; value: BuiltinRule }
 | { kind: 'UserRule'; value: UserRule }
 
 export type UserRule = {
@@ -85,9 +85,15 @@ export type UserRule = {
   rule_loc: Location;
 }
 
-export type BuiltinName =
-| { kind: 'Logic'; value: string }
-| { kind: 'FFI'; value: string }
+export type BuiltinKind =
+| { kind: 'Logic' }
+| { kind: 'FFI' }
+
+export type BuiltinRule = {
+  name: string;
+  kind: BuiltinKind;
+  payload: string[];
+}
 
 export type Location =
 | { kind: 'File'; value: FileLocation }
@@ -411,7 +417,7 @@ export function readAttempt(x: any, context: any = x): Attempt {
 export function writeRule(x: Rule, context: any = x): any {
   switch (x.kind) {
     case 'BuiltinRule':
-      return ['BuiltinRule', writeBuiltinName(x.value, x)]
+      return ['BuiltinRule', writeBuiltinRule(x.value, x)]
     case 'UserRule':
       return ['UserRule', writeUserRule(x.value, x)]
   }
@@ -421,7 +427,7 @@ export function readRule(x: any, context: any = x): Rule {
   _atd_check_json_tuple(2, x, context)
   switch (x[0]) {
     case 'BuiltinRule':
-      return { kind: 'BuiltinRule', value: readBuiltinName(x[1], x) }
+      return { kind: 'BuiltinRule', value: readBuiltinRule(x[1], x) }
     case 'UserRule':
       return { kind: 'UserRule', value: readUserRule(x[1], x) }
     default:
@@ -444,26 +450,41 @@ export function readUserRule(x: any, context: any = x): UserRule {
   };
 }
 
-export function writeBuiltinName(x: BuiltinName, context: any = x): any {
+export function writeBuiltinKind(x: BuiltinKind, context: any = x): any {
   switch (x.kind) {
     case 'Logic':
-      return ['Logic', _atd_write_string(x.value, x)]
+      return 'Logic'
     case 'FFI':
-      return ['FFI', _atd_write_string(x.value, x)]
+      return 'FFI'
   }
 }
 
-export function readBuiltinName(x: any, context: any = x): BuiltinName {
-  _atd_check_json_tuple(2, x, context)
-  switch (x[0]) {
+export function readBuiltinKind(x: any, context: any = x): BuiltinKind {
+  switch (x) {
     case 'Logic':
-      return { kind: 'Logic', value: _atd_read_string(x[1], x) }
+      return { kind: 'Logic' }
     case 'FFI':
-      return { kind: 'FFI', value: _atd_read_string(x[1], x) }
+      return { kind: 'FFI' }
     default:
-      _atd_bad_json('BuiltinName', x, context)
+      _atd_bad_json('BuiltinKind', x, context)
       throw new Error('impossible')
   }
+}
+
+export function writeBuiltinRule(x: BuiltinRule, context: any = x): any {
+  return {
+    'name': _atd_write_required_field('BuiltinRule', 'name', _atd_write_string, x.name, x),
+    'kind': _atd_write_required_field('BuiltinRule', 'kind', writeBuiltinKind, x.kind, x),
+    'payload': _atd_write_required_field('BuiltinRule', 'payload', _atd_write_array(_atd_write_string), x.payload, x),
+  };
+}
+
+export function readBuiltinRule(x: any, context: any = x): BuiltinRule {
+  return {
+    name: _atd_read_required_field('BuiltinRule', 'name', _atd_read_string, x['name'], x),
+    kind: _atd_read_required_field('BuiltinRule', 'kind', readBuiltinKind, x['kind'], x),
+    payload: _atd_read_required_field('BuiltinRule', 'payload', _atd_read_array(_atd_read_string), x['payload'], x),
+  };
 }
 
 export function writeLocation(x: Location, context: any = x): any {

--- a/tests/sources/trace.elab.json
+++ b/tests/sources/trace.elab.json
@@ -374,7 +374,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "FFI", "calc" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "calc", "kind": "FFI", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "1 = 5", "goal_id": 9 } ],
@@ -384,7 +387,9 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "FFI", "calc" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "calc", "kind": "FFI", "payload": [] }
+            ],
             "step_id": 5,
             "runtime_id": 0
           },
@@ -480,7 +485,9 @@
         "current_goal_predicate": "=",
         "failed_attempts": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "eq", "kind": "Logic", "payload": [] }
+            ],
             "events": [ [ "Fail", "unify 1 with 5" ] ]
           }
         ],
@@ -488,12 +495,16 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "eq", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 6,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "FFI", "calc" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "calc", "kind": "FFI", "payload": [] }
+            ],
             "step_id": 5,
             "runtime_id": 0
           },
@@ -693,7 +704,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "eq", "kind": "Logic", "payload": [] }
+              ],
               "events": [ [ "Assign", "X2 := 1" ] ]
             },
             "siblings": [],
@@ -703,7 +717,9 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "eq", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 8,
             "runtime_id": 0
           },
@@ -782,7 +798,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "eq", "kind": "Logic", "payload": [] }
+              ],
               "events": [ [ "Assign", "X3 := 2" ] ]
             },
             "siblings": [],
@@ -792,7 +811,9 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "eq", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 9,
             "runtime_id": 0
           },
@@ -869,7 +890,9 @@
         "current_goal_predicate": "=",
         "failed_attempts": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "eq", "kind": "Logic", "payload": [] }
+            ],
             "events": [ [ "Fail", "unify 1 with 2" ] ]
           }
         ],
@@ -877,7 +900,9 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "eq", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 10,
             "runtime_id": 0
           },

--- a/tests/sources/trace2.elab.json
+++ b/tests/sources/trace2.elab.json
@@ -259,7 +259,7 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nfail :- ." ] ],
             "step_id": 5,
             "runtime_id": 0
           },
@@ -328,7 +328,7 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nfail :- ." ] ],
             "step_id": 5,
             "runtime_id": 0
           },
@@ -427,7 +427,7 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nfail :- ." ] ],
             "step_id": 5,
             "runtime_id": 0
           },
@@ -504,7 +504,7 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nfail :- ." ] ],
             "step_id": 5,
             "runtime_id": 0
           },

--- a/tests/sources/trace2.elab.json
+++ b/tests/sources/trace2.elab.json
@@ -84,7 +84,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "FFI", "print" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "print", "kind": "FFI", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [],
@@ -94,7 +97,10 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "FFI", "print" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "print", "kind": "FFI", "payload": [] }
+            ],
             "step_id": 2,
             "runtime_id": 0
           },
@@ -135,7 +141,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "pi", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [
@@ -150,7 +159,9 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -191,7 +202,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "sigma" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "sigma", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [
@@ -203,12 +217,17 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "sigma" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "sigma", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 4,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -249,7 +268,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "true , fail", "goal_id": 9 } ],
@@ -259,17 +281,29 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nfail :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "fail :- ." ]
+              }
+            ],
             "step_id": 5,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "sigma" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "sigma", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 4,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -310,7 +344,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "and" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "and", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [
@@ -323,22 +360,37 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "and" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "and", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 6,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nfail :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "fail :- ." ]
+              }
+            ],
             "step_id": 5,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "sigma" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "sigma", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 4,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -422,22 +474,37 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "and" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "and", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 6,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nfail :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "fail :- ." ]
+              }
+            ],
             "step_id": 5,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "sigma" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "sigma", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 4,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -499,22 +566,37 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "and" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "and", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 6,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nfail :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "fail :- ." ]
+              }
+            ],
             "step_id": 5,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "sigma" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "sigma", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 4,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },

--- a/tests/sources/trace2.json
+++ b/tests/sources/trace2.json
@@ -26,6 +26,7 @@
 {"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["9"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["true , fail"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["fail :- ."]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:curgoal","payload" : [",","true , fail"]}
 {"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule","payload" : ["and"]}

--- a/tests/sources/trace_chr.elab.json
+++ b/tests/sources/trace_chr.elab.json
@@ -165,7 +165,10 @@
         "suspend_sibling": { "goal_text": "even X0", "goal_id": 10 },
         "suspend_stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "suspend" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "suspend", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -223,7 +226,10 @@
         "suspend_sibling": { "goal_text": "true", "goal_id": 11 },
         "suspend_stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "suspend" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "suspend", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 4,
             "runtime_id": 0
           },
@@ -264,7 +270,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "eq", "kind": "Logic", "payload": [] }
+              ],
               "events": [
                 [ "Assign", "X0 := s X1" ], [ "ResumeGoal", [ 11, 10 ] ]
               ]
@@ -276,7 +285,9 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "eq", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 5,
             "runtime_id": 0
           },
@@ -372,12 +383,18 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "resume" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "resume", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 6,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "suspend" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "suspend", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 4,
             "runtime_id": 0
           },
@@ -461,12 +478,18 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "resume" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "resume", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 6,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "suspend" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "suspend", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -593,12 +616,18 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "resume" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "resume", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 6,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "suspend" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "suspend", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -656,7 +685,10 @@
         "suspend_sibling": { "goal_text": "odd X1", "goal_id": 14 },
         "suspend_stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "suspend" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "suspend", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 10,
             "runtime_id": 0
           },
@@ -699,12 +731,18 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "resume" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "resume", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 6,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "suspend" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "suspend", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -948,7 +986,10 @@
         "suspend_sibling": { "goal_text": "even X1", "goal_id": 19 },
         "suspend_stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "suspend" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "suspend", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 13,
             "runtime_id": 0
           },
@@ -1244,7 +1285,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "fail", "goal_id": 24 } ],
@@ -1254,7 +1298,18 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
+            "step_id": 15,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 15,
             "runtime_id": 0
           }
@@ -1277,7 +1332,18 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
+            "step_id": 15,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 15,
             "runtime_id": 0
           }

--- a/tests/sources/trace_chr.json
+++ b/tests/sources/trace_chr.json
@@ -130,6 +130,7 @@
 {"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["24"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["fail"]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:new-hyps","payload" : []}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
 {"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["fail","fail"]}
 {"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}

--- a/tests/sources/trace_cut.elab.json
+++ b/tests/sources/trace_cut.elab.json
@@ -575,7 +575,7 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nq :- ." ] ],
             "step_id": 10,
             "runtime_id": 0
           },
@@ -626,12 +626,12 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nq :- !." ] ],
             "step_id": 11,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nq :- ." ] ],
             "step_id": 10,
             "runtime_id": 0
           },
@@ -693,12 +693,12 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nq :- !." ] ],
             "step_id": 11,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nq :- ." ] ],
             "step_id": 10,
             "runtime_id": 0
           },

--- a/tests/sources/trace_cut.elab.json
+++ b/tests/sources/trace_cut.elab.json
@@ -565,7 +565,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "(q :- !) => q", "goal_id": 12 } ],
@@ -575,7 +578,14 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nq :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "q :- ." ]
+              }
+            ],
             "step_id": 10,
             "runtime_id": 0
           },
@@ -616,7 +626,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "q", "goal_id": 13 } ],
@@ -626,12 +639,26 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nq :- !." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "q :- !." ]
+              }
+            ],
             "step_id": 11,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nq :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "q :- ." ]
+              }
+            ],
             "step_id": 10,
             "runtime_id": 0
           },
@@ -693,12 +720,26 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nq :- !." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "q :- !." ]
+              }
+            ],
             "step_id": 11,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nq :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "q :- ." ]
+              }
+            ],
             "step_id": 10,
             "runtime_id": 0
           },

--- a/tests/sources/trace_cut.json
+++ b/tests/sources/trace_cut.json
@@ -59,11 +59,13 @@
 {"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["12"]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["(q :- !) => q"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["q :- ."]}
 {"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","(q :- !) => q"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["13"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["q"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["q :- !."]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["q","q"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}

--- a/tests/sources/trace_findall.elab.json
+++ b/tests/sources/trace_findall.elab.json
@@ -429,7 +429,10 @@
         "findall_solution_text": [ "X0 := [p 1, p 2, p 3]" ],
         "findall_stack": [
           {
-            "rule": [ "BuiltinRule", [ "FFI", "findall" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "findall", "kind": "FFI", "payload": [] }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -489,7 +492,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "FFI", "print" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "print", "kind": "FFI", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [],
@@ -499,7 +505,10 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "FFI", "print" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "print", "kind": "FFI", "payload": [] }
+            ],
             "step_id": 4,
             "runtime_id": 0
           },

--- a/tests/sources/trace_implication.elab.json
+++ b/tests/sources/trace_implication.elab.json
@@ -1,0 +1,3217 @@
+[
+  {
+    "step_id": 0,
+    "runtime_id": 0,
+    "step": [ "Init", { "goal_text": "main", "goal_id": 4 } ],
+    "color": "Grey"
+  },
+  {
+    "step_id": 1,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 4,
+        "current_goal_text": "main",
+        "current_goal_predicate": "main",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "tests/sources/trace_implication.elpi",
+                      "line": 8,
+                      "column": 0,
+                      "character": 136
+                    }
+                  ]
+                }
+              ],
+              "events": []
+            },
+            "siblings": [
+              {
+                "goal_text": "x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+                "goal_id": 5
+              }
+            ],
+            "siblings_aggregated_outcome": "Success"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Green"
+  },
+  {
+    "step_id": 2,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 5,
+        "current_goal_text": "x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(A0 ; _) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 41,
+                      "column": 0,
+                      "character": 586
+                    }
+                  ]
+                }
+              ],
+              "events": [ [ "Assign", "A0 := x0 => z0" ] ]
+            },
+            "siblings": [ { "goal_text": "x0 => z0", "goal_id": 6 } ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [ 5 ],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 2,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowGreen"
+  },
+  {
+    "step_id": 3,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 6,
+        "current_goal_text": "x0 => z0",
+        "current_goal_predicate": "=>",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "events": []
+            },
+            "siblings": [ { "goal_text": "z0", "goal_id": 7 } ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nx0 :- ." ] ],
+            "step_id": 3,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 2,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowRed"
+  },
+  {
+    "step_id": 4,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 7,
+        "current_goal_text": "z0",
+        "current_goal_predicate": "z0",
+        "failed_attempts": [],
+        "successful_attempts": [],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nx0 :- ." ] ],
+            "step_id": 3,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 2,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Red"
+  },
+  {
+    "step_id": 5,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 5,
+        "current_goal_text": "x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(_ ; A0) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 43,
+                      "column": 0,
+                      "character": 601
+                    }
+                  ]
+                }
+              ],
+              "events": [
+                [
+                  "Assign",
+                  "A0 := (x1 , y1) => z1 ;\n       [x2, y2] => z2 ;\n        [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"
+                ]
+              ]
+            },
+            "siblings": [
+              {
+                "goal_text": "(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+                "goal_id": 8
+              }
+            ],
+            "siblings_aggregated_outcome": "Success"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Green"
+  },
+  {
+    "step_id": 6,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 8,
+        "current_goal_text": "(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(A0 ; _) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 41,
+                      "column": 0,
+                      "character": 586
+                    }
+                  ]
+                }
+              ],
+              "events": [ [ "Assign", "A0 := (x1 , y1) => z1" ] ]
+            },
+            "siblings": [ { "goal_text": "(x1 , y1) => z1", "goal_id": 9 } ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [ 9 ],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 6,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowGreen"
+  },
+  {
+    "step_id": 7,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 9,
+        "current_goal_text": "(x1 , y1) => z1",
+        "current_goal_predicate": "=>",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "events": []
+            },
+            "siblings": [ { "goal_text": "z1", "goal_id": 10 } ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\ny1 :- ." ] ],
+            "step_id": 7,
+            "runtime_id": 0
+          },
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nx1 :- ." ] ],
+            "step_id": 7,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 6,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowRed"
+  },
+  {
+    "step_id": 8,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 10,
+        "current_goal_text": "z1",
+        "current_goal_predicate": "z1",
+        "failed_attempts": [],
+        "successful_attempts": [],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\ny1 :- ." ] ],
+            "step_id": 7,
+            "runtime_id": 0
+          },
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nx1 :- ." ] ],
+            "step_id": 7,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 6,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Red"
+  },
+  {
+    "step_id": 9,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 8,
+        "current_goal_text": "(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(_ ; A0) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 43,
+                      "column": 0,
+                      "character": 601
+                    }
+                  ]
+                }
+              ],
+              "events": [
+                [
+                  "Assign",
+                  "A0 := [x2, y2] => z2 ;\n       [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"
+                ]
+              ]
+            },
+            "siblings": [
+              {
+                "goal_text": "[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+                "goal_id": 11
+              }
+            ],
+            "siblings_aggregated_outcome": "Success"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Green"
+  },
+  {
+    "step_id": 10,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 11,
+        "current_goal_text": "[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(A0 ; _) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 41,
+                      "column": 0,
+                      "character": 586
+                    }
+                  ]
+                }
+              ],
+              "events": [ [ "Assign", "A0 := [x2, y2] => z2" ] ]
+            },
+            "siblings": [ { "goal_text": "[x2, y2] => z2", "goal_id": 12 } ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [ 13 ],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 10,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowGreen"
+  },
+  {
+    "step_id": 11,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 12,
+        "current_goal_text": "[x2, y2] => z2",
+        "current_goal_predicate": "=>",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "events": []
+            },
+            "siblings": [ { "goal_text": "z2", "goal_id": 13 } ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\ny2 :- ." ] ],
+            "step_id": 11,
+            "runtime_id": 0
+          },
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nx2 :- ." ] ],
+            "step_id": 11,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 10,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowRed"
+  },
+  {
+    "step_id": 12,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 13,
+        "current_goal_text": "z2",
+        "current_goal_predicate": "z2",
+        "failed_attempts": [],
+        "successful_attempts": [],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\ny2 :- ." ] ],
+            "step_id": 11,
+            "runtime_id": 0
+          },
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nx2 :- ." ] ],
+            "step_id": 11,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 10,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Red"
+  },
+  {
+    "step_id": 13,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 11,
+        "current_goal_text": "[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(_ ; A0) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 43,
+                      "column": 0,
+                      "character": 601
+                    }
+                  ]
+                }
+              ],
+              "events": [
+                [
+                  "Assign",
+                  "A0 := [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"
+                ]
+              ]
+            },
+            "siblings": [
+              {
+                "goal_text": "[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+                "goal_id": 14
+              }
+            ],
+            "siblings_aggregated_outcome": "Success"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Green"
+  },
+  {
+    "step_id": 14,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 14,
+        "current_goal_text": "[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(A0 ; _) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 41,
+                      "column": 0,
+                      "character": 586
+                    }
+                  ]
+                }
+              ],
+              "events": [
+                [ "Assign", "A0 := [(x3 :- !), (y3 :- !)] => z3" ]
+              ]
+            },
+            "siblings": [
+              { "goal_text": "[(x3 :- !), (y3 :- !)] => z3", "goal_id": 15 }
+            ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [ 17 ],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 14,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowGreen"
+  },
+  {
+    "step_id": 15,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 15,
+        "current_goal_text": "[(x3 :- !), (y3 :- !)] => z3",
+        "current_goal_predicate": "=>",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "events": []
+            },
+            "siblings": [ { "goal_text": "z3", "goal_id": 16 } ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\ny3 :- !." ] ],
+            "step_id": 15,
+            "runtime_id": 0
+          },
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nx3 :- !." ] ],
+            "step_id": 15,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 14,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowRed"
+  },
+  {
+    "step_id": 16,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 16,
+        "current_goal_text": "z3",
+        "current_goal_predicate": "z3",
+        "failed_attempts": [],
+        "successful_attempts": [],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\ny3 :- !." ] ],
+            "step_id": 15,
+            "runtime_id": 0
+          },
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication\nx3 :- !." ] ],
+            "step_id": 15,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 14,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Red"
+  },
+  {
+    "step_id": 17,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 14,
+        "current_goal_text": "[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(_ ; A0) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 43,
+                      "column": 0,
+                      "character": 601
+                    }
+                  ]
+                }
+              ],
+              "events": [
+                [ "Assign", "A0 := (x4 :- y4 , !) => z4 ; [] => z5 ; true" ]
+              ]
+            },
+            "siblings": [
+              {
+                "goal_text": "(x4 :- y4 , !) => z4 ; [] => z5 ; true",
+                "goal_id": 17
+              }
+            ],
+            "siblings_aggregated_outcome": "Success"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 17,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Green"
+  },
+  {
+    "step_id": 18,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 17,
+        "current_goal_text": "(x4 :- y4 , !) => z4 ; [] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(A0 ; _) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 41,
+                      "column": 0,
+                      "character": 586
+                    }
+                  ]
+                }
+              ],
+              "events": [ [ "Assign", "A0 := (x4 :- y4 , !) => z4" ] ]
+            },
+            "siblings": [
+              { "goal_text": "(x4 :- y4 , !) => z4", "goal_id": 18 }
+            ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [ 21 ],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 18,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 17,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowGreen"
+  },
+  {
+    "step_id": 19,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 18,
+        "current_goal_text": "(x4 :- y4 , !) => z4",
+        "current_goal_predicate": "=>",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "events": []
+            },
+            "siblings": [ { "goal_text": "z4", "goal_id": 19 } ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [
+              "BuiltinRule", [ "Logic", "implication\nx4 :- y4, !." ]
+            ],
+            "step_id": 19,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 18,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 17,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowRed"
+  },
+  {
+    "step_id": 20,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 19,
+        "current_goal_text": "z4",
+        "current_goal_predicate": "z4",
+        "failed_attempts": [],
+        "successful_attempts": [],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [
+              "BuiltinRule", [ "Logic", "implication\nx4 :- y4, !." ]
+            ],
+            "step_id": 19,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 18,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 17,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Red"
+  },
+  {
+    "step_id": 21,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 17,
+        "current_goal_text": "(x4 :- y4 , !) => z4 ; [] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(_ ; A0) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 43,
+                      "column": 0,
+                      "character": 601
+                    }
+                  ]
+                }
+              ],
+              "events": [ [ "Assign", "A0 := [] => z5 ; true" ] ]
+            },
+            "siblings": [ { "goal_text": "[] => z5 ; true", "goal_id": 20 } ],
+            "siblings_aggregated_outcome": "Success"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 21,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 17,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Green"
+  },
+  {
+    "step_id": 22,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 20,
+        "current_goal_text": "[] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(A0 ; _) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 41,
+                      "column": 0,
+                      "character": 586
+                    }
+                  ]
+                }
+              ],
+              "events": [ [ "Assign", "A0 := [] => z5" ] ]
+            },
+            "siblings": [ { "goal_text": "[] => z5", "goal_id": 21 } ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [ 25 ],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 22,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 21,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 17,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowGreen"
+  },
+  {
+    "step_id": 23,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 21,
+        "current_goal_text": "[] => z5",
+        "current_goal_predicate": "=>",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "events": []
+            },
+            "siblings": [ { "goal_text": "z5", "goal_id": 22 } ],
+            "siblings_aggregated_outcome": "Fail"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "step_id": 23,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 22,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 21,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 17,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "YellowRed"
+  },
+  {
+    "step_id": 24,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 22,
+        "current_goal_text": "z5",
+        "current_goal_predicate": "z5",
+        "failed_attempts": [],
+        "successful_attempts": [],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "step_id": 23,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(A0 ; _) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 41,
+                    "column": 0,
+                    "character": 586
+                  }
+                ]
+              }
+            ],
+            "step_id": 22,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 21,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 17,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Red"
+  },
+  {
+    "step_id": 25,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 20,
+        "current_goal_text": "[] => z5 ; true",
+        "current_goal_predicate": ";",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "(_ ; A0) :- A0.",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 43,
+                      "column": 0,
+                      "character": 601
+                    }
+                  ]
+                }
+              ],
+              "events": [ [ "Assign", "A0 := true" ] ]
+            },
+            "siblings": [ { "goal_text": "true", "goal_id": 23 } ],
+            "siblings_aggregated_outcome": "Success"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 25,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 21,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 17,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Green"
+  },
+  {
+    "step_id": 26,
+    "runtime_id": 0,
+    "step": [
+      "Inference",
+      {
+        "current_goal_id": 23,
+        "current_goal_text": "true",
+        "current_goal_predicate": "true",
+        "failed_attempts": [],
+        "successful_attempts": [
+          {
+            "attempt": {
+              "rule": [
+                "UserRule",
+                {
+                  "rule_text": "true :- .",
+                  "rule_loc": [
+                    "File",
+                    {
+                      "filename": "builtin.elpi",
+                      "line": 11,
+                      "column": 0,
+                      "character": 147
+                    }
+                  ]
+                }
+              ],
+              "events": []
+            },
+            "siblings": [],
+            "siblings_aggregated_outcome": "Success"
+          }
+        ],
+        "more_successful_attempts": [],
+        "stack": [
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "true :- .",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 11,
+                    "column": 0,
+                    "character": 147
+                  }
+                ]
+              }
+            ],
+            "step_id": 26,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 25,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 21,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 17,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 13,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 9,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "(_ ; A0) :- A0.",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "builtin.elpi",
+                    "line": 43,
+                    "column": 0,
+                    "character": 601
+                  }
+                ]
+              }
+            ],
+            "step_id": 5,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "UserRule",
+              {
+                "rule_text": "main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true).",
+                "rule_loc": [
+                  "File",
+                  {
+                    "filename": "tests/sources/trace_implication.elpi",
+                    "line": 8,
+                    "column": 0,
+                    "character": 136
+                  }
+                ]
+              }
+            ],
+            "step_id": 1,
+            "runtime_id": 0
+          }
+        ]
+      }
+    ],
+    "color": "Green"
+  }
+]

--- a/tests/sources/trace_implication.elab.json
+++ b/tests/sources/trace_implication.elab.json
@@ -162,7 +162,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "z0", "goal_id": 7 } ],
@@ -172,7 +175,14 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nx0 :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "x0 :- ." ]
+              }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -233,7 +243,14 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nx0 :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "x0 :- ." ]
+              }
+            ],
             "step_id": 3,
             "runtime_id": 0
           },
@@ -480,7 +497,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "z1", "goal_id": 10 } ],
@@ -490,12 +510,14 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\ny1 :- ." ] ],
-            "step_id": 7,
-            "runtime_id": 0
-          },
-          {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nx1 :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "x1 :- .", "y1 :- ." ]
+              }
+            ],
             "step_id": 7,
             "runtime_id": 0
           },
@@ -575,12 +597,14 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\ny1 :- ." ] ],
-            "step_id": 7,
-            "runtime_id": 0
-          },
-          {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nx1 :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "x1 :- .", "y1 :- ." ]
+              }
+            ],
             "step_id": 7,
             "runtime_id": 0
           },
@@ -884,7 +908,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "z2", "goal_id": 13 } ],
@@ -894,12 +921,14 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\ny2 :- ." ] ],
-            "step_id": 11,
-            "runtime_id": 0
-          },
-          {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nx2 :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "x2 :- .", "y2 :- ." ]
+              }
+            ],
             "step_id": 11,
             "runtime_id": 0
           },
@@ -998,12 +1027,14 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\ny2 :- ." ] ],
-            "step_id": 11,
-            "runtime_id": 0
-          },
-          {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nx2 :- ." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "x2 :- .", "y2 :- ." ]
+              }
+            ],
             "step_id": 11,
             "runtime_id": 0
           },
@@ -1368,7 +1399,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "z3", "goal_id": 16 } ],
@@ -1378,12 +1412,14 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\ny3 :- !." ] ],
-            "step_id": 15,
-            "runtime_id": 0
-          },
-          {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nx3 :- !." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "x3 :- !.", "y3 :- !." ]
+              }
+            ],
             "step_id": 15,
             "runtime_id": 0
           },
@@ -1501,12 +1537,14 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\ny3 :- !." ] ],
-            "step_id": 15,
-            "runtime_id": 0
-          },
-          {
-            "rule": [ "BuiltinRule", [ "Logic", "implication\nx3 :- !." ] ],
+            "rule": [
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "x3 :- !.", "y3 :- !." ]
+              }
+            ],
             "step_id": 15,
             "runtime_id": 0
           },
@@ -1923,7 +1961,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "z4", "goal_id": 19 } ],
@@ -1934,7 +1975,12 @@
         "stack": [
           {
             "rule": [
-              "BuiltinRule", [ "Logic", "implication\nx4 :- y4, !." ]
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "x4 :- y4, !." ]
+              }
             ],
             "step_id": 19,
             "runtime_id": 0
@@ -2073,7 +2119,12 @@
         "stack": [
           {
             "rule": [
-              "BuiltinRule", [ "Logic", "implication\nx4 :- y4, !." ]
+              "BuiltinRule",
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "x4 :- y4, !." ]
+              }
             ],
             "step_id": 19,
             "runtime_id": 0
@@ -2539,7 +2590,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "z5", "goal_id": 22 } ],
@@ -2549,7 +2603,18 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
+            "step_id": 23,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 23,
             "runtime_id": 0
           },
@@ -2705,7 +2770,18 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
+            "step_id": 23,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 23,
             "runtime_id": 0
           },

--- a/tests/sources/trace_implication.elpi
+++ b/tests/sources/trace_implication.elpi
@@ -1,0 +1,15 @@
+pred x0. pred z0.
+pred x1. pred y1. pred z1.
+pred x2. pred y2. pred z2.
+pred x3. pred y3. pred z3.
+pred x4. pred y4. pred z4.
+pred z5.
+
+main :-
+  (x0 => z0);
+  ((x1, y1) => z1);
+  ([x2, y2] ==> z2);
+  ([x3, y3] =!=> z3);
+  ((x4 :- y4) =!=> z4);
+  ([] => z5);
+  true.

--- a/tests/sources/trace_implication.json
+++ b/tests/sources/trace_implication.json
@@ -1,0 +1,169 @@
+{"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_implication.elpi\", line 8, column 0, characters 136-265:"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_implication.elpi\", line 8, column 0, characters 136-265:","main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true)."]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := x0 => z0"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["x0 => z0"]}
+{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","x0 => z0"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["7"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z0"]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["x0 :- ."]}
+{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z0","z0"]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
+{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := (x1 , y1) => z1 ;\n       [x2, y2] => z2 ;\n        [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["8"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := (x1 , y1) => z1"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["9"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["(x1 , y1) => z1"]}
+{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 7,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","(x1 , y1) => z1"]}
+{"step" : 7,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
+{"step" : 7,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["10"]}
+{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z1"]}
+{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["x1 :- .","y1 :- ."]}
+{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z1","z1"]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [x2, y2] => z2 ;\n       [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["11"]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 9,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [x2, y2] => z2"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["12"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[x2, y2] => z2"]}
+{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","[x2, y2] => z2"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["13"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z2"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["x2 :- .","y2 :- ."]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z2","z2"]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["14"]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 13,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 14,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 14,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 14,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 14,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [(x3 :- !), (y3 :- !)] => z3"]}
+{"step" : 14,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["15"]}
+{"step" : 14,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[(x3 :- !), (y3 :- !)] => z3"]}
+{"step" : 14,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","[(x3 :- !), (y3 :- !)] => z3"]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["16"]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z3"]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["x3 :- !.","y3 :- !."]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
+{"step" : 16,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z3","z3"]}
+{"step" : 16,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 16,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
+{"step" : 16,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["17"]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["(x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 17,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","(x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := (x4 :- y4 , !) => z4"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["18"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["(x4 :- y4 , !) => z4"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 19,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","(x4 :- y4 , !) => z4"]}
+{"step" : 19,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
+{"step" : 19,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["19"]}
+{"step" : 19,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z4"]}
+{"step" : 19,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["x4 :- y4, !."]}
+{"step" : 19,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
+{"step" : 20,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z4","z4"]}
+{"step" : 20,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 20,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
+{"step" : 20,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
+{"step" : 21,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","(x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step" : 21,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 21,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 21,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step" : 21,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [] => z5 ; true"]}
+{"step" : 21,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["20"]}
+{"step" : 21,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[] => z5 ; true"]}
+{"step" : 21,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[] => z5 ; true"]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [] => z5"]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["21"]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[] => z5"]}
+{"step" : 22,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 23,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","[] => z5"]}
+{"step" : 23,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
+{"step" : 23,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["22"]}
+{"step" : 23,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z5"]}
+{"step" : 23,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:new-hyps","payload" : []}
+{"step" : 23,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
+{"step" : 24,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z5","z5"]}
+{"step" : 24,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 24,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
+{"step" : 24,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[] => z5 ; true"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := true"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["23"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["true"]}
+{"step" : 25,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["true","true"]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 11, column 0, characters 147-151:"]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 11, column 0, characters 147-151:","true :- ."]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}

--- a/tests/sources/trace_w.elab.json
+++ b/tests/sources/trace_w.elab.json
@@ -382,7 +382,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "FFI", "print" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "print", "kind": "FFI", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [],
@@ -392,7 +395,10 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "FFI", "print" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "print", "kind": "FFI", "payload": [] }
+            ],
             "step_id": 5,
             "runtime_id": 0
           },
@@ -731,7 +737,10 @@
         "suspend_sibling": { "goal_text": "theta []", "goal_id": 16 },
         "suspend_stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "suspend" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "suspend", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 8,
             "runtime_id": 0
           },
@@ -1121,7 +1130,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "pi", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [
@@ -1136,7 +1148,9 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 11,
             "runtime_id": 0
           },
@@ -1253,7 +1267,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [ { "goal_text": "of c0 (mono X6)", "goal_id": 22 } ],
@@ -1265,13 +1282,19 @@
           {
             "rule": [
               "BuiltinRule",
-              [ "Logic", "implication\n(of c0 (mono X5)) :- ." ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "(of c0 (mono X5)) :- ." ]
+              }
             ],
             "step_id": 12,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 11,
             "runtime_id": 0
           },
@@ -1417,13 +1440,19 @@
           {
             "rule": [
               "BuiltinRule",
-              [ "Logic", "implication\n(of c0 (mono X5)) :- ." ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [ "(of c0 (mono X5)) :- ." ]
+              }
             ],
             "step_id": 12,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 11,
             "runtime_id": 0
           },
@@ -1847,7 +1876,10 @@
         },
         "suspend_stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "suspend" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "suspend", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 16,
             "runtime_id": 0
           },
@@ -3016,7 +3048,14 @@
                       "successful_attempts": [
                         {
                           "attempt": {
-                            "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+                            "rule": [
+                              "BuiltinRule",
+                              {
+                                "name": "eq",
+                                "kind": "Logic",
+                                "payload": []
+                              }
+                            ],
                             "events": [
                               [ "Assign", "X7 := [uvar frozen--452 []]" ]
                             ]
@@ -3028,7 +3067,10 @@
                       "more_successful_attempts": [],
                       "stack": [
                         {
-                          "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+                          "rule": [
+                            "BuiltinRule",
+                            { "name": "eq", "kind": "Logic", "payload": [] }
+                          ],
                           "step_id": 9,
                           "runtime_id": 1
                         },
@@ -3827,7 +3869,14 @@
                       "successful_attempts": [
                         {
                           "attempt": {
-                            "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+                            "rule": [
+                              "BuiltinRule",
+                              {
+                                "name": "eq",
+                                "kind": "Logic",
+                                "payload": []
+                              }
+                            ],
                             "events": [
                               [ "Assign", "X4 := [uvar frozen--452 []]" ]
                             ]
@@ -3839,7 +3888,10 @@
                       "more_successful_attempts": [],
                       "stack": [
                         {
-                          "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+                          "rule": [
+                            "BuiltinRule",
+                            { "name": "eq", "kind": "Logic", "payload": [] }
+                          ],
                           "step_id": 16,
                           "runtime_id": 1
                         },
@@ -5217,7 +5269,14 @@
                       "successful_attempts": [
                         {
                           "attempt": {
-                            "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+                            "rule": [
+                              "BuiltinRule",
+                              {
+                                "name": "eq",
+                                "kind": "Logic",
+                                "payload": []
+                              }
+                            ],
                             "events": [ [ "Assign", "X12 := any" ] ]
                           },
                           "siblings": [],
@@ -5227,7 +5286,10 @@
                       "more_successful_attempts": [],
                       "stack": [
                         {
-                          "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+                          "rule": [
+                            "BuiltinRule",
+                            { "name": "eq", "kind": "Logic", "payload": [] }
+                          ],
                           "step_id": 30,
                           "runtime_id": 1
                         },
@@ -5306,7 +5368,14 @@
                       "successful_attempts": [
                         {
                           "attempt": {
-                            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+                            "rule": [
+                              "BuiltinRule",
+                              {
+                                "name": "pi",
+                                "kind": "Logic",
+                                "payload": []
+                              }
+                            ],
                             "events": []
                           },
                           "siblings": [
@@ -5321,7 +5390,10 @@
                       "more_successful_attempts": [],
                       "stack": [
                         {
-                          "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+                          "rule": [
+                            "BuiltinRule",
+                            { "name": "pi", "kind": "Logic", "payload": [] }
+                          ],
                           "step_id": 31,
                           "runtime_id": 1
                         },
@@ -5382,7 +5454,12 @@
                         {
                           "attempt": {
                             "rule": [
-                              "BuiltinRule", [ "Logic", "implication" ]
+                              "BuiltinRule",
+                              {
+                                "name": "implication",
+                                "kind": "Logic",
+                                "payload": []
+                              }
                             ],
                             "events": []
                           },
@@ -5400,16 +5477,22 @@
                         {
                           "rule": [
                             "BuiltinRule",
-                            [
-                              "Logic",
-                              "implication\n(copy (uvar frozen--452 []) c0) :- ."
-                            ]
+                            {
+                              "name": "implication",
+                              "kind": "Logic",
+                              "payload": [
+                                "(copy (uvar frozen--452 []) c0) :- ."
+                              ]
+                            }
                           ],
                           "step_id": 32,
                           "runtime_id": 1
                         },
                         {
-                          "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+                          "rule": [
+                            "BuiltinRule",
+                            { "name": "pi", "kind": "Logic", "payload": [] }
+                          ],
                           "step_id": 31,
                           "runtime_id": 1
                         },
@@ -5526,16 +5609,22 @@
                         {
                           "rule": [
                             "BuiltinRule",
-                            [
-                              "Logic",
-                              "implication\n(copy (uvar frozen--452 []) c0) :- ."
-                            ]
+                            {
+                              "name": "implication",
+                              "kind": "Logic",
+                              "payload": [
+                                "(copy (uvar frozen--452 []) c0) :- ."
+                              ]
+                            }
                           ],
                           "step_id": 32,
                           "runtime_id": 1
                         },
                         {
-                          "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+                          "rule": [
+                            "BuiltinRule",
+                            { "name": "pi", "kind": "Logic", "payload": [] }
+                          ],
                           "step_id": 31,
                           "runtime_id": 1
                         },
@@ -5672,16 +5761,22 @@
                         {
                           "rule": [
                             "BuiltinRule",
-                            [
-                              "Logic",
-                              "implication\n(copy (uvar frozen--452 []) c0) :- ."
-                            ]
+                            {
+                              "name": "implication",
+                              "kind": "Logic",
+                              "payload": [
+                                "(copy (uvar frozen--452 []) c0) :- ."
+                              ]
+                            }
                           ],
                           "step_id": 32,
                           "runtime_id": 1
                         },
                         {
-                          "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+                          "rule": [
+                            "BuiltinRule",
+                            { "name": "pi", "kind": "Logic", "payload": [] }
+                          ],
                           "step_id": 31,
                           "runtime_id": 1
                         },
@@ -5808,16 +5903,22 @@
                         {
                           "rule": [
                             "BuiltinRule",
-                            [
-                              "Logic",
-                              "implication\n(copy (uvar frozen--452 []) c0) :- ."
-                            ]
+                            {
+                              "name": "implication",
+                              "kind": "Logic",
+                              "payload": [
+                                "(copy (uvar frozen--452 []) c0) :- ."
+                              ]
+                            }
                           ],
                           "step_id": 32,
                           "runtime_id": 1
                         },
                         {
-                          "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+                          "rule": [
+                            "BuiltinRule",
+                            { "name": "pi", "kind": "Logic", "payload": [] }
+                          ],
                           "step_id": 31,
                           "runtime_id": 1
                         },
@@ -5944,16 +6045,22 @@
                         {
                           "rule": [
                             "BuiltinRule",
-                            [
-                              "Logic",
-                              "implication\n(copy (uvar frozen--452 []) c0) :- ."
-                            ]
+                            {
+                              "name": "implication",
+                              "kind": "Logic",
+                              "payload": [
+                                "(copy (uvar frozen--452 []) c0) :- ."
+                              ]
+                            }
                           ],
                           "step_id": 32,
                           "runtime_id": 1
                         },
                         {
-                          "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+                          "rule": [
+                            "BuiltinRule",
+                            { "name": "pi", "kind": "Logic", "payload": [] }
+                          ],
                           "step_id": 31,
                           "runtime_id": 1
                         },
@@ -6038,7 +6145,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [
@@ -6053,7 +6163,18 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
+            "step_id": 18,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 18,
             "runtime_id": 0
           }
@@ -6075,7 +6196,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "eq", "kind": "Logic", "payload": [] }
+              ],
               "events": [
                 [ "Assign", "X1 := all any c0 \\ mono (c0 ===> c0)" ]
               ]
@@ -6087,12 +6211,25 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "eq" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "eq", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 19,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
+            "step_id": 18,
+            "runtime_id": 0
+          },
+          {
+            "rule": [
+              "BuiltinRule",
+              { "name": "implication", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 18,
             "runtime_id": 0
           }
@@ -6114,7 +6251,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "pi", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [
@@ -6129,7 +6269,9 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 20,
             "runtime_id": 0
           },
@@ -6227,7 +6369,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "implication", "kind": "Logic", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [
@@ -6244,16 +6389,21 @@
           {
             "rule": [
               "BuiltinRule",
-              [
-                "Logic",
-                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
-              ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [
+                  "(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+                ]
+              }
             ],
             "step_id": 21,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 20,
             "runtime_id": 0
           },
@@ -6403,16 +6553,21 @@
           {
             "rule": [
               "BuiltinRule",
-              [
-                "Logic",
-                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
-              ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [
+                  "(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+                ]
+              }
             ],
             "step_id": 21,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 20,
             "runtime_id": 0
           },
@@ -6590,16 +6745,21 @@
           {
             "rule": [
               "BuiltinRule",
-              [
-                "Logic",
-                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
-              ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [
+                  "(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+                ]
+              }
             ],
             "step_id": 21,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 20,
             "runtime_id": 0
           },
@@ -6759,16 +6919,21 @@
           {
             "rule": [
               "BuiltinRule",
-              [
-                "Logic",
-                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
-              ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [
+                  "(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+                ]
+              }
             ],
             "step_id": 21,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 20,
             "runtime_id": 0
           },
@@ -6949,16 +7114,21 @@
           {
             "rule": [
               "BuiltinRule",
-              [
-                "Logic",
-                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
-              ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [
+                  "(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+                ]
+              }
             ],
             "step_id": 21,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 20,
             "runtime_id": 0
           },
@@ -7154,16 +7324,21 @@
           {
             "rule": [
               "BuiltinRule",
-              [
-                "Logic",
-                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
-              ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [
+                  "(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+                ]
+              }
             ],
             "step_id": 21,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 20,
             "runtime_id": 0
           },
@@ -7501,16 +7676,21 @@
           {
             "rule": [
               "BuiltinRule",
-              [
-                "Logic",
-                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
-              ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [
+                  "(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+                ]
+              }
             ],
             "step_id": 21,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 20,
             "runtime_id": 0
           },
@@ -7767,16 +7947,21 @@
           {
             "rule": [
               "BuiltinRule",
-              [
-                "Logic",
-                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
-              ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [
+                  "(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+                ]
+              }
             ],
             "step_id": 21,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 20,
             "runtime_id": 0
           },
@@ -7965,16 +8150,21 @@
           {
             "rule": [
               "BuiltinRule",
-              [
-                "Logic",
-                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
-              ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [
+                  "(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+                ]
+              }
             ],
             "step_id": 21,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 20,
             "runtime_id": 0
           },
@@ -8179,16 +8369,21 @@
           {
             "rule": [
               "BuiltinRule",
-              [
-                "Logic",
-                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
-              ]
+              {
+                "name": "implication",
+                "kind": "Logic",
+                "payload": [
+                  "(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+                ]
+              }
             ],
             "step_id": 21,
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "pi" ] ],
+            "rule": [
+              "BuiltinRule", { "name": "pi", "kind": "Logic", "payload": [] }
+            ],
             "step_id": 20,
             "runtime_id": 0
           },
@@ -8803,7 +8998,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "FFI", "print" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "print", "kind": "FFI", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [],
@@ -8813,7 +9011,10 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "FFI", "print" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "print", "kind": "FFI", "payload": [] }
+            ],
             "step_id": 32,
             "runtime_id": 0
           },
@@ -8892,7 +9093,10 @@
         "successful_attempts": [
           {
             "attempt": {
-              "rule": [ "BuiltinRule", [ "FFI", "print" ] ],
+              "rule": [
+                "BuiltinRule",
+                { "name": "print", "kind": "FFI", "payload": [] }
+              ],
               "events": []
             },
             "siblings": [],
@@ -8902,7 +9106,10 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "FFI", "print" ] ],
+            "rule": [
+              "BuiltinRule",
+              { "name": "print", "kind": "FFI", "payload": [] }
+            ],
             "step_id": 33,
             "runtime_id": 0
           },

--- a/tests/sources/trace_w.elab.json
+++ b/tests/sources/trace_w.elab.json
@@ -1263,7 +1263,10 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [ "Logic", "implication\n(of c0 (mono X5)) :- ." ]
+            ],
             "step_id": 12,
             "runtime_id": 0
           },
@@ -1412,7 +1415,10 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [ "Logic", "implication\n(of c0 (mono X5)) :- ." ]
+            ],
             "step_id": 12,
             "runtime_id": 0
           },
@@ -5393,7 +5399,11 @@
                       "stack": [
                         {
                           "rule": [
-                            "BuiltinRule", [ "Logic", "implication" ]
+                            "BuiltinRule",
+                            [
+                              "Logic",
+                              "implication\n(copy (uvar frozen--452 []) c0) :- ."
+                            ]
                           ],
                           "step_id": 32,
                           "runtime_id": 1
@@ -5515,7 +5525,11 @@
                         },
                         {
                           "rule": [
-                            "BuiltinRule", [ "Logic", "implication" ]
+                            "BuiltinRule",
+                            [
+                              "Logic",
+                              "implication\n(copy (uvar frozen--452 []) c0) :- ."
+                            ]
                           ],
                           "step_id": 32,
                           "runtime_id": 1
@@ -5657,7 +5671,11 @@
                         },
                         {
                           "rule": [
-                            "BuiltinRule", [ "Logic", "implication" ]
+                            "BuiltinRule",
+                            [
+                              "Logic",
+                              "implication\n(copy (uvar frozen--452 []) c0) :- ."
+                            ]
                           ],
                           "step_id": 32,
                           "runtime_id": 1
@@ -5789,7 +5807,11 @@
                         },
                         {
                           "rule": [
-                            "BuiltinRule", [ "Logic", "implication" ]
+                            "BuiltinRule",
+                            [
+                              "Logic",
+                              "implication\n(copy (uvar frozen--452 []) c0) :- ."
+                            ]
                           ],
                           "step_id": 32,
                           "runtime_id": 1
@@ -5921,7 +5943,11 @@
                         },
                         {
                           "rule": [
-                            "BuiltinRule", [ "Logic", "implication" ]
+                            "BuiltinRule",
+                            [
+                              "Logic",
+                              "implication\n(copy (uvar frozen--452 []) c0) :- ."
+                            ]
                           ],
                           "step_id": 32,
                           "runtime_id": 1
@@ -6216,7 +6242,13 @@
         "more_successful_attempts": [],
         "stack": [
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [
+                "Logic",
+                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+              ]
+            ],
             "step_id": 21,
             "runtime_id": 0
           },
@@ -6369,7 +6401,13 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [
+                "Logic",
+                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+              ]
+            ],
             "step_id": 21,
             "runtime_id": 0
           },
@@ -6550,7 +6588,13 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [
+                "Logic",
+                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+              ]
+            ],
             "step_id": 21,
             "runtime_id": 0
           },
@@ -6713,7 +6757,13 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [
+                "Logic",
+                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+              ]
+            ],
             "step_id": 21,
             "runtime_id": 0
           },
@@ -6897,7 +6947,13 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [
+                "Logic",
+                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+              ]
+            ],
             "step_id": 21,
             "runtime_id": 0
           },
@@ -7096,7 +7152,13 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [
+                "Logic",
+                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+              ]
+            ],
             "step_id": 21,
             "runtime_id": 0
           },
@@ -7437,7 +7499,13 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [
+                "Logic",
+                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+              ]
+            ],
             "step_id": 21,
             "runtime_id": 0
           },
@@ -7697,7 +7765,13 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [
+                "Logic",
+                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+              ]
+            ],
             "step_id": 21,
             "runtime_id": 0
           },
@@ -7889,7 +7963,13 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [
+                "Logic",
+                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+              ]
+            ],
             "step_id": 21,
             "runtime_id": 0
           },
@@ -8097,7 +8177,13 @@
             "runtime_id": 0
           },
           {
-            "rule": [ "BuiltinRule", [ "Logic", "implication" ] ],
+            "rule": [
+              "BuiltinRule",
+              [
+                "Logic",
+                "implication\n(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."
+              ]
+            ],
             "step_id": 21,
             "runtime_id": 0
           },

--- a/tests/sources/trace_w.json
+++ b/tests/sources/trace_w.json
@@ -100,6 +100,7 @@
 {"step" : 12,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["22"]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of c0 (mono X6)"]}
+{"step" : 12,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["(of c0 (mono X5)) :- ."]}
 {"step" : 12,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of c0 (mono X6)"]}
 {"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
@@ -404,6 +405,7 @@
 {"step" : 32,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:rule","payload" : ["implication"]}
 {"step" : 32,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["61"]}
 {"step" : 32,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
+{"step" : 32,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:new-hyps","payload" : ["(copy (uvar frozen--452 []) c0) :- ."]}
 {"step" : 32,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:implication","payload" : ["success"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["bind","bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
 {"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
@@ -451,6 +453,7 @@
 {"step" : 18,"kind" : ["Info"],"goal_id" : 65,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 65,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["66"]}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["X1 = all any c0 \\ mono (c0 ===> c0)"]}
+{"step" : 18,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:new-hyps","payload" : []}
 {"step" : 18,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
 {"step" : 19,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=","X1 = all any c0 \\ mono (c0 ===> c0)"]}
 {"step" : 19,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:rule","payload" : ["eq"]}
@@ -466,6 +469,7 @@
 {"step" : 21,"kind" : ["Info"],"goal_id" : 67,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
 {"step" : 21,"kind" : ["Info"],"goal_id" : 67,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["68"]}
 {"step" : 21,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of (app c0 (global [])) (mono X3)"]}
+{"step" : 21,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."]}
 {"step" : 21,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
 {"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of (app c0 (global [])) (mono X3)"]}
 {"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}

--- a/tests/suite/elpi_specific.ml
+++ b/tests/suite/elpi_specific.ml
@@ -460,6 +460,21 @@ let () = declare "trace-browser-elab-cut"
   ~expectation:(SuccessOutputFile { sample; adjust = Util.strip_cwd; reference = "trace_cut.elab.json" })
   ()
 
+let sample = mk_tmp_file "trace_implication.json" ".new"
+let () = declare "trace-browser-implication"
+  ~source_elpi:"trace_implication.elpi"
+  ~description:"trace generation"
+    ~trace:(On["json";"file://"^sample;"-trace-at";"0";"99";"-trace-only";"user"])
+  ~expectation:(SuccessOutputFile { sample; adjust = Util.strip_cwd; reference = "trace_implication.json" })
+  ()
+
+let sample = mk_tmp_file "trace_implication.elab.json" ".new"
+let () = declare "trace-browser-elab-implication"
+  ~source_json:"trace_implication.json"
+  ~description:"trace elaboration"
+  ~expectation:(SuccessOutputFile { sample; adjust = Util.strip_cwd; reference = "trace_implication.elab.json" })
+  ()
+
 let sample = Filename.temp_file "broken_trace1.elab.json" ".new"
 let () = declare "trace-browser-elab-broken1"
   ~source_json:"broken_trace1.json"


### PR DESCRIPTION
It's useful to see in the stacktrace what rules were added to the context. It could probably be done with better UI, but this is the least invasive version.

Example stack trace
<img width="866" height="875" alt="image" src="https://github.com/user-attachments/assets/4c6dc887-1bbf-42f0-bea0-5883c6cb08bb" />
