### PR TITLE
Simplify getenv FFI binding

### DIFF
--- a/src/builtin.elpi
+++ b/src/builtin.elpi
@@ -344,7 +344,7 @@ external func eof in_stream.
 % [gettimeofday T] sets T to the number of seconds elapsed since 1/1/1970
 external func gettimeofday -> float.
 
-% [getenv VarName Value] Like Sys.getenv
+% [getenv VarName Value] Like Sys.getenv_opt
 external func getenv string -> option string.
 
 % [system Command RetVal] executes Command and sets RetVal to the exit code

--- a/src/builtin.ml
+++ b/src/builtin.ml
@@ -492,10 +492,8 @@ let io_builtins = let open BuiltIn in let open BuiltInData in [
   MLCode(Pred("getenv",
     In(string,  "VarName",
     Out(option string, "Value",
-    Easy      ("Like Sys.getenv"))),
-  (fun s _ ~depth ->
-     try !:(Some (Sys.getenv s))
-     with Not_found -> !: None)),
+    Easy       "Like Sys.getenv_opt")),
+  (fun s _ ~depth -> !:(Sys.getenv_opt s))),
   DocAbove);
 
   MLCode(Pred("system",

--- a/tests/sources/trace_w.elab.json
+++ b/tests/sources/trace_w.elab.json
@@ -2472,7 +2472,7 @@
                                     "filename": "builtin.elpi",
                                     "line": 536,
                                     "column": 0,
-                                    "character": 13939
+                                    "character": 13943
                                   }
                                 ]
                               }
@@ -2509,7 +2509,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 536,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13943
                                 }
                               ]
                             }
@@ -2672,7 +2672,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 536,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13943
                                 }
                               ]
                             }
@@ -2804,7 +2804,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 536,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13943
                                 }
                               ]
                             }
@@ -2916,7 +2916,7 @@
                                     "filename": "builtin.elpi",
                                     "line": 537,
                                     "column": 0,
-                                    "character": 13960
+                                    "character": 13964
                                   }
                                 ]
                               }
@@ -2949,7 +2949,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 537,
                                   "column": 0,
-                                  "character": 13960
+                                  "character": 13964
                                 }
                               ]
                             }
@@ -3088,7 +3088,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 537,
                                   "column": 0,
-                                  "character": 13960
+                                  "character": 13964
                                 }
                               ]
                             }
@@ -3326,7 +3326,7 @@
                                     "filename": "builtin.elpi",
                                     "line": 536,
                                     "column": 0,
-                                    "character": 13939
+                                    "character": 13943
                                   }
                                 ]
                               }
@@ -3368,7 +3368,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 536,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13943
                                 }
                               ]
                             }
@@ -3531,7 +3531,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 536,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13943
                                 }
                               ]
                             }
@@ -3708,7 +3708,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 536,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13943
                                 }
                               ]
                             }
@@ -3849,7 +3849,7 @@
                                 "filename": "builtin.elpi",
                                 "line": 537,
                                 "column": 0,
-                                "character": 13960
+                                "character": 13964
                               }
                             ]
                           }
@@ -3909,7 +3909,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 536,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13943
                                 }
                               ]
                             }
@@ -4852,7 +4852,7 @@
                                     "filename": "builtin.elpi",
                                     "line": 536,
                                     "column": 0,
-                                    "character": 13939
+                                    "character": 13943
                                   }
                                 ]
                               }
@@ -4889,7 +4889,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 536,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13943
                                 }
                               ]
                             }
@@ -5014,7 +5014,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 536,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13943
                                 }
                               ]
                             }
@@ -5108,7 +5108,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 536,
                                   "column": 0,
-                                  "character": 13939
+                                  "character": 13943
                                 }
                               ]
                             }
@@ -5182,7 +5182,7 @@
                                     "filename": "builtin.elpi",
                                     "line": 537,
                                     "column": 0,
-                                    "character": 13960
+                                    "character": 13964
                                   }
                                 ]
                               }
@@ -5208,7 +5208,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 537,
                                   "column": 0,
-                                  "character": 13960
+                                  "character": 13964
                                 }
                               ]
                             }
@@ -5307,7 +5307,7 @@
                                   "filename": "builtin.elpi",
                                   "line": 537,
                                   "column": 0,
-                                  "character": 13960
+                                  "character": 13964
                                 }
                               ]
                             }

--- a/tests/sources/trace_w.json
+++ b/tests/sources/trace_w.json
@@ -191,8 +191,8 @@
 {"step" : 4,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","File \"builtin.elpi\", line 537, column 0, characters 13960-13973:"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","(if A0 A1 _) :- A0, !, A1."]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
+{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","(if A0 A1 _) :- A0, !, A1."]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--452 [])"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X7 = []"]}
 {"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["35"]}
@@ -217,8 +217,8 @@
 {"step" : 7,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13960-13973:"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13960-13973:","(if _ _ A0) :- A0."]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
+{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:","(if _ _ A0) :- A0."]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := X7 = [uvar frozen--452 []]"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["39"]}
 {"step" : 8,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X7 = [uvar frozen--452 []]"]}
@@ -240,8 +240,8 @@
 {"step" : 10,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [uvar frozen--452 []] (uvar frozen--452 [])) \n (X4 = [uvar frozen--452 []]) \n (X4 = [uvar frozen--452 [], uvar frozen--452 []])"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","File \"builtin.elpi\", line 537, column 0, characters 13960-13973:"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","(if A0 A1 _) :- A0, !, A1."]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
+{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","(if A0 A1 _) :- A0, !, A1."]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [uvar frozen--452 []] (uvar frozen--452 [])"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X4 = [uvar frozen--452 []]"]}
 {"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["41"]}
@@ -275,7 +275,7 @@
 {"step" : 14,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:rule:cut","payload" : ["success"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["!","!"]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["40","File \"builtin.elpi\", line 537, column 0, characters 13960-13973:","(if _ _ A0) :- A0."]}
+{"step" : 15,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["40","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:","(if _ _ A0) :- A0."]}
 {"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:rule:cut","payload" : ["success"]}
 {"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=","X4 = [uvar frozen--452 []]"]}
 {"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:rule","payload" : ["eq"]}
@@ -360,8 +360,8 @@
 {"step" : 25,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","File \"builtin.elpi\", line 537, column 0, characters 13960-13973:"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13939-13958:","(if A0 A1 _) :- A0, !, A1."]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
+{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","(if A0 A1 _) :- A0, !, A1."]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--452 [])"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X12 = eqt"]}
 {"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["55"]}
@@ -386,8 +386,8 @@
 {"step" : 28,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)"]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13960-13973:"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13960-13973:","(if _ _ A0) :- A0."]}
+{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
+{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:","(if _ _ A0) :- A0."]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := X12 = any"]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["59"]}
 {"step" : 29,"kind" : ["Info"],"goal_id" : 59,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X12 = any"]}


### PR DESCRIPTION
`Sys.gentenv_opt` was introduced in OCaml 4.05, and since the current compiler lower bound for elpi is 4.13, we know it will be available. Using it here allows us to forgo a try/with, and manual wrapping of the happy path in a `Some`.

This also lets us correct the documentation, which referred to `Sys.getenv` tho the implementation provided matches the behaviour of `Sys.getenv_opt`.

This is essentially just a stylistic fix I noticed while prepping for #427. I'll take offense if its not suitable for some reason, but any feedback in that case to guide the other work will be welcomed gratefully :)