### PR TITLE
Fix double stack frames for empty implications

### DIFF
--- a/src/elpi_trace_elaborator.ml
+++ b/src/elpi_trace_elaborator.ml
@@ -403,9 +403,6 @@ try
             push_stack (step,rid) goal_id (`BuiltinRule ({ kind = `Logic; name = name; payload = new_hyps })) siblings
           in
           let name = { kind = `Logic; name = name; payload = [] } in
-          (* Every step needs to push a stack, even a degenerate ([] => P) *)
-          if new_hyps = [] then
-            push_stack (step,rid) goal_id (`BuiltinRule name) siblings;
           Builtin { name; outcome; events = [] }
         else
           let name = { kind = `Logic; name = name; payload = [] } in

--- a/tests/sources/trace_chr.elab.json
+++ b/tests/sources/trace_chr.elab.json
@@ -1304,14 +1304,6 @@
             ],
             "step_id": 15,
             "runtime_id": 0
-          },
-          {
-            "rule": [
-              "BuiltinRule",
-              { "name": "implication", "kind": "Logic", "payload": [] }
-            ],
-            "step_id": 15,
-            "runtime_id": 0
           }
         ]
       }
@@ -1331,14 +1323,6 @@
         "successful_attempts": [],
         "more_successful_attempts": [],
         "stack": [
-          {
-            "rule": [
-              "BuiltinRule",
-              { "name": "implication", "kind": "Logic", "payload": [] }
-            ],
-            "step_id": 15,
-            "runtime_id": 0
-          },
           {
             "rule": [
               "BuiltinRule",

--- a/tests/sources/trace_implication.elab.json
+++ b/tests/sources/trace_implication.elab.json
@@ -2612,14 +2612,6 @@
           },
           {
             "rule": [
-              "BuiltinRule",
-              { "name": "implication", "kind": "Logic", "payload": [] }
-            ],
-            "step_id": 23,
-            "runtime_id": 0
-          },
-          {
-            "rule": [
               "UserRule",
               {
                 "rule_text": "(A0 ; _) :- A0.",
@@ -2769,14 +2761,6 @@
         "successful_attempts": [],
         "more_successful_attempts": [],
         "stack": [
-          {
-            "rule": [
-              "BuiltinRule",
-              { "name": "implication", "kind": "Logic", "payload": [] }
-            ],
-            "step_id": 23,
-            "runtime_id": 0
-          },
           {
             "rule": [
               "BuiltinRule",

--- a/tests/sources/trace_w.elab.json
+++ b/tests/sources/trace_w.elab.json
@@ -6169,14 +6169,6 @@
             ],
             "step_id": 18,
             "runtime_id": 0
-          },
-          {
-            "rule": [
-              "BuiltinRule",
-              { "name": "implication", "kind": "Logic", "payload": [] }
-            ],
-            "step_id": 18,
-            "runtime_id": 0
           }
         ]
       }
@@ -6215,14 +6207,6 @@
               "BuiltinRule", { "name": "eq", "kind": "Logic", "payload": [] }
             ],
             "step_id": 19,
-            "runtime_id": 0
-          },
-          {
-            "rule": [
-              "BuiltinRule",
-              { "name": "implication", "kind": "Logic", "payload": [] }
-            ],
-            "step_id": 18,
             "runtime_id": 0
           },
           {


### PR DESCRIPTION
Our wires got crossed in #424, so implications of the form `[] => C` pushed two identical frames to the stack