### PR TITLE
Run tests/tests.exe from dune

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ tests:
 	$(MAKE) build
 	dune runtest
 	ulimit -s $(STACK); OCAMLRUNPARAM=l=$(STACK) \
-		tests/test.exe \
+		dune exec tests/test.exe -- \
 		--seed $$RANDOM \
 		--promote $(PROMOTE) \
 		--ln_nb=$(LN_NB) \


### PR DESCRIPTION
By running `tests/tests.exe` with `dune exec` we can ensure that any other executables dune is aware of will be available for the `tests/test.exe`. It will also ensure that the `tests/test.exe` is up to date before being run.

This suggestion is motivated by a test failures encountered in my dev env while working on #432, due to the inability to locate the `ydump` executable (provided by yocaml), which is an implicit dependency assumed by `tests/suite/suite.ml`: 

https://github.com/LPCIC/elpi/blob/18e079b67356ebe2ffae565c3415a864956410b1/tests/suite/suite.ml#L502

Development environments using the right opam switch will have `ydump` available in the environment, but other environments may not (E.g., i'm using dune package management). If these tests were being run inside dune, we'd specify `ydump` as a dependency to be made available on the path via `%{bin:ydumb}`, but that's obviously not available from the Makefile.