### PR TITLE
Use the ATD writer to write trace items

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -36,11 +36,17 @@
       (run elpi -document-builtins)))
 )
 
+(library
+  (name elpi_trace_atd)
+  (public_name elpi.trace.atd)
+  (libraries atdgen-runtime)
+  (modules trace_atd))
+
 (executable
   (name elpi_trace_elaborator)
   (public_name elpi-trace-elaborator)
-  (libraries yojson atdgen-runtime re)
-  (modules elpi_trace_elaborator trace_atd)
+  (libraries yojson re elpi.trace.atd)
+  (modules elpi_trace_elaborator)
   (package elpi)
 )
 

--- a/src/elpi_trace_elaborator.ml
+++ b/src/elpi_trace_elaborator.ml
@@ -17,6 +17,7 @@
   
 *)
 
+open Elpi_trace_atd
 open Trace_atd
 module Str = Re.Str
 

--- a/src/trace.atd
+++ b/src/trace.atd
@@ -10,10 +10,10 @@
 (* input: raw events  *)
 
 type item = {
+  step : int;
   kind : kind list;
   goal_id : int;
   runtime_id : int;
-  step : int;
   name : string;
   payload : string list;
 }

--- a/src/trace_atd.ts
+++ b/src/trace_atd.ts
@@ -15,10 +15,10 @@
 /* eslint-disable */
 
 export type Item = {
+  step: number /*int*/;
   kind: Kind[];
   goal_id: number /*int*/;
   runtime_id: number /*int*/;
-  step: number /*int*/;
   name: string;
   payload: string[];
 }
@@ -196,10 +196,10 @@ export type ChrText = string
 
 export function writeItem(x: Item, context: any = x): any {
   return {
+    'step': _atd_write_required_field('Item', 'step', _atd_write_int, x.step, x),
     'kind': _atd_write_required_field('Item', 'kind', _atd_write_array(writeKind), x.kind, x),
     'goal_id': _atd_write_required_field('Item', 'goal_id', _atd_write_int, x.goal_id, x),
     'runtime_id': _atd_write_required_field('Item', 'runtime_id', _atd_write_int, x.runtime_id, x),
-    'step': _atd_write_required_field('Item', 'step', _atd_write_int, x.step, x),
     'name': _atd_write_required_field('Item', 'name', _atd_write_string, x.name, x),
     'payload': _atd_write_required_field('Item', 'payload', _atd_write_array(_atd_write_string), x.payload, x),
   };
@@ -207,10 +207,10 @@ export function writeItem(x: Item, context: any = x): any {
 
 export function readItem(x: any, context: any = x): Item {
   return {
+    step: _atd_read_required_field('Item', 'step', _atd_read_int, x['step'], x),
     kind: _atd_read_required_field('Item', 'kind', _atd_read_array(readKind), x['kind'], x),
     goal_id: _atd_read_required_field('Item', 'goal_id', _atd_read_int, x['goal_id'], x),
     runtime_id: _atd_read_required_field('Item', 'runtime_id', _atd_read_int, x['runtime_id'], x),
-    step: _atd_read_required_field('Item', 'step', _atd_read_int, x['step'], x),
     name: _atd_read_required_field('Item', 'name', _atd_read_string, x['name'], x),
     payload: _atd_read_required_field('Item', 'payload', _atd_read_array(_atd_read_string), x['payload'], x),
   };

--- a/tests/sources/trace.json
+++ b/tests/sources/trace.json
@@ -1,85 +1,85 @@
-{"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace.elpi\", line 6, column 0, characters 80-105:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace.elpi\", line 6, column 0, characters 80-105:","main :- (p 1 A0 ; p 2 A1)."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["p 1 X0 ; p 2 X1"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","p 1 X0 ; p 2 X1"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := p 1 X0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["p 1 X0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["p","p 1 X0"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace.elpi\", line 2, column 0, characters 21-40:","File \"tests/sources/trace.elpi\", line 3, column 0, characters 42-70:"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace.elpi\", line 2, column 0, characters 21-40:","(p 1 1) :- (1 is 2 + 3)."]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 1"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["7"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["1 is 2 + 3"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["is","1 is 2 + 3"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 91, column 0, characters 1631-1649:"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 91, column 0, characters 1631-1649:","(A1 is A0) :- (calc A0 A1)."]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := 1"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := 2 + 3"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["8"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["calc (2 + 3) 1"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["calc","calc (2 + 3) 1"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["calc"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["9"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["1 = 5"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=","1 = 5"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule","payload" : ["eq"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["="]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify 1 with 5"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:eq","payload" : ["fail"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["p","p 1 X0"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace.elpi\", line 3, column 0, characters 42-70:"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace.elpi\", line 3, column 0, characters 42-70:","(p 1 2) :- (A0 = 1), (A1 = 2), (A0 = A1)."]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 2"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["10"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["X2 = 1"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["11"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["X3 = 2"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["12"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["X2 = X3"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=","X2 = 1"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule","payload" : ["eq"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["="]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X2 := 1"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:eq","payload" : ["success"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=","X3 = 2"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule","payload" : ["eq"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["="]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X3 := 2"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:eq","payload" : ["success"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=","1 = 2"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule","payload" : ["eq"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["="]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify 1 with 2"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:eq","payload" : ["fail"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","p 1 X0 ; p 2 X1"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := p 2 X1"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["13"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["p 2 X1"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["p","p 2 X1"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace.elpi\", line 4, column 0, characters 72-77:"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace.elpi\", line 4, column 0, characters 72-77:","(p 2 3) :- ."]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X1 := 3"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step":0,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:newgoal","payload":["main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:curgoal","payload":["main","main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace.elpi\", line 6, column 0, characters 80-105:"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace.elpi\", line 6, column 0, characters 80-105:","main :- (p 1 A0 ; p 2 A1)."]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:subgoal","payload":["5"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:newgoal","payload":["p 1 X0 ; p 2 X1"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":[";","p 1 X0 ; p 2 X1"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := p 1 X0"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["6"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:newgoal","payload":["p 1 X0"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:curgoal","payload":["p","p 1 X0"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace.elpi\", line 2, column 0, characters 21-40:","File \"tests/sources/trace.elpi\", line 3, column 0, characters 42-70:"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace.elpi\", line 2, column 0, characters 21-40:","(p 1 1) :- (1 is 2 + 3)."]}
+{"step":3,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 1"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:subgoal","payload":["7"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:newgoal","payload":["1 is 2 + 3"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:curgoal","payload":["is","1 is 2 + 3"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 91, column 0, characters 1631-1649:"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 91, column 0, characters 1631-1649:","(A1 is A0) :- (calc A0 A1)."]}
+{"step":4,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A1 := 1"]}
+{"step":4,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := 2 + 3"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:subgoal","payload":["8"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:newgoal","payload":["calc (2 + 3) 1"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:curgoal","payload":["calc","calc (2 + 3) 1"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:builtin:name","payload":["calc"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:subgoal","payload":["9"]}
+{"step":5,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:newgoal","payload":["1 = 5"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:curgoal","payload":["=","1 = 5"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule","payload":["eq"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:builtin:name","payload":["="]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify 1 with 5"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:eq","payload":["fail"]}
+{"step":7,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:curgoal","payload":["p","p 1 X0"]}
+{"step":7,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":7,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace.elpi\", line 3, column 0, characters 42-70:"]}
+{"step":7,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace.elpi\", line 3, column 0, characters 42-70:","(p 1 2) :- (A0 = 1), (A1 = 2), (A0 = A1)."]}
+{"step":7,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 2"]}
+{"step":7,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:subgoal","payload":["10"]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:newgoal","payload":["X2 = 1"]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:subgoal","payload":["11"]}
+{"step":7,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:newgoal","payload":["X3 = 2"]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:subgoal","payload":["12"]}
+{"step":7,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:newgoal","payload":["X2 = X3"]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:curgoal","payload":["=","X2 = 1"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule","payload":["eq"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:builtin:name","payload":["="]}
+{"step":8,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X2 := 1"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:eq","payload":["success"]}
+{"step":9,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:curgoal","payload":["=","X3 = 2"]}
+{"step":9,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule","payload":["eq"]}
+{"step":9,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:builtin:name","payload":["="]}
+{"step":9,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X3 := 2"]}
+{"step":9,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:eq","payload":["success"]}
+{"step":10,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:curgoal","payload":["=","1 = 2"]}
+{"step":10,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule","payload":["eq"]}
+{"step":10,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule:builtin:name","payload":["="]}
+{"step":10,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify 1 with 2"]}
+{"step":10,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule:eq","payload":["fail"]}
+{"step":11,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":[";","p 1 X0 ; p 2 X1"]}
+{"step":11,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":11,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":11,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step":11,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := p 2 X1"]}
+{"step":11,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["13"]}
+{"step":11,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:newgoal","payload":["p 2 X1"]}
+{"step":11,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:curgoal","payload":["p","p 2 X1"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace.elpi\", line 4, column 0, characters 72-77:"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace.elpi\", line 4, column 0, characters 72-77:","(p 2 3) :- ."]}
+{"step":12,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X1 := 3"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}

--- a/tests/sources/trace2.json
+++ b/tests/sources/trace2.json
@@ -1,49 +1,49 @@
-{"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace2.elpi\", line 1, column 0, characters 0-56:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace2.elpi\", line 1, column 0, characters 0-56:","main :- (print 1), (pi c0 \\ (sigma (c1 \\ (fail => (true , fail)))))."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["print 1"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["pi c0 \\ sigma c1 \\ fail => (true , fail)"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["print","print 1"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["print"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["pi","pi c0 \\ sigma c1 \\ fail => (true , fail)"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["pi"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["7"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["sigma c1 \\ fail => (true , fail)"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:new-quant","payload" : ["c0"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:pi","payload" : ["success"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["sigma","sigma c1 \\ fail => (true , fail)"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["sigma"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["8"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["fail => (true , fail)"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:new-quant","payload" : ["X0^1"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:sigma","payload" : ["success"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","fail => (true , fail)"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["9"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["true , fail"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["fail :- ."]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:curgoal","payload" : [",","true , fail"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule","payload" : ["and"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["10"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["true"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["11"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["fail"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:and","payload" : ["success"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["true","true"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 11, column 0, characters 147-151:"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 11, column 0, characters 147-151:","true :- ."]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["fail","fail"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:5)\", line 1, column 0, characters 0-0:"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:5)\", line 1, column 0, characters 0-0:","fail :- ."]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step":0,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:newgoal","payload":["main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:curgoal","payload":["main","main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace2.elpi\", line 1, column 0, characters 0-56:"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace2.elpi\", line 1, column 0, characters 0-56:","main :- (print 1), (pi c0 \\ (sigma (c1 \\ (fail => (true , fail)))))."]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:subgoal","payload":["5"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:newgoal","payload":["print 1"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["6"]}
+{"step":1,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:newgoal","payload":["pi c0 \\ sigma c1 \\ fail => (true , fail)"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":["print","print 1"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:builtin:name","payload":["print"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:curgoal","payload":["pi","pi c0 \\ sigma c1 \\ fail => (true , fail)"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule","payload":["pi"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:subgoal","payload":["7"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:newgoal","payload":["sigma c1 \\ fail => (true , fail)"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:new-quant","payload":["c0"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:pi","payload":["success"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:curgoal","payload":["sigma","sigma c1 \\ fail => (true , fail)"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule","payload":["sigma"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:subgoal","payload":["8"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:newgoal","payload":["fail => (true , fail)"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:new-quant","payload":["X0^1"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:sigma","payload":["success"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:curgoal","payload":["=>","fail => (true , fail)"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:subgoal","payload":["9"]}
+{"step":5,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:newgoal","payload":["true , fail"]}
+{"step":5,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:new-hyps","payload":["fail :- ."]}
+{"step":5,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:curgoal","payload":[",","true , fail"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule","payload":["and"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:subgoal","payload":["10"]}
+{"step":6,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:newgoal","payload":["true"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:subgoal","payload":["11"]}
+{"step":6,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:newgoal","payload":["fail"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:and","payload":["success"]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:curgoal","payload":["true","true"]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 11, column 0, characters 147-151:"]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 11, column 0, characters 147-151:","true :- ."]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":8,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:curgoal","payload":["fail","fail"]}
+{"step":8,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":8,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"(context step_id:5)\", line 1, column 0, characters 0-0:"]}
+{"step":8,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"(context step_id:5)\", line 1, column 0, characters 0-0:","fail :- ."]}
+{"step":8,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}

--- a/tests/sources/trace3.json
+++ b/tests/sources/trace3.json
@@ -1,50 +1,50 @@
-{"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace3.elpi\", line 12, column 0, characters 89-103:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace3.elpi\", line 12, column 0, characters 89-103:","main :- (p A0 3)."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["p X0 3"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["p","p X0 3"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace3.elpi\", line 3, column 0, characters 22-27:","File \"tests/sources/trace3.elpi\", line 4, column 0, characters 29-34:","File \"tests/sources/trace3.elpi\", line 5, column 0, characters 36-49:","File \"tests/sources/trace3.elpi\", line 6, column 0, characters 51-56:","File \"tests/sources/trace3.elpi\", line 7, column 0, characters 58-63:","File \"tests/sources/trace3.elpi\", line 8, column 0, characters 65-78:","File \"tests/sources/trace3.elpi\", line 9, column 0, characters 80-85:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace3.elpi\", line 3, column 0, characters 22-27:","(p 1 1) :- ."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 1"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify 3 with 1"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace3.elpi\", line 4, column 0, characters 29-34:","(p 2 2) :- ."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 2"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify 3 with 2"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace3.elpi\", line 5, column 0, characters 36-49:","(p 3 3) :- fail."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 3"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["fail"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["fail","fail"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["p","p X0 3"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace3.elpi\", line 6, column 0, characters 51-56:","File \"tests/sources/trace3.elpi\", line 7, column 0, characters 58-63:","File \"tests/sources/trace3.elpi\", line 8, column 0, characters 65-78:","File \"tests/sources/trace3.elpi\", line 9, column 0, characters 80-85:"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace3.elpi\", line 6, column 0, characters 51-56:","(p 4 1) :- ."]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 4"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify 3 with 1"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace3.elpi\", line 7, column 0, characters 58-63:","(p 4 2) :- ."]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 4"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify 3 with 2"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace3.elpi\", line 8, column 0, characters 65-78:","(p 4 3) :- fail."]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 4"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["7"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["fail"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["fail","fail"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["p","p X0 3"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace3.elpi\", line 9, column 0, characters 80-85:"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace3.elpi\", line 9, column 0, characters 80-85:","(p 5 3) :- ."]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 5"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step":0,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:newgoal","payload":["main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:curgoal","payload":["main","main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace3.elpi\", line 12, column 0, characters 89-103:"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace3.elpi\", line 12, column 0, characters 89-103:","main :- (p A0 3)."]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:subgoal","payload":["5"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:newgoal","payload":["p X0 3"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":["p","p X0 3"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace3.elpi\", line 3, column 0, characters 22-27:","File \"tests/sources/trace3.elpi\", line 4, column 0, characters 29-34:","File \"tests/sources/trace3.elpi\", line 5, column 0, characters 36-49:","File \"tests/sources/trace3.elpi\", line 6, column 0, characters 51-56:","File \"tests/sources/trace3.elpi\", line 7, column 0, characters 58-63:","File \"tests/sources/trace3.elpi\", line 8, column 0, characters 65-78:","File \"tests/sources/trace3.elpi\", line 9, column 0, characters 80-85:"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace3.elpi\", line 3, column 0, characters 22-27:","(p 1 1) :- ."]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 1"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify 3 with 1"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace3.elpi\", line 4, column 0, characters 29-34:","(p 2 2) :- ."]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 2"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify 3 with 2"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace3.elpi\", line 5, column 0, characters 36-49:","(p 3 3) :- fail."]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 3"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["6"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:newgoal","payload":["fail"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:curgoal","payload":["fail","fail"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":["p","p X0 3"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace3.elpi\", line 6, column 0, characters 51-56:","File \"tests/sources/trace3.elpi\", line 7, column 0, characters 58-63:","File \"tests/sources/trace3.elpi\", line 8, column 0, characters 65-78:","File \"tests/sources/trace3.elpi\", line 9, column 0, characters 80-85:"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace3.elpi\", line 6, column 0, characters 51-56:","(p 4 1) :- ."]}
+{"step":4,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 4"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify 3 with 1"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace3.elpi\", line 7, column 0, characters 58-63:","(p 4 2) :- ."]}
+{"step":4,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 4"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify 3 with 2"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace3.elpi\", line 8, column 0, characters 65-78:","(p 4 3) :- fail."]}
+{"step":4,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 4"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["7"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:newgoal","payload":["fail"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":5,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:curgoal","payload":["fail","fail"]}
+{"step":5,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":5,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":5,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":6,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":["p","p X0 3"]}
+{"step":6,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":6,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace3.elpi\", line 9, column 0, characters 80-85:"]}
+{"step":6,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace3.elpi\", line 9, column 0, characters 80-85:","(p 5 3) :- ."]}
+{"step":6,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 5"]}
+{"step":6,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}

--- a/tests/sources/trace4.json
+++ b/tests/sources/trace4.json
@@ -1,60 +1,60 @@
-{"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace4.elpi\", line 11, column 0, characters 74-95:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace4.elpi\", line 11, column 0, characters 74-95:","main :- (p A0 3 ; true)."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["p X0 3 ; true"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","p X0 3 ; true"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := p X0 3"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["p X0 3"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["p","p X0 3"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace4.elpi\", line 3, column 0, characters 22-27:","File \"tests/sources/trace4.elpi\", line 4, column 0, characters 29-34:","File \"tests/sources/trace4.elpi\", line 5, column 0, characters 36-49:","File \"tests/sources/trace4.elpi\", line 6, column 0, characters 51-56:","File \"tests/sources/trace4.elpi\", line 7, column 0, characters 58-63:","File \"tests/sources/trace4.elpi\", line 8, column 0, characters 65-70:"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace4.elpi\", line 3, column 0, characters 22-27:","(p 1 1) :- ."]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 1"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify 3 with 1"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace4.elpi\", line 4, column 0, characters 29-34:","(p 2 2) :- ."]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 2"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify 3 with 2"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace4.elpi\", line 5, column 0, characters 36-49:","(p 3 3) :- fail."]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 3"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["7"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["fail"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["fail","fail"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["p","p X0 3"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace4.elpi\", line 6, column 0, characters 51-56:","File \"tests/sources/trace4.elpi\", line 7, column 0, characters 58-63:","File \"tests/sources/trace4.elpi\", line 8, column 0, characters 65-70:"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace4.elpi\", line 6, column 0, characters 51-56:","(p 4 1) :- ."]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 4"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify 3 with 1"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace4.elpi\", line 7, column 0, characters 58-63:","(p 4 2) :- ."]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 4"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify 3 with 2"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace4.elpi\", line 8, column 0, characters 65-70:","(p 4 4) :- ."]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := 4"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify 3 with 4"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","p X0 3 ; true"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := true"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["8"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["true"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["true","true"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 11, column 0, characters 147-151:"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 11, column 0, characters 147-151:","true :- ."]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step":0,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:newgoal","payload":["main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:curgoal","payload":["main","main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace4.elpi\", line 11, column 0, characters 74-95:"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace4.elpi\", line 11, column 0, characters 74-95:","main :- (p A0 3 ; true)."]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:subgoal","payload":["5"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:newgoal","payload":["p X0 3 ; true"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":[";","p X0 3 ; true"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := p X0 3"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["6"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:newgoal","payload":["p X0 3"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:curgoal","payload":["p","p X0 3"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace4.elpi\", line 3, column 0, characters 22-27:","File \"tests/sources/trace4.elpi\", line 4, column 0, characters 29-34:","File \"tests/sources/trace4.elpi\", line 5, column 0, characters 36-49:","File \"tests/sources/trace4.elpi\", line 6, column 0, characters 51-56:","File \"tests/sources/trace4.elpi\", line 7, column 0, characters 58-63:","File \"tests/sources/trace4.elpi\", line 8, column 0, characters 65-70:"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace4.elpi\", line 3, column 0, characters 22-27:","(p 1 1) :- ."]}
+{"step":3,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 1"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify 3 with 1"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace4.elpi\", line 4, column 0, characters 29-34:","(p 2 2) :- ."]}
+{"step":3,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 2"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify 3 with 2"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace4.elpi\", line 5, column 0, characters 36-49:","(p 3 3) :- fail."]}
+{"step":3,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 3"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:subgoal","payload":["7"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:newgoal","payload":["fail"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:curgoal","payload":["fail","fail"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":5,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:curgoal","payload":["p","p X0 3"]}
+{"step":5,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":5,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace4.elpi\", line 6, column 0, characters 51-56:","File \"tests/sources/trace4.elpi\", line 7, column 0, characters 58-63:","File \"tests/sources/trace4.elpi\", line 8, column 0, characters 65-70:"]}
+{"step":5,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace4.elpi\", line 6, column 0, characters 51-56:","(p 4 1) :- ."]}
+{"step":5,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 4"]}
+{"step":5,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify 3 with 1"]}
+{"step":5,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace4.elpi\", line 7, column 0, characters 58-63:","(p 4 2) :- ."]}
+{"step":5,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 4"]}
+{"step":5,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify 3 with 2"]}
+{"step":5,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace4.elpi\", line 8, column 0, characters 65-70:","(p 4 4) :- ."]}
+{"step":5,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := 4"]}
+{"step":5,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify 3 with 4"]}
+{"step":5,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":6,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":[";","p X0 3 ; true"]}
+{"step":6,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":6,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":6,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step":6,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := true"]}
+{"step":6,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["8"]}
+{"step":6,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:newgoal","payload":["true"]}
+{"step":6,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":7,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:curgoal","payload":["true","true"]}
+{"step":7,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":7,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 11, column 0, characters 147-151:"]}
+{"step":7,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 11, column 0, characters 147-151:","true :- ."]}
+{"step":7,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}

--- a/tests/sources/trace_chr.json
+++ b/tests/sources/trace_chr.json
@@ -1,143 +1,143 @@
-{"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 19, column 0, characters 349-420:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 19, column 0, characters 349-420:","main :- (even A0), (declare_constraint true A0), (A0 = s A1), \n (not (even A1))."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["even X0"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["declare_constraint true X0"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["7"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["X0 = s X1"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["8"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["not (even X1)"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["even","even X0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:","(even (as uvar A0)) :- (declare_constraint (even A0) A0)."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := X0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["9"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["declare_constraint (even X0) X0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["declare_constraint","declare_constraint (even X0) X0"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["declare_constraint"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["10"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["even X0"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["declare_constraint","declare_constraint true X0"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["declare_constraint"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["11"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["true"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=","X0 = s X1"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["eq"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["="]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := s X1"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign:resume","payload" : ["11 10"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:eq","payload" : ["success"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule","payload" : ["resume"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:resume:resumed","payload" : ["true"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:resume:resumed","payload" : ["even (s X1)"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:resume","payload" : ["success"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["true","true"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 11, column 0, characters 147-151:"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 11, column 0, characters 147-151:","true :- ."]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["even","even (s X1)"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 14, column 0, characters 226-245:"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 14, column 0, characters 226-245:","(even (s A0)) :- (odd A0)."]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := X1"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["12"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["odd X1"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["odd","odd X1"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 17, column 0, characters 299-346:"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 17, column 0, characters 299-346:","(odd (as uvar A0)) :- (declare_constraint (odd A0) A0)."]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := X1"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["13"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["declare_constraint (odd X1) X1"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["declare_constraint","declare_constraint (odd X1) X1"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["declare_constraint"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["14"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["odd X1"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["not","not (even X1)"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","(not A0) :- A0, !, fail."]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := even X1"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["15"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["even X1"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["16"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["!"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["17"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["fail"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["even","even X1"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:","(even (as uvar A0)) :- (declare_constraint (even A0) A0)."]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := X1"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["18"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["declare_constraint (even X1) X1"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["declare_constraint","declare_constraint (even X1) X1"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["declare_constraint"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["19"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["even X1"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:CHR:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 1, column 21, characters 21-66:"," \\ (even A0) (odd A0) | (odd z) <=> (true)"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--421 []"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["odd z"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["odd","odd z"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:CHR:rule-failed","payload" : []}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:CHR:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 2, column 45, characters 67-116:"," \\ (even A0) (odd A0) | (odd (s z)) <=> (fail)"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 2,"name" : "user:assign","payload" : ["A0 := uvar frozen--422 []"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:newgoal","payload" : ["odd (s z)"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:curgoal","payload" : ["odd","odd (s z)"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 13, column 0, characters 205-224:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 13, column 0, characters 205-224:","(odd (s A0)) :- (even A0)."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 2,"name" : "user:assign","payload" : ["A0 := z"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 2,"name" : "user:subgoal","payload" : ["22"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:newgoal","payload" : ["even z"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:curgoal","payload" : ["even","even z"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_chr.elpi\", line 11, column 0, characters 196-202:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_chr.elpi\", line 11, column 0, characters 196-202:","(even z) :- ."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 2,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["23"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["_ => fail"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:CHR:rule-fired","payload" : ["File \"tests/sources/trace_chr.elpi\", line 2, column 45, characters 67-116:"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:CHR:rule-remove-constraints","payload" : ["19","14"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:CHR:store:before","payload" : ["19"," even X1  /* suspended on X1 */"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:CHR:store:before","payload" : ["14"," odd X1  /* suspended on X1 */"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:CHR:resumed","payload" : ["_ => fail"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","_ => fail"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["24"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["fail"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:new-hyps","payload" : []}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["fail","fail"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["not","not (even X1)"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:","(not _) :- ."]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step":0,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:newgoal","payload":["main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:curgoal","payload":["main","main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_chr.elpi\", line 19, column 0, characters 349-420:"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_chr.elpi\", line 19, column 0, characters 349-420:","main :- (even A0), (declare_constraint true A0), (A0 = s A1), \n (not (even A1))."]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:subgoal","payload":["5"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:newgoal","payload":["even X0"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["6"]}
+{"step":1,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:newgoal","payload":["declare_constraint true X0"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["7"]}
+{"step":1,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:newgoal","payload":["X0 = s X1"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["8"]}
+{"step":1,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:newgoal","payload":["not (even X1)"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":["even","even X0"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:","(even (as uvar A0)) :- (declare_constraint (even A0) A0)."]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := X0"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["9"]}
+{"step":2,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:newgoal","payload":["declare_constraint (even X0) X0"]}
+{"step":2,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:curgoal","payload":["declare_constraint","declare_constraint (even X0) X0"]}
+{"step":3,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":3,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:builtin:name","payload":["declare_constraint"]}
+{"step":3,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:subgoal","payload":["10"]}
+{"step":3,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:newgoal","payload":["even X0"]}
+{"step":3,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}
+{"step":4,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:curgoal","payload":["declare_constraint","declare_constraint true X0"]}
+{"step":4,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":4,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:builtin:name","payload":["declare_constraint"]}
+{"step":4,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:subgoal","payload":["11"]}
+{"step":4,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:newgoal","payload":["true"]}
+{"step":4,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}
+{"step":5,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:curgoal","payload":["=","X0 = s X1"]}
+{"step":5,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule","payload":["eq"]}
+{"step":5,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:builtin:name","payload":["="]}
+{"step":5,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := s X1"]}
+{"step":5,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign:resume","payload":["11 10"]}
+{"step":5,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:eq","payload":["success"]}
+{"step":6,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule","payload":["resume"]}
+{"step":6,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:resume:resumed","payload":["true"]}
+{"step":6,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:resume:resumed","payload":["even (s X1)"]}
+{"step":6,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:resume","payload":["success"]}
+{"step":7,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:curgoal","payload":["true","true"]}
+{"step":7,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":7,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 11, column 0, characters 147-151:"]}
+{"step":7,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 11, column 0, characters 147-151:","true :- ."]}
+{"step":7,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:curgoal","payload":["even","even (s X1)"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_chr.elpi\", line 14, column 0, characters 226-245:"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_chr.elpi\", line 14, column 0, characters 226-245:","(even (s A0)) :- (odd A0)."]}
+{"step":8,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := X1"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:subgoal","payload":["12"]}
+{"step":8,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:newgoal","payload":["odd X1"]}
+{"step":8,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":9,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:curgoal","payload":["odd","odd X1"]}
+{"step":9,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":9,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_chr.elpi\", line 17, column 0, characters 299-346:"]}
+{"step":9,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_chr.elpi\", line 17, column 0, characters 299-346:","(odd (as uvar A0)) :- (declare_constraint (odd A0) A0)."]}
+{"step":9,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := X1"]}
+{"step":9,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:subgoal","payload":["13"]}
+{"step":9,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:newgoal","payload":["declare_constraint (odd X1) X1"]}
+{"step":9,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":10,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:curgoal","payload":["declare_constraint","declare_constraint (odd X1) X1"]}
+{"step":10,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":10,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:builtin:name","payload":["declare_constraint"]}
+{"step":10,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:subgoal","payload":["14"]}
+{"step":10,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:newgoal","payload":["odd X1"]}
+{"step":10,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}
+{"step":11,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:curgoal","payload":["not","not (even X1)"]}
+{"step":11,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":11,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
+{"step":11,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","(not A0) :- A0, !, fail."]}
+{"step":11,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := even X1"]}
+{"step":11,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:subgoal","payload":["15"]}
+{"step":11,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:newgoal","payload":["even X1"]}
+{"step":11,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:subgoal","payload":["16"]}
+{"step":11,"kind":["Info"],"goal_id":16,"runtime_id":0,"name":"user:newgoal","payload":["!"]}
+{"step":11,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:subgoal","payload":["17"]}
+{"step":11,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:newgoal","payload":["fail"]}
+{"step":11,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":12,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:curgoal","payload":["even","even X1"]}
+{"step":12,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":12,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:"]}
+{"step":12,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_chr.elpi\", line 16, column 0, characters 248-297:","(even (as uvar A0)) :- (declare_constraint (even A0) A0)."]}
+{"step":12,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := X1"]}
+{"step":12,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:subgoal","payload":["18"]}
+{"step":12,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:newgoal","payload":["declare_constraint (even X1) X1"]}
+{"step":12,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":13,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:curgoal","payload":["declare_constraint","declare_constraint (even X1) X1"]}
+{"step":13,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":13,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:rule:builtin:name","payload":["declare_constraint"]}
+{"step":13,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:subgoal","payload":["19"]}
+{"step":13,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:newgoal","payload":["even X1"]}
+{"step":13,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}
+{"step":14,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:CHR:try","payload":["File \"tests/sources/trace_chr.elpi\", line 1, column 21, characters 21-66:"," \\ (even A0) (odd A0) | (odd z) <=> (true)"]}
+{"step":0,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := uvar frozen--421 []"]}
+{"step":0,"kind":["Info"],"goal_id":20,"runtime_id":1,"name":"user:newgoal","payload":["odd z"]}
+{"step":1,"kind":["Info"],"goal_id":20,"runtime_id":1,"name":"user:curgoal","payload":["odd","odd z"]}
+{"step":1,"kind":["Info"],"goal_id":20,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":20,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":1,"kind":["Info"],"goal_id":20,"runtime_id":1,"name":"user:rule:backchain","payload":["fail"]}
+{"step":14,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:CHR:rule-failed","payload":[]}
+{"step":14,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:CHR:try","payload":["File \"tests/sources/trace_chr.elpi\", line 2, column 45, characters 67-116:"," \\ (even A0) (odd A0) | (odd (s z)) <=> (fail)"]}
+{"step":0,"kind":["Info"],"goal_id":0,"runtime_id":2,"name":"user:assign","payload":["A0 := uvar frozen--422 []"]}
+{"step":0,"kind":["Info"],"goal_id":21,"runtime_id":2,"name":"user:newgoal","payload":["odd (s z)"]}
+{"step":1,"kind":["Info"],"goal_id":21,"runtime_id":2,"name":"user:curgoal","payload":["odd","odd (s z)"]}
+{"step":1,"kind":["Info"],"goal_id":21,"runtime_id":2,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":21,"runtime_id":2,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_chr.elpi\", line 13, column 0, characters 205-224:"]}
+{"step":1,"kind":["Info"],"goal_id":21,"runtime_id":2,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_chr.elpi\", line 13, column 0, characters 205-224:","(odd (s A0)) :- (even A0)."]}
+{"step":1,"kind":["Info"],"goal_id":0,"runtime_id":2,"name":"user:assign","payload":["A0 := z"]}
+{"step":1,"kind":["Info"],"goal_id":21,"runtime_id":2,"name":"user:subgoal","payload":["22"]}
+{"step":1,"kind":["Info"],"goal_id":22,"runtime_id":2,"name":"user:newgoal","payload":["even z"]}
+{"step":1,"kind":["Info"],"goal_id":22,"runtime_id":2,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":22,"runtime_id":2,"name":"user:curgoal","payload":["even","even z"]}
+{"step":2,"kind":["Info"],"goal_id":22,"runtime_id":2,"name":"user:rule","payload":["backchain"]}
+{"step":2,"kind":["Info"],"goal_id":22,"runtime_id":2,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_chr.elpi\", line 11, column 0, characters 196-202:"]}
+{"step":2,"kind":["Info"],"goal_id":22,"runtime_id":2,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_chr.elpi\", line 11, column 0, characters 196-202:","(even z) :- ."]}
+{"step":2,"kind":["Info"],"goal_id":22,"runtime_id":2,"name":"user:rule:backchain","payload":["success"]}
+{"step":14,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:subgoal","payload":["23"]}
+{"step":14,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:newgoal","payload":["_ => fail"]}
+{"step":14,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:CHR:rule-fired","payload":["File \"tests/sources/trace_chr.elpi\", line 2, column 45, characters 67-116:"]}
+{"step":14,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:CHR:rule-remove-constraints","payload":["19","14"]}
+{"step":14,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:CHR:store:before","payload":["19"," even X1  /* suspended on X1 */"]}
+{"step":14,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:CHR:store:before","payload":["14"," odd X1  /* suspended on X1 */"]}
+{"step":14,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:CHR:resumed","payload":["_ => fail"]}
+{"step":15,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:curgoal","payload":["=>","_ => fail"]}
+{"step":15,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":15,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:subgoal","payload":["24"]}
+{"step":15,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:newgoal","payload":["fail"]}
+{"step":15,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:new-hyps","payload":[]}
+{"step":15,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":16,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:curgoal","payload":["fail","fail"]}
+{"step":16,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":16,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":16,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":17,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:curgoal","payload":["not","not (even X1)"]}
+{"step":17,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":17,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
+{"step":17,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:","(not _) :- ."]}
+{"step":17,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}

--- a/tests/sources/trace_cut.json
+++ b/tests/sources/trace_cut.json
@@ -1,82 +1,82 @@
-{"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_cut.elpi\", line 12, column 0, characters 78-87:","File \"tests/sources/trace_cut.elpi\", line 13, column 0, characters 89-121:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_cut.elpi\", line 12, column 0, characters 78-87:","main :- p."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["p"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["p","p"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_cut.elpi\", line 3, column 0, characters 9-18:","File \"tests/sources/trace_cut.elpi\", line 4, column 0, characters 20-32:","File \"tests/sources/trace_cut.elpi\", line 5, column 0, characters 34-35:","File \"tests/sources/trace_cut.elpi\", line 6, column 0, characters 37-49:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_cut.elpi\", line 3, column 0, characters 9-18:","p :- fail."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["fail"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["fail","fail"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["p","p (! !)"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_cut.elpi\", line 4, column 0, characters 20-32:","File \"tests/sources/trace_cut.elpi\", line 5, column 0, characters 34-35:","File \"tests/sources/trace_cut.elpi\", line 6, column 0, characters 37-49:"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_cut.elpi\", line 4, column 0, characters 20-32:","p :- !, fail."]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["7"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["!"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["8"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["fail"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["!","!"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["5","File \"tests/sources/trace_cut.elpi\", line 5, column 0, characters 34-35:","p :- ."]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["5","File \"tests/sources/trace_cut.elpi\", line 6, column 0, characters 37-49:","p :- (print 1)."]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:cut","payload" : ["success"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["fail","fail"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main (! !)"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_cut.elpi\", line 13, column 0, characters 89-121:"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_cut.elpi\", line 13, column 0, characters 89-121:","main :- q, !, (q => (q :- !) => q)."]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["9"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["q"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["10"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["!"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["11"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["q => (q :- !) => q"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["q","q"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_cut.elpi\", line 9, column 0, characters 60-61:","File \"tests/sources/trace_cut.elpi\", line 10, column 0, characters 63-75:"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_cut.elpi\", line 9, column 0, characters 60-61:","q :- ."]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["!","!"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["9","File \"tests/sources/trace_cut.elpi\", line 10, column 0, characters 63-75:","q :- (print 2)."]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:cut","payload" : ["success"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","q => (q :- !) => q"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["12"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["(q :- !) => q"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["q :- ."]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","(q :- !) => q"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["13"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["q"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["q :- !."]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["q","q"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:11)\", line 1, column 0, characters 0-0:","File \"(context step_id:10)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace_cut.elpi\", line 9, column 0, characters 60-61:","File \"tests/sources/trace_cut.elpi\", line 10, column 0, characters 63-75:"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:11)\", line 1, column 0, characters 0-0:","q :- !."]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["14"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["!"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["!","!"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["13","File \"(context step_id:10)\", line 1, column 0, characters 0-0:","q :- ."]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["13","File \"tests/sources/trace_cut.elpi\", line 9, column 0, characters 60-61:","q :- ."]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["13","File \"tests/sources/trace_cut.elpi\", line 10, column 0, characters 63-75:","q :- (print 2)."]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:cut","payload" : ["success"]}
+{"step":0,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:newgoal","payload":["main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:curgoal","payload":["main","main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_cut.elpi\", line 12, column 0, characters 78-87:","File \"tests/sources/trace_cut.elpi\", line 13, column 0, characters 89-121:"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_cut.elpi\", line 12, column 0, characters 78-87:","main :- p."]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:subgoal","payload":["5"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:newgoal","payload":["p"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":["p","p"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_cut.elpi\", line 3, column 0, characters 9-18:","File \"tests/sources/trace_cut.elpi\", line 4, column 0, characters 20-32:","File \"tests/sources/trace_cut.elpi\", line 5, column 0, characters 34-35:","File \"tests/sources/trace_cut.elpi\", line 6, column 0, characters 37-49:"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_cut.elpi\", line 3, column 0, characters 9-18:","p :- fail."]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["6"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:newgoal","payload":["fail"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:curgoal","payload":["fail","fail"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":["p","p (! !)"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_cut.elpi\", line 4, column 0, characters 20-32:","File \"tests/sources/trace_cut.elpi\", line 5, column 0, characters 34-35:","File \"tests/sources/trace_cut.elpi\", line 6, column 0, characters 37-49:"]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_cut.elpi\", line 4, column 0, characters 20-32:","p :- !, fail."]}
+{"step":4,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["7"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:newgoal","payload":["!"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:subgoal","payload":["8"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:newgoal","payload":["fail"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":5,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:curgoal","payload":["!","!"]}
+{"step":5,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule","payload":["cut"]}
+{"step":5,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["5","File \"tests/sources/trace_cut.elpi\", line 5, column 0, characters 34-35:","p :- ."]}
+{"step":5,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["5","File \"tests/sources/trace_cut.elpi\", line 6, column 0, characters 37-49:","p :- (print 1)."]}
+{"step":5,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:cut","payload":["success"]}
+{"step":6,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:curgoal","payload":["fail","fail"]}
+{"step":6,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":6,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":6,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":7,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:curgoal","payload":["main","main (! !)"]}
+{"step":7,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":7,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_cut.elpi\", line 13, column 0, characters 89-121:"]}
+{"step":7,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_cut.elpi\", line 13, column 0, characters 89-121:","main :- q, !, (q => (q :- !) => q)."]}
+{"step":7,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:subgoal","payload":["9"]}
+{"step":7,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:newgoal","payload":["q"]}
+{"step":7,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:subgoal","payload":["10"]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:newgoal","payload":["!"]}
+{"step":7,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:subgoal","payload":["11"]}
+{"step":7,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:newgoal","payload":["q => (q :- !) => q"]}
+{"step":7,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":8,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:curgoal","payload":["q","q"]}
+{"step":8,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":8,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_cut.elpi\", line 9, column 0, characters 60-61:","File \"tests/sources/trace_cut.elpi\", line 10, column 0, characters 63-75:"]}
+{"step":8,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_cut.elpi\", line 9, column 0, characters 60-61:","q :- ."]}
+{"step":8,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":9,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:curgoal","payload":["!","!"]}
+{"step":9,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule","payload":["cut"]}
+{"step":9,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["9","File \"tests/sources/trace_cut.elpi\", line 10, column 0, characters 63-75:","q :- (print 2)."]}
+{"step":9,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:cut","payload":["success"]}
+{"step":10,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:curgoal","payload":["=>","q => (q :- !) => q"]}
+{"step":10,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":10,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:subgoal","payload":["12"]}
+{"step":10,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:newgoal","payload":["(q :- !) => q"]}
+{"step":10,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:new-hyps","payload":["q :- ."]}
+{"step":10,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":11,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:curgoal","payload":["=>","(q :- !) => q"]}
+{"step":11,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":11,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:subgoal","payload":["13"]}
+{"step":11,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:newgoal","payload":["q"]}
+{"step":11,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:new-hyps","payload":["q :- !."]}
+{"step":11,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:curgoal","payload":["q","q"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"(context step_id:11)\", line 1, column 0, characters 0-0:","File \"(context step_id:10)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace_cut.elpi\", line 9, column 0, characters 60-61:","File \"tests/sources/trace_cut.elpi\", line 10, column 0, characters 63-75:"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"(context step_id:11)\", line 1, column 0, characters 0-0:","q :- !."]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:subgoal","payload":["14"]}
+{"step":12,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:newgoal","payload":["!"]}
+{"step":12,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":13,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:curgoal","payload":["!","!"]}
+{"step":13,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule","payload":["cut"]}
+{"step":13,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["13","File \"(context step_id:10)\", line 1, column 0, characters 0-0:","q :- ."]}
+{"step":13,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["13","File \"tests/sources/trace_cut.elpi\", line 9, column 0, characters 60-61:","q :- ."]}
+{"step":13,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["13","File \"tests/sources/trace_cut.elpi\", line 10, column 0, characters 63-75:","q :- (print 2)."]}
+{"step":13,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule:cut","payload":["success"]}

--- a/tests/sources/trace_findall.json
+++ b/tests/sources/trace_findall.json
@@ -1,53 +1,53 @@
-{"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_findall.elpi\", line 6, column 0, characters 37-75:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_findall.elpi\", line 6, column 0, characters 37-75:","main :- (std.findall (p _) A0), (print A0)."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["std.findall (p _) X0"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["print X0"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["std.findall","std.findall (p _) X0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin_stdlib.elpi\", line 322, column 0, characters 10227-10263:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin_stdlib.elpi\", line 322, column 0, characters 10227-10263:","(std.findall A0 A1) :- (findall_solutions A0 A1)."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := p _"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := X0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["7"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["findall_solutions (p _) X0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["findall_solutions","findall_solutions (p _) X0"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["findall"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["p X0"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["p","p X0"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_findall.elpi\", line 2, column 0, characters 14-17:","File \"tests/sources/trace_findall.elpi\", line 3, column 0, characters 19-22:","File \"tests/sources/trace_findall.elpi\", line 4, column 0, characters 24-34:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_findall.elpi\", line 2, column 0, characters 14-17:","(p 1) :- ."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X0 := 1"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["p","p X0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_findall.elpi\", line 3, column 0, characters 19-22:","File \"tests/sources/trace_findall.elpi\", line 4, column 0, characters 24-34:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_findall.elpi\", line 3, column 0, characters 19-22:","(p 2) :- ."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X0 := 2"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["p","p X0"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_findall.elpi\", line 4, column 0, characters 24-34:"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_findall.elpi\", line 4, column 0, characters 24-34:","(p 3) :- (p 2)."]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X0 := 3"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["9"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["p 2"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["p","p 2"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_findall.elpi\", line 3, column 0, characters 19-22:"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_findall.elpi\", line 3, column 0, characters 19-22:","(p 2) :- ."]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := [p 1, p 2, p 3]"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:findall","payload" : ["success"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["print","print [p 1, p 2, p 3]"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["print"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
+{"step":0,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:newgoal","payload":["main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:curgoal","payload":["main","main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_findall.elpi\", line 6, column 0, characters 37-75:"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_findall.elpi\", line 6, column 0, characters 37-75:","main :- (std.findall (p _) A0), (print A0)."]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:subgoal","payload":["5"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:newgoal","payload":["std.findall (p _) X0"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["6"]}
+{"step":1,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:newgoal","payload":["print X0"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":["std.findall","std.findall (p _) X0"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin_stdlib.elpi\", line 322, column 0, characters 10227-10263:"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin_stdlib.elpi\", line 322, column 0, characters 10227-10263:","(std.findall A0 A1) :- (findall_solutions A0 A1)."]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := p _"]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A1 := X0"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["7"]}
+{"step":2,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:newgoal","payload":["findall_solutions (p _) X0"]}
+{"step":2,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:curgoal","payload":["findall_solutions","findall_solutions (p _) X0"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule","payload":["findall"]}
+{"step":0,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:newgoal","payload":["p X0"]}
+{"step":1,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:curgoal","payload":["p","p X0"]}
+{"step":1,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_findall.elpi\", line 2, column 0, characters 14-17:","File \"tests/sources/trace_findall.elpi\", line 3, column 0, characters 19-22:","File \"tests/sources/trace_findall.elpi\", line 4, column 0, characters 24-34:"]}
+{"step":1,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_findall.elpi\", line 2, column 0, characters 14-17:","(p 1) :- ."]}
+{"step":1,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X0 := 1"]}
+{"step":1,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:curgoal","payload":["p","p X0"]}
+{"step":2,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":2,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_findall.elpi\", line 3, column 0, characters 19-22:","File \"tests/sources/trace_findall.elpi\", line 4, column 0, characters 24-34:"]}
+{"step":2,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_findall.elpi\", line 3, column 0, characters 19-22:","(p 2) :- ."]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X0 := 2"]}
+{"step":2,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:curgoal","payload":["p","p X0"]}
+{"step":3,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":3,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_findall.elpi\", line 4, column 0, characters 24-34:"]}
+{"step":3,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_findall.elpi\", line 4, column 0, characters 24-34:","(p 3) :- (p 2)."]}
+{"step":3,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X0 := 3"]}
+{"step":3,"kind":["Info"],"goal_id":8,"runtime_id":1,"name":"user:subgoal","payload":["9"]}
+{"step":3,"kind":["Info"],"goal_id":9,"runtime_id":1,"name":"user:newgoal","payload":["p 2"]}
+{"step":3,"kind":["Info"],"goal_id":9,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":4,"kind":["Info"],"goal_id":9,"runtime_id":1,"name":"user:curgoal","payload":["p","p 2"]}
+{"step":4,"kind":["Info"],"goal_id":9,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":4,"kind":["Info"],"goal_id":9,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_findall.elpi\", line 3, column 0, characters 19-22:"]}
+{"step":4,"kind":["Info"],"goal_id":9,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_findall.elpi\", line 3, column 0, characters 19-22:","(p 2) :- ."]}
+{"step":4,"kind":["Info"],"goal_id":9,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := [p 1, p 2, p 3]"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:findall","payload":["success"]}
+{"step":4,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:curgoal","payload":["print","print [p 1, p 2, p 3]"]}
+{"step":4,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":4,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:builtin:name","payload":["print"]}
+{"step":4,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}

--- a/tests/sources/trace_implication.json
+++ b/tests/sources/trace_implication.json
@@ -1,169 +1,169 @@
-{"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace_implication.elpi\", line 8, column 0, characters 136-265:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace_implication.elpi\", line 8, column 0, characters 136-265:","main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true)."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := x0 => z0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["x0 => z0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","x0 => z0"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["7"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z0"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["x0 :- ."]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z0","z0"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := (x1 , y1) => z1 ;\n       [x2, y2] => z2 ;\n        [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["8"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := (x1 , y1) => z1"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["9"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["(x1 , y1) => z1"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","(x1 , y1) => z1"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["10"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z1"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["x1 :- .","y1 :- ."]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z1","z1"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [x2, y2] => z2 ;\n       [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["11"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [x2, y2] => z2"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["12"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[x2, y2] => z2"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","[x2, y2] => z2"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["13"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z2"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["x2 :- .","y2 :- ."]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z2","z2"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["14"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [(x3 :- !), (y3 :- !)] => z3"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["15"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[(x3 :- !), (y3 :- !)] => z3"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","[(x3 :- !), (y3 :- !)] => z3"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["16"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z3"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["x3 :- !.","y3 :- !."]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z3","z3"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["17"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["(x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","(x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := (x4 :- y4 , !) => z4"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["18"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["(x4 :- y4 , !) => z4"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","(x4 :- y4 , !) => z4"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["19"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z4"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["x4 :- y4, !."]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z4","z4"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","(x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [] => z5 ; true"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["20"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[] => z5 ; true"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[] => z5 ; true"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := [] => z5"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["21"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["[] => z5"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","[] => z5"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["22"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["z5"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:new-hyps","payload" : []}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["z5","z5"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:curgoal","payload" : [";","[] => z5 ; true"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := true"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["23"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["true"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["true","true"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 11, column 0, characters 147-151:"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 11, column 0, characters 147-151:","true :- ."]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
+{"step":0,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:newgoal","payload":["main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:curgoal","payload":["main","main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace_implication.elpi\", line 8, column 0, characters 136-265:"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace_implication.elpi\", line 8, column 0, characters 136-265:","main :- (x0 => z0 ;\n          (x1 , y1) => z1 ;\n           [x2, y2] => z2 ;\n            [(x3 :- !), (y3 :- !)] => z3 ;\n             (x4 :- y4 , !) => z4 ; [] => z5 ; true)."]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:subgoal","payload":["5"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:newgoal","payload":["x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":[";","x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := x0 => z0"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["6"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:newgoal","payload":["x0 => z0"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:curgoal","payload":["=>","x0 => z0"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:subgoal","payload":["7"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:newgoal","payload":["z0"]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:new-hyps","payload":["x0 :- ."]}
+{"step":3,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:curgoal","payload":["z0","z0"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":5,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":[";","x0 => z0 ;\n (x1 , y1) => z1 ;\n  [x2, y2] => z2 ;\n   [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":5,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":5,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":5,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step":5,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := (x1 , y1) => z1 ;\n       [x2, y2] => z2 ;\n        [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":5,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["8"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:newgoal","payload":["(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":6,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:curgoal","payload":[";","(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":6,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":6,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":6,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step":6,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := (x1 , y1) => z1"]}
+{"step":6,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:subgoal","payload":["9"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:newgoal","payload":["(x1 , y1) => z1"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":7,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:curgoal","payload":["=>","(x1 , y1) => z1"]}
+{"step":7,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":7,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:subgoal","payload":["10"]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:newgoal","payload":["z1"]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:new-hyps","payload":["x1 :- .","y1 :- ."]}
+{"step":7,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:curgoal","payload":["z1","z1"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":8,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":9,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:curgoal","payload":[";","(x1 , y1) => z1 ;\n [x2, y2] => z2 ;\n  [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":9,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":9,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":9,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step":9,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := [x2, y2] => z2 ;\n       [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":9,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:subgoal","payload":["11"]}
+{"step":9,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:newgoal","payload":["[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":9,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":10,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:curgoal","payload":[";","[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":10,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":10,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":10,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step":10,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := [x2, y2] => z2"]}
+{"step":10,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:subgoal","payload":["12"]}
+{"step":10,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:newgoal","payload":["[x2, y2] => z2"]}
+{"step":10,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":11,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:curgoal","payload":["=>","[x2, y2] => z2"]}
+{"step":11,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":11,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:subgoal","payload":["13"]}
+{"step":11,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:newgoal","payload":["z2"]}
+{"step":11,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:new-hyps","payload":["x2 :- .","y2 :- ."]}
+{"step":11,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:curgoal","payload":["z2","z2"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":12,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":13,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:curgoal","payload":[";","[x2, y2] => z2 ;\n [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":13,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":13,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":13,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step":13,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := [(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":13,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:subgoal","payload":["14"]}
+{"step":13,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:newgoal","payload":["[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":13,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":14,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:curgoal","payload":[";","[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":14,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":14,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":14,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step":14,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := [(x3 :- !), (y3 :- !)] => z3"]}
+{"step":14,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:subgoal","payload":["15"]}
+{"step":14,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:newgoal","payload":["[(x3 :- !), (y3 :- !)] => z3"]}
+{"step":14,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":15,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:curgoal","payload":["=>","[(x3 :- !), (y3 :- !)] => z3"]}
+{"step":15,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":15,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:subgoal","payload":["16"]}
+{"step":15,"kind":["Info"],"goal_id":16,"runtime_id":0,"name":"user:newgoal","payload":["z3"]}
+{"step":15,"kind":["Info"],"goal_id":16,"runtime_id":0,"name":"user:new-hyps","payload":["x3 :- !.","y3 :- !."]}
+{"step":15,"kind":["Info"],"goal_id":16,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":16,"kind":["Info"],"goal_id":16,"runtime_id":0,"name":"user:curgoal","payload":["z3","z3"]}
+{"step":16,"kind":["Info"],"goal_id":16,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":16,"kind":["Info"],"goal_id":16,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":16,"kind":["Info"],"goal_id":16,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":17,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:curgoal","payload":[";","[(x3 :- !), (y3 :- !)] => z3 ; (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":17,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":17,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":17,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step":17,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := (x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":17,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:subgoal","payload":["17"]}
+{"step":17,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:newgoal","payload":["(x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":17,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":18,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:curgoal","payload":[";","(x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":18,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":18,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":18,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step":18,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := (x4 :- y4 , !) => z4"]}
+{"step":18,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:subgoal","payload":["18"]}
+{"step":18,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:newgoal","payload":["(x4 :- y4 , !) => z4"]}
+{"step":18,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":19,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:curgoal","payload":["=>","(x4 :- y4 , !) => z4"]}
+{"step":19,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":19,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:subgoal","payload":["19"]}
+{"step":19,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:newgoal","payload":["z4"]}
+{"step":19,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:new-hyps","payload":["x4 :- y4, !."]}
+{"step":19,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":20,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:curgoal","payload":["z4","z4"]}
+{"step":20,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":20,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":20,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":21,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:curgoal","payload":[";","(x4 :- y4 , !) => z4 ; [] => z5 ; true"]}
+{"step":21,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":21,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":21,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step":21,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := [] => z5 ; true"]}
+{"step":21,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:subgoal","payload":["20"]}
+{"step":21,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:newgoal","payload":["[] => z5 ; true"]}
+{"step":21,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":22,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:curgoal","payload":[";","[] => z5 ; true"]}
+{"step":22,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":22,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":22,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 41, column 0, characters 586-598:","(A0 ; _) :- A0."]}
+{"step":22,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := [] => z5"]}
+{"step":22,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:subgoal","payload":["21"]}
+{"step":22,"kind":["Info"],"goal_id":21,"runtime_id":0,"name":"user:newgoal","payload":["[] => z5"]}
+{"step":22,"kind":["Info"],"goal_id":21,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":23,"kind":["Info"],"goal_id":21,"runtime_id":0,"name":"user:curgoal","payload":["=>","[] => z5"]}
+{"step":23,"kind":["Info"],"goal_id":21,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":23,"kind":["Info"],"goal_id":21,"runtime_id":0,"name":"user:subgoal","payload":["22"]}
+{"step":23,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:newgoal","payload":["z5"]}
+{"step":23,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:new-hyps","payload":[]}
+{"step":23,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":24,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:curgoal","payload":["z5","z5"]}
+{"step":24,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":24,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":24,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:rule:backchain","payload":["fail"]}
+{"step":25,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:curgoal","payload":[";","[] => z5 ; true"]}
+{"step":25,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":25,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:"]}
+{"step":25,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 43, column 0, characters 601-613:","(_ ; A0) :- A0."]}
+{"step":25,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := true"]}
+{"step":25,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:subgoal","payload":["23"]}
+{"step":25,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:newgoal","payload":["true"]}
+{"step":25,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":26,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:curgoal","payload":["true","true"]}
+{"step":26,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":26,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 11, column 0, characters 147-151:"]}
+{"step":26,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 11, column 0, characters 147-151:","true :- ."]}
+{"step":26,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}

--- a/tests/sources/trace_w.json
+++ b/tests/sources/trace_w.json
@@ -1,626 +1,626 @@
-{"step" : 0,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["main","main"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 177, column 0, characters 4824-4843:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 177, column 0, characters 4824-4843:","main :- (tests [2])."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 4,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["5"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["tests [2]"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["tests","tests [2]"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 175, column 0, characters 4785-4821:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 175, column 0, characters 4785-4821:","(tests [A0]) :- (test A0 A1), (typecheck A1)."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := 2"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 5,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["6"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["test 2 X0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["7"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["typecheck X0"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["test","test 2 X0"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 184, column 0, characters 4948-5011:"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 184, column 0, characters 4948-5011:","(test 2 (let (lam (c0 \\ c0)) A0 (c0 \\ (app c0 (global []))))) :- ."]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X0 := let (lam c0 \\ c0) X1 c0 \\ app c0 (global [])"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 6,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["typecheck","typecheck (let (lam c0 \\ c0) X1 c0 \\ app c0 (global []))"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 167, column 0, characters 4665-4756:"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 167, column 0, characters 4665-4756:","(typecheck A0) :- (print Checking: A0), (theta []), (of A0 A1), !, \n (print A0  :  A1), print."]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := let (lam c0 \\ c0) X1 c0 \\ app c0 (global [])"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 7,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["8"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["print Checking: (let (lam c0 \\ c0) X1 c0 \\ app c0 (global []))"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["9"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["theta []"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["10"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of (let (lam c0 \\ c0) X1 c0 \\ app c0 (global [])) X2"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["11"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["!"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["12"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["print (let (lam c0 \\ c0) X1 c0 \\ app c0 (global []))  :  X2"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["13"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["print"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["print","print Checking: (let (lam c0 \\ c0) X1 c0 \\ app c0 (global []))"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["print"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 8,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["theta","theta []"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 76, column 0, characters 1782-1821:"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 76, column 0, characters 1782-1821:","(theta A0) :- (new_constraint (theta A0) [_])."]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := []"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 9,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["14"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["new_constraint (theta []) [_]"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["new_constraint","new_constraint (theta []) [_]"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:","(new_constraint A0 A1) :- (declare_constraint A0 A1)."]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := theta []"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := [_]"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 14,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["15"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["declare_constraint (theta []) [_]"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["declare_constraint","declare_constraint (theta []) [_]"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["declare_constraint"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["16"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 16,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["theta []"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 15,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of (let (lam c0 \\ c0) X1 c0 \\ app c0 (global [])) X2"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 11, column 0, characters 177-284:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 11, column 0, characters 177-284:","(of (let A0 A2 A3) (mono A4)) :- (of A0 (mono A1)), (gammabar (mono A1) A2), \n (pi c0 \\ (of c0 A2 => of (A3 c0) (mono A4)))."]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := lam c0 \\ c0"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A2 := X1"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A3 := c0 \\\napp c0 (global [])"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X2 := mono X3"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 10,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["17"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of (lam c0 \\ c0) (mono X4)"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["18"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["gammabar (mono X4) X1"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["19"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["pi c0 \\ of c0 X1 => of (app c0 (global [])) (mono X3)"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of (lam c0 \\ c0) (mono X4)"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 8, column 0, characters 100-174:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 8, column 0, characters 100-174:","(of (lam A0) (mono (A2 ===> A1))) :- (pi c0 \\\n                                       (of c0 (mono A2) =>\n                                         of (A0 c0) (mono A1)))."]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := c0 \\\nc0"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X4 := X5 ===> X6"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 17,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["20"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["pi c0 \\ of c0 (mono X5) => of c0 (mono X6)"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["pi","pi c0 \\ of c0 (mono X5) => of c0 (mono X6)"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:rule","payload" : ["pi"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 20,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["21"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of c0 (mono X5) => of c0 (mono X6)"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:new-quant","payload" : ["c0"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:rule:pi","payload" : ["success"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","of c0 (mono X5) => of c0 (mono X6)"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 21,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["22"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of c0 (mono X6)"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["(of c0 (mono X5)) :- ."]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of c0 (mono X6)"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:12)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:12)\", line 1, column 0, characters 0-0:","(of c0 (mono X5)) :- ."]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X6 := X5"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 22,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["gammabar","gammabar (mono (X5 ===> X5)) X1"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 81, column 0, characters 1900-1967:"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 81, column 0, characters 1900-1967:","(gammabar (mono A0) A1) :- (new_constraint (gammabar (mono A0) A1) [_])."]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := X5 ===> X5"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := X1"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 18,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["23"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["new_constraint (gammabar (mono (X5 ===> X5)) X1) [_]"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["new_constraint","new_constraint (gammabar (mono (X5 ===> X5)) X1) [_]"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:","(new_constraint A0 A1) :- (declare_constraint A0 A1)."]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := gammabar (mono (X5 ===> X5)) X1"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := [_]"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 23,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["24"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["declare_constraint (gammabar (mono (X5 ===> X5)) X1) [_]"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["declare_constraint","declare_constraint (gammabar (mono (X5 ===> X5)) X1) [_]"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["declare_constraint"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["25"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["gammabar (mono (X5 ===> X5)) X1"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 24,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:CHR:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 85, column 36, characters 2027-2199:","(theta A0) \\ (A1 ?- gammabar A2 A3) | (generalize A0 A1 A2 A4) <=> (A3 = A4)"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X0 := []"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X1 := mono (uvar frozen--452 [] ===> uvar frozen--452 [])"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A3 := uvar frozen--453 []"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X2 := []"]}
-{"step" : 0,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["generalize [] [] (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) X3"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["generalize","generalize [] [] (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) X3"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 97, column 0, characters 2346-2521:"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 97, column 0, characters 2346-2521:","(generalize A5 A2 (mono A0) A6) :- (free-ty (mono A0) [] A1), \n (free-gamma A2 [] A3), (filter A1 (c0 \\ (not (mem A3 c0))) A4), \n (bind A4 A5 A0 A6)."]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A5 := []"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := []"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A6 := X3"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 26,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["27"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free-ty (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) [] X4"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["28"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free-gamma [] [] X5"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["29"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["filter X4 (c0 \\ not (mem X5 c0)) X6"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["30"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["bind X6 [] (uvar frozen--452 [] ===> uvar frozen--452 []) X3"]}
-{"step" : 1,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free-ty","free-ty (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) [] X4"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 105, column 0, characters 2637-2673:"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 105, column 0, characters 2637-2673:","(free-ty (mono A0) A1 A2) :- (free A0 A1 A2)."]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := []"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := X4"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 27,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["31"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free (uvar frozen--452 [] ===> uvar frozen--452 []) [] X4"]}
-{"step" : 2,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--452 [] ===> uvar frozen--452 []) [] X4"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 117, column 0, characters 3023-3072:"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 117, column 0, characters 3023-3072:","(free (A0 ===> A3) A1 A4) :- (free A0 A1 A2), (free A3 A2 A4)."]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 []"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A3 := uvar frozen--452 []"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := []"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A4 := X4"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 31,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["32"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free (uvar frozen--452 []) [] X7"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["33"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["free (uvar frozen--452 []) X7 X4"]}
-{"step" : 3,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--452 []) [] X7"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:","(free (as (uvar _ _) A1) A0 A2) :- (if (mem A0 A1) (A2 = A0) (A2 = [A1 | A0]))."]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--452 []"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := X7"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 32,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["34"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])"]}
-{"step" : 4,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","(if A0 A1 _) :- A0, !, A1."]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--452 [])"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X7 = []"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["35"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [] (uvar frozen--452 [])"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["36"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 36,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["37"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 37,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X7 = []"]}
-{"step" : 5,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--452 [])"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--452"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 35,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["38"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [] (uvar frozen--452 X8)"]}
-{"step" : 6,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [] (uvar frozen--452 X8)"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 7,"kind" : ["Info"],"goal_id" : 38,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:","(if _ _ A0) :- A0."]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := X7 = [uvar frozen--452 []]"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 34,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["39"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X7 = [uvar frozen--452 []]"]}
-{"step" : 8,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=","X7 = [uvar frozen--452 []]"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:rule","payload" : ["eq"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:rule:builtin:name","payload" : ["="]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X7 := [uvar frozen--452 []]"]}
-{"step" : 9,"kind" : ["Info"],"goal_id" : 39,"runtime_id" : 1,"name" : "user:rule:eq","payload" : ["success"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free","free (uvar frozen--452 []) [uvar frozen--452 []] X4"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:","(free (as (uvar _ _) A1) A0 A2) :- (if (mem A0 A1) (A2 = A0) (A2 = [A1 | A0]))."]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--452 []"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := [uvar frozen--452 []]"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := X4"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 33,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["40"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["if (mem [uvar frozen--452 []] (uvar frozen--452 [])) \n (X4 = [uvar frozen--452 []]) \n (X4 = [uvar frozen--452 [], uvar frozen--452 []])"]}
-{"step" : 10,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [uvar frozen--452 []] (uvar frozen--452 [])) \n (X4 = [uvar frozen--452 []]) \n (X4 = [uvar frozen--452 [], uvar frozen--452 []])"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","(if A0 A1 _) :- A0, !, A1."]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [uvar frozen--452 []] (uvar frozen--452 [])"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X4 = [uvar frozen--452 []]"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 40,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["41"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [uvar frozen--452 []] (uvar frozen--452 [])"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["42"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["43"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X4 = [uvar frozen--452 []]"]}
-{"step" : 11,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [uvar frozen--452 []] (uvar frozen--452 [])"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := [uvar frozen--452 []]"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--452"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 41,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["44"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [uvar frozen--452 []] (uvar frozen--452 X9)"]}
-{"step" : 12,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [uvar frozen--452 []] (uvar frozen--452 X9)"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 143, column 0, characters 3903-3920:","File \"tests/sources/trace-w/main.elpi\", line 144, column 0, characters 3922-3948:"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 143, column 0, characters 3903-3920:","(mem! [A0 | _] A0) :- !."]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 []"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X9 := []"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 44,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["45"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
-{"step" : 13,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["!","!"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["44","File \"tests/sources/trace-w/main.elpi\", line 144, column 0, characters 3922-3948:","(mem! [_ | A0] A1) :- (mem! A0 A1)."]}
-{"step" : 14,"kind" : ["Info"],"goal_id" : 45,"runtime_id" : 1,"name" : "user:rule:cut","payload" : ["success"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["!","!"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["40","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:","(if _ _ A0) :- A0."]}
-{"step" : 15,"kind" : ["Info"],"goal_id" : 42,"runtime_id" : 1,"name" : "user:rule:cut","payload" : ["success"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=","X4 = [uvar frozen--452 []]"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:rule","payload" : ["eq"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:rule:builtin:name","payload" : ["="]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X4 := [uvar frozen--452 []]"]}
-{"step" : 16,"kind" : ["Info"],"goal_id" : 43,"runtime_id" : 1,"name" : "user:rule:eq","payload" : ["success"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["free-gamma","free-gamma [] [] X5"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 109, column 0, characters 2781-2798:"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 109, column 0, characters 2781-2798:","(free-gamma [] A0 A0) :- ."]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X5 := []"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 28,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["filter","filter [uvar frozen--452 []] (c0 \\ not (mem [] c0)) X6"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 139, column 0, characters 3789-3837:","File \"tests/sources/trace-w/main.elpi\", line 140, column 0, characters 3839-3875:"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 139, column 0, characters 3789-3837:","(filter [A0 | A2] A1 [A0 | A3]) :- (A1 A0), !, (filter A2 A1 A3)."]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 []"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := []"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := c0 \\\nnot (mem [] c0)"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X6 := [uvar frozen--452 [] | X10]"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 29,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["46"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["not (mem [] (uvar frozen--452 []))"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["47"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 47,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["48"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["filter [] (c0 \\ not (mem [] c0)) X10"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["not","not (mem [] (uvar frozen--452 []))"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","(not A0) :- A0, !, fail."]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--452 [])"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["49"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [] (uvar frozen--452 [])"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["50"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 50,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["51"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 51,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["fail"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--452 [])"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--452"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 49,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["52"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [] (uvar frozen--452 X11)"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [] (uvar frozen--452 X11)"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 52,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["not","not (mem [] (uvar frozen--452 []))"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:","(not _) :- ."]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 46,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 47,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["!","!"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 47,"runtime_id" : 1,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:rule:cut:branch","payload" : ["29","File \"tests/sources/trace-w/main.elpi\", line 140, column 0, characters 3839-3875:","(filter [_ | A0] A1 A2) :- (filter A0 A1 A2)."]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 47,"runtime_id" : 1,"name" : "user:rule:cut","payload" : ["success"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["filter","filter [] (c0 \\ not (mem [] c0)) X10"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 138, column 0, characters 3773-3787:"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 138, column 0, characters 3773-3787:","(filter [] _ []) :- ."]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X10 := []"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 48,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["bind","bind [uvar frozen--452 []] [] (uvar frozen--452 [] ===> uvar frozen--452 []) \n X3"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 123, column 0, characters 3297-3418:"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 123, column 0, characters 3297-3418:","(bind [A1 | A3] A0 A4 (all A2 (c0 \\ (A5 c0)))) :- (if (mem A0 A1) (A2 = eqt) \n                                                    (A2 = any)), \n (pi c0 \\ (copy A1 c0 => bind A3 A0 A4 (A5 c0)))."]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := uvar frozen--452 []"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A3 := []"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A4 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X3 := all X12 c0 \\ X13 c0"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 30,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["53"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["54"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 54,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["pi c0 \\\n copy (uvar frozen--452 []) c0 =>\n  bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","(if A0 A1 _) :- A0, !, A1."]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := mem [] (uvar frozen--452 [])"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := X12 = eqt"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["55"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem [] (uvar frozen--452 [])"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["56"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 56,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["!"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["57"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 57,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X12 = eqt"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem","mem [] (uvar frozen--452 [])"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := []"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A1 := frozen--452"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 55,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["58"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["mem! [] (uvar frozen--452 X14)"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["mem!","mem! [] (uvar frozen--452 X14)"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : []}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 58,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["fail"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["if","if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:","(if _ _ A0) :- A0."]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := X12 = any"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 53,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["59"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 59,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["X12 = any"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 59,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 59,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=","X12 = any"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 59,"runtime_id" : 1,"name" : "user:rule","payload" : ["eq"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 59,"runtime_id" : 1,"name" : "user:rule:builtin:name","payload" : ["="]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X12 := any"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 59,"runtime_id" : 1,"name" : "user:rule:eq","payload" : ["success"]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 54,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["pi","pi c0 \\\n copy (uvar frozen--452 []) c0 =>\n  bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 54,"runtime_id" : 1,"name" : "user:rule","payload" : ["pi"]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 54,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["60"]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--452 []) c0 =>\n bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:new-quant","payload" : ["c0"]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:rule:pi","payload" : ["success"]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["=>","copy (uvar frozen--452 []) c0 =>\n bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 60,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["61"]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:new-hyps","payload" : ["(copy (uvar frozen--452 []) c0) :- ."]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["bind","bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, characters 3261-3295:"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, characters 3261-3295:","(bind [] _ A0 (mono A1)) :- (copy A0 A1)."]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign:simplify:heap","payload" : ["X13 := c0 \\\nX15 c0"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X15^1 := mono X16^1"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 61,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["62"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--452 [] ===> uvar frozen--452 []) X16^1"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--452 [] ===> uvar frozen--452 []) X16^1"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 130, column 0, characters 3475-3527:"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 130, column 0, characters 3475-3527:","(copy (A0 ===> A2) (A1 ===> A3)) :- (copy A0 A1), (copy A2 A3)."]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A0 := uvar frozen--452 []"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["A2 := uvar frozen--452 []"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X16^1 := X17^1 ===> X18^1"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 62,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["63"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--452 []) X17^1"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:subgoal","payload" : ["64"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:newgoal","payload" : ["copy (uvar frozen--452 []) X18^1"]}
-{"step" : 34,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--452 []) X17^1"]}
-{"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/main.elpi\", line 133, column 0, characters 3621-3647:"]}
-{"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","(copy (uvar frozen--452 []) c0) :- ."]}
-{"step" : 35,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X17^1 := c0"]}
-{"step" : 35,"kind" : ["Info"],"goal_id" : 63,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:curgoal","payload" : ["copy","copy (uvar frozen--452 []) X18^1"]}
-{"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/main.elpi\", line 133, column 0, characters 3621-3647:"]}
-{"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","(copy (uvar frozen--452 []) c0) :- ."]}
-{"step" : 36,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 1,"name" : "user:assign","payload" : ["X18^1 := c0"]}
-{"step" : 36,"kind" : ["Info"],"goal_id" : 64,"runtime_id" : 1,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["65"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 65,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["_ => X1 = all any c0 \\ mono (c0 ===> c0)"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:CHR:rule-fired","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 85, column 36, characters 2027-2199:"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 25,"runtime_id" : 0,"name" : "user:CHR:rule-remove-constraints","payload" : ["25"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:CHR:store:before","payload" : ["25"," gammabar (mono (X5 ===> X5)) X1  /* suspended on X7 */"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:CHR:store:before","payload" : ["16"," theta []  /* suspended on X7 */"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:CHR:store:after","payload" : ["16"," theta []  /* suspended on X7 */"]}
-{"step" : 17,"kind" : ["Info"],"goal_id" : 65,"runtime_id" : 0,"name" : "user:CHR:resumed","payload" : ["_ => X1 = all any c0 \\ mono (c0 ===> c0)"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 65,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","_ => X1 = all any c0 \\ mono (c0 ===> c0)"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 65,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 65,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["66"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["X1 = all any c0 \\ mono (c0 ===> c0)"]}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:new-hyps","payload" : []}
-{"step" : 18,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=","X1 = all any c0 \\ mono (c0 ===> c0)"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:rule","payload" : ["eq"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["="]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X1 := all any c0 \\ mono (c0 ===> c0)"]}
-{"step" : 19,"kind" : ["Info"],"goal_id" : 66,"runtime_id" : 0,"name" : "user:rule:eq","payload" : ["success"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["pi","pi c0 \\\n of c0 (all any c1 \\ mono (c1 ===> c1)) => of (app c0 (global [])) (mono X3)"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:rule","payload" : ["pi"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 19,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["67"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 67,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of c0 (all any c1 \\ mono (c1 ===> c1)) => of (app c0 (global [])) (mono X3)"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 67,"runtime_id" : 0,"name" : "user:new-quant","payload" : ["c0"]}
-{"step" : 20,"kind" : ["Info"],"goal_id" : 67,"runtime_id" : 0,"name" : "user:rule:pi","payload" : ["success"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 67,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["=>","of c0 (all any c1 \\ mono (c1 ===> c1)) => of (app c0 (global [])) (mono X3)"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 67,"runtime_id" : 0,"name" : "user:rule","payload" : ["implication"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 67,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["68"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of (app c0 (global [])) (mono X3)"]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:new-hyps","payload" : ["(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."]}
-{"step" : 21,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:rule:implication","payload" : ["success"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of (app c0 (global [])) (mono X3)"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 4, column 0, characters 31-97:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 4, column 0, characters 31-97:","(of (app A0 A3) (mono A2)) :- (of A0 (mono (A1 ===> A2))), (of A3 (mono A1))."]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := c0"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A3 := global []"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A2 := X3"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 68,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["69"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of c0 (mono (X8^1 ===> X3))"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["70"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of (global []) (mono X8^1)"]}
-{"step" : 22,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of c0 (mono (X8^1 ===> X3))"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify mono (X8^1 ===> X3) with all any c1 \\ mono (c1 ===> c1)"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := c0"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A3 := X8^1 ===> X3"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 69,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["71"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of c0 (all X9^1 X10^1)"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["72"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 72,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["specialize (all X9^1 X10^1) (X8^1 ===> X3)"]}
-{"step" : 23,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of c0 (all X9^1 X10^1)"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X9^1 := any"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X10^1 := c1 \\\nmono (c1 ===> c1)"]}
-{"step" : 24,"kind" : ["Info"],"goal_id" : 71,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 72,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["specialize","specialize (all any c1 \\ mono (c1 ===> c1)) (X8^1 ===> X3)"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 72,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 72,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 57, column 0, characters 1282-1333:","File \"tests/sources/trace-w/main.elpi\", line 58, column 0, characters 1335-1398:"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 72,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 57, column 0, characters 1282-1333:","(specialize (all any A1) A2) :- (specialize (A1 A0) A2)."]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := c1 \\\nmono (c1 ===> c1)"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A2 := X8^1 ===> X3"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 72,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["73"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 73,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["specialize (mono (X11^1 ===> X11^1)) (X8^1 ===> X3)"]}
-{"step" : 25,"kind" : ["Info"],"goal_id" : 73,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 73,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["specialize","specialize (mono (X11^1 ===> X11^1)) (X8^1 ===> X3)"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 73,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 73,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 56, column 0, characters 1259-1280:"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 73,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 56, column 0, characters 1259-1280:","(specialize (mono A0) A0) :- ."]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := X11^1 ===> X11^1"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X11 c0 := X8 c0"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X8 c0 := X3"]}
-{"step" : 26,"kind" : ["Info"],"goal_id" : 73,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of (global []) (mono X3)"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","(of (global 1) (mono int)) :- ."]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global 1"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","(of (global 2) (mono int)) :- ."]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global 2"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","(of (global 3) (mono int)) :- ."]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global 3"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","(of (global plus) (mono (int ===> int ===> int))) :- ."]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global plus"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","(of (global []) (all any (c0 \\ (mono (list c0))))) :- ."]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["unify mono X3 with all any c0 \\ mono (list c0)"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","(of (global ::) (all any (c0 \\ (mono (c0 ===> list c0 ===> list c0))))) :- ."]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global ::"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","(of (global size) (all any (c0 \\ (mono (list c0 ===> int))))) :- ."]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global size"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","(of (global undup) (all eqt (c0 \\ (mono (list c0 ===> list c0))))) :- ."]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global undup"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","(of (global ,) \n  (all any (c0 \\ (all any (c1 \\ (mono (c0 ===> c1 ===> pair c0 c1))))))) :- ."]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global ,"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := global []"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A3 := X3"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 70,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["74"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["of (global []) (all X12^1 X13^1)"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["75"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 75,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["specialize (all X12^1 X13^1) X3"]}
-{"step" : 27,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["of","of (global []) (all X12^1 X13^1)"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","(of (global 1) (mono int)) :- ."]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global 1"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","(of (global 2) (mono int)) :- ."]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global 2"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","(of (global 3) (mono int)) :- ."]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global 3"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","(of (global plus) (mono (int ===> int ===> int))) :- ."]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:backchain:fail-to","payload" : ["match global [] with global plus"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","(of (global []) (all any (c0 \\ (mono (list c0))))) :- ."]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X12^1 := any"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X13^1 := c1 \\\nmono (list c1)"]}
-{"step" : 28,"kind" : ["Info"],"goal_id" : 74,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 75,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["specialize","specialize (all any c1 \\ mono (list c1)) X3"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 75,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 75,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 57, column 0, characters 1282-1333:","File \"tests/sources/trace-w/main.elpi\", line 58, column 0, characters 1335-1398:"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 75,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 57, column 0, characters 1282-1333:","(specialize (all any A1) A2) :- (specialize (A1 A0) A2)."]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A1 := c1 \\\nmono (list c1)"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A2 := X3"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 75,"runtime_id" : 0,"name" : "user:subgoal","payload" : ["76"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 76,"runtime_id" : 0,"name" : "user:newgoal","payload" : ["specialize (mono (list X14^1)) X3"]}
-{"step" : 29,"kind" : ["Info"],"goal_id" : 76,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 76,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["specialize","specialize (mono (list X14^1)) X3"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 76,"runtime_id" : 0,"name" : "user:rule","payload" : ["backchain"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 76,"runtime_id" : 0,"name" : "user:rule:backchain:candidates","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 56, column 0, characters 1259-1280:"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 76,"runtime_id" : 0,"name" : "user:rule:backchain:try","payload" : ["File \"tests/sources/trace-w/main.elpi\", line 56, column 0, characters 1259-1280:","(specialize (mono A0) A0) :- ."]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["A0 := list X14^1"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign:expand","payload" : ["X14^1 := X15 c0"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign:restrict","payload" : ["0 X15 c0 := c0 \\\n.X16"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:assign","payload" : ["X3 := list X16"]}
-{"step" : 30,"kind" : ["Info"],"goal_id" : 76,"runtime_id" : 0,"name" : "user:rule:backchain","payload" : ["success"]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["!","!"]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule","payload" : ["cut"]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["75","File \"tests/sources/trace-w/main.elpi\", line 58, column 0, characters 1335-1398:","(specialize (all eqt A1) A2) :- (specialize (A1 A0) A2), (eqbar A0)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","(of (global ::) (all any (c0 \\ (mono (c0 ===> list c0 ===> list c0))))) :- ."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","(of (global size) (all any (c0 \\ (mono (list c0 ===> int))))) :- ."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","(of (global undup) (all eqt (c0 \\ (mono (list c0 ===> list c0))))) :- ."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","(of (global ,) \n  (all any (c0 \\ (all any (c1 \\ (mono (c0 ===> c1 ===> pair c0 c1))))))) :- ."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["74","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["70","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["70","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["72","File \"tests/sources/trace-w/main.elpi\", line 58, column 0, characters 1335-1398:","(specialize (all eqt A1) A2) :- (specialize (A1 A0) A2), (eqbar A0)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["71","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["71","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["71","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["69","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["69","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["68","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["68","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["68","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["22","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["22","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["22","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["17","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["17","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["17","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["10","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["10","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 0,"runtime_id" : 0,"name" : "user:rule:cut:branch","payload" : ["10","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
-{"step" : 31,"kind" : ["Info"],"goal_id" : 11,"runtime_id" : 0,"name" : "user:rule:cut","payload" : ["success"]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["print","print\n (let (lam c0 \\ c0) (all any c0 \\ mono (c0 ===> c0)) c0 \\ app c0 (global [])) \n  :  (mono (list X16))"]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["print"]}
-{"step" : 32,"kind" : ["Info"],"goal_id" : 12,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:curgoal","payload" : ["print","print"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule","payload" : ["builtin"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:builtin:name","payload" : ["print"]}
-{"step" : 33,"kind" : ["Info"],"goal_id" : 13,"runtime_id" : 0,"name" : "user:rule:builtin","payload" : ["success"]}
+{"step":0,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:newgoal","payload":["main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:curgoal","payload":["main","main"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 177, column 0, characters 4824-4843:"]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 177, column 0, characters 4824-4843:","main :- (tests [2])."]}
+{"step":1,"kind":["Info"],"goal_id":4,"runtime_id":0,"name":"user:subgoal","payload":["5"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:newgoal","payload":["tests [2]"]}
+{"step":1,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:curgoal","payload":["tests","tests [2]"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 175, column 0, characters 4785-4821:"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 175, column 0, characters 4785-4821:","(tests [A0]) :- (test A0 A1), (typecheck A1)."]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := 2"]}
+{"step":2,"kind":["Info"],"goal_id":5,"runtime_id":0,"name":"user:subgoal","payload":["6"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:newgoal","payload":["test 2 X0"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:subgoal","payload":["7"]}
+{"step":2,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:newgoal","payload":["typecheck X0"]}
+{"step":2,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:curgoal","payload":["test","test 2 X0"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 184, column 0, characters 4948-5011:"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 184, column 0, characters 4948-5011:","(test 2 (let (lam (c0 \\ c0)) A0 (c0 \\ (app c0 (global []))))) :- ."]}
+{"step":3,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X0 := let (lam c0 \\ c0) X1 c0 \\ app c0 (global [])"]}
+{"step":3,"kind":["Info"],"goal_id":6,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:curgoal","payload":["typecheck","typecheck (let (lam c0 \\ c0) X1 c0 \\ app c0 (global []))"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 167, column 0, characters 4665-4756:"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 167, column 0, characters 4665-4756:","(typecheck A0) :- (print Checking: A0), (theta []), (of A0 A1), !, \n (print A0  :  A1), print."]}
+{"step":4,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := let (lam c0 \\ c0) X1 c0 \\ app c0 (global [])"]}
+{"step":4,"kind":["Info"],"goal_id":7,"runtime_id":0,"name":"user:subgoal","payload":["8"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:newgoal","payload":["print Checking: (let (lam c0 \\ c0) X1 c0 \\ app c0 (global []))"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:subgoal","payload":["9"]}
+{"step":4,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:newgoal","payload":["theta []"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:subgoal","payload":["10"]}
+{"step":4,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:newgoal","payload":["of (let (lam c0 \\ c0) X1 c0 \\ app c0 (global [])) X2"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:subgoal","payload":["11"]}
+{"step":4,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:newgoal","payload":["!"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:subgoal","payload":["12"]}
+{"step":4,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:newgoal","payload":["print (let (lam c0 \\ c0) X1 c0 \\ app c0 (global []))  :  X2"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:subgoal","payload":["13"]}
+{"step":4,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:newgoal","payload":["print"]}
+{"step":4,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:curgoal","payload":["print","print Checking: (let (lam c0 \\ c0) X1 c0 \\ app c0 (global []))"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:builtin:name","payload":["print"]}
+{"step":5,"kind":["Info"],"goal_id":8,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:curgoal","payload":["theta","theta []"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 76, column 0, characters 1782-1821:"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 76, column 0, characters 1782-1821:","(theta A0) :- (new_constraint (theta A0) [_])."]}
+{"step":6,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := []"]}
+{"step":6,"kind":["Info"],"goal_id":9,"runtime_id":0,"name":"user:subgoal","payload":["14"]}
+{"step":6,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:newgoal","payload":["new_constraint (theta []) [_]"]}
+{"step":6,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":7,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:curgoal","payload":["new_constraint","new_constraint (theta []) [_]"]}
+{"step":7,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":7,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:"]}
+{"step":7,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:","(new_constraint A0 A1) :- (declare_constraint A0 A1)."]}
+{"step":7,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := theta []"]}
+{"step":7,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A1 := [_]"]}
+{"step":7,"kind":["Info"],"goal_id":14,"runtime_id":0,"name":"user:subgoal","payload":["15"]}
+{"step":7,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:newgoal","payload":["declare_constraint (theta []) [_]"]}
+{"step":7,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":8,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:curgoal","payload":["declare_constraint","declare_constraint (theta []) [_]"]}
+{"step":8,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":8,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:rule:builtin:name","payload":["declare_constraint"]}
+{"step":8,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:subgoal","payload":["16"]}
+{"step":8,"kind":["Info"],"goal_id":16,"runtime_id":0,"name":"user:newgoal","payload":["theta []"]}
+{"step":8,"kind":["Info"],"goal_id":15,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}
+{"step":9,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:curgoal","payload":["of","of (let (lam c0 \\ c0) X1 c0 \\ app c0 (global [])) X2"]}
+{"step":9,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":9,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/hm.elpi\", line 11, column 0, characters 177-284:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
+{"step":9,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/hm.elpi\", line 11, column 0, characters 177-284:","(of (let A0 A2 A3) (mono A4)) :- (of A0 (mono A1)), (gammabar (mono A1) A2), \n (pi c0 \\ (of c0 A2 => of (A3 c0) (mono A4)))."]}
+{"step":9,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := lam c0 \\ c0"]}
+{"step":9,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A2 := X1"]}
+{"step":9,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A3 := c0 \\\napp c0 (global [])"]}
+{"step":9,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X2 := mono X3"]}
+{"step":9,"kind":["Info"],"goal_id":10,"runtime_id":0,"name":"user:subgoal","payload":["17"]}
+{"step":9,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:newgoal","payload":["of (lam c0 \\ c0) (mono X4)"]}
+{"step":9,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:subgoal","payload":["18"]}
+{"step":9,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:newgoal","payload":["gammabar (mono X4) X1"]}
+{"step":9,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:subgoal","payload":["19"]}
+{"step":9,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:newgoal","payload":["pi c0 \\ of c0 X1 => of (app c0 (global [])) (mono X3)"]}
+{"step":9,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":10,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:curgoal","payload":["of","of (lam c0 \\ c0) (mono X4)"]}
+{"step":10,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":10,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/hm.elpi\", line 8, column 0, characters 100-174:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
+{"step":10,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/hm.elpi\", line 8, column 0, characters 100-174:","(of (lam A0) (mono (A2 ===> A1))) :- (pi c0 \\\n                                       (of c0 (mono A2) =>\n                                         of (A0 c0) (mono A1)))."]}
+{"step":10,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := c0 \\\nc0"]}
+{"step":10,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X4 := X5 ===> X6"]}
+{"step":10,"kind":["Info"],"goal_id":17,"runtime_id":0,"name":"user:subgoal","payload":["20"]}
+{"step":10,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:newgoal","payload":["pi c0 \\ of c0 (mono X5) => of c0 (mono X6)"]}
+{"step":10,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":11,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:curgoal","payload":["pi","pi c0 \\ of c0 (mono X5) => of c0 (mono X6)"]}
+{"step":11,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:rule","payload":["pi"]}
+{"step":11,"kind":["Info"],"goal_id":20,"runtime_id":0,"name":"user:subgoal","payload":["21"]}
+{"step":11,"kind":["Info"],"goal_id":21,"runtime_id":0,"name":"user:newgoal","payload":["of c0 (mono X5) => of c0 (mono X6)"]}
+{"step":11,"kind":["Info"],"goal_id":21,"runtime_id":0,"name":"user:new-quant","payload":["c0"]}
+{"step":11,"kind":["Info"],"goal_id":21,"runtime_id":0,"name":"user:rule:pi","payload":["success"]}
+{"step":12,"kind":["Info"],"goal_id":21,"runtime_id":0,"name":"user:curgoal","payload":["=>","of c0 (mono X5) => of c0 (mono X6)"]}
+{"step":12,"kind":["Info"],"goal_id":21,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":12,"kind":["Info"],"goal_id":21,"runtime_id":0,"name":"user:subgoal","payload":["22"]}
+{"step":12,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:newgoal","payload":["of c0 (mono X6)"]}
+{"step":12,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:new-hyps","payload":["(of c0 (mono X5)) :- ."]}
+{"step":12,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":13,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:curgoal","payload":["of","of c0 (mono X6)"]}
+{"step":13,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":13,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"(context step_id:12)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
+{"step":13,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"(context step_id:12)\", line 1, column 0, characters 0-0:","(of c0 (mono X5)) :- ."]}
+{"step":13,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X6 := X5"]}
+{"step":13,"kind":["Info"],"goal_id":22,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":14,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:curgoal","payload":["gammabar","gammabar (mono (X5 ===> X5)) X1"]}
+{"step":14,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":14,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 81, column 0, characters 1900-1967:"]}
+{"step":14,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 81, column 0, characters 1900-1967:","(gammabar (mono A0) A1) :- (new_constraint (gammabar (mono A0) A1) [_])."]}
+{"step":14,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := X5 ===> X5"]}
+{"step":14,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A1 := X1"]}
+{"step":14,"kind":["Info"],"goal_id":18,"runtime_id":0,"name":"user:subgoal","payload":["23"]}
+{"step":14,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:newgoal","payload":["new_constraint (gammabar (mono (X5 ===> X5)) X1) [_]"]}
+{"step":14,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":15,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:curgoal","payload":["new_constraint","new_constraint (gammabar (mono (X5 ===> X5)) X1) [_]"]}
+{"step":15,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":15,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:"]}
+{"step":15,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 158, column 0, characters 4374-4418:","(new_constraint A0 A1) :- (declare_constraint A0 A1)."]}
+{"step":15,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := gammabar (mono (X5 ===> X5)) X1"]}
+{"step":15,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A1 := [_]"]}
+{"step":15,"kind":["Info"],"goal_id":23,"runtime_id":0,"name":"user:subgoal","payload":["24"]}
+{"step":15,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:newgoal","payload":["declare_constraint (gammabar (mono (X5 ===> X5)) X1) [_]"]}
+{"step":15,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":16,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:curgoal","payload":["declare_constraint","declare_constraint (gammabar (mono (X5 ===> X5)) X1) [_]"]}
+{"step":16,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":16,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:rule:builtin:name","payload":["declare_constraint"]}
+{"step":16,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:subgoal","payload":["25"]}
+{"step":16,"kind":["Info"],"goal_id":25,"runtime_id":0,"name":"user:newgoal","payload":["gammabar (mono (X5 ===> X5)) X1"]}
+{"step":16,"kind":["Info"],"goal_id":24,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}
+{"step":17,"kind":["Info"],"goal_id":25,"runtime_id":0,"name":"user:CHR:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 85, column 36, characters 2027-2199:","(theta A0) \\ (A1 ?- gammabar A2 A3) | (generalize A0 A1 A2 A4) <=> (A3 = A4)"]}
+{"step":0,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X0 := []"]}
+{"step":0,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X1 := mono (uvar frozen--452 [] ===> uvar frozen--452 [])"]}
+{"step":0,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A3 := uvar frozen--453 []"]}
+{"step":0,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X2 := []"]}
+{"step":0,"kind":["Info"],"goal_id":26,"runtime_id":1,"name":"user:newgoal","payload":["generalize [] [] (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) X3"]}
+{"step":1,"kind":["Info"],"goal_id":26,"runtime_id":1,"name":"user:curgoal","payload":["generalize","generalize [] [] (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) X3"]}
+{"step":1,"kind":["Info"],"goal_id":26,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":1,"kind":["Info"],"goal_id":26,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 97, column 0, characters 2346-2521:"]}
+{"step":1,"kind":["Info"],"goal_id":26,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 97, column 0, characters 2346-2521:","(generalize A5 A2 (mono A0) A6) :- (free-ty (mono A0) [] A1), \n (free-gamma A2 [] A3), (filter A1 (c0 \\ (not (mem A3 c0))) A4), \n (bind A4 A5 A0 A6)."]}
+{"step":1,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A5 := []"]}
+{"step":1,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A2 := []"]}
+{"step":1,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
+{"step":1,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A6 := X3"]}
+{"step":1,"kind":["Info"],"goal_id":26,"runtime_id":1,"name":"user:subgoal","payload":["27"]}
+{"step":1,"kind":["Info"],"goal_id":27,"runtime_id":1,"name":"user:newgoal","payload":["free-ty (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) [] X4"]}
+{"step":1,"kind":["Info"],"goal_id":27,"runtime_id":1,"name":"user:subgoal","payload":["28"]}
+{"step":1,"kind":["Info"],"goal_id":28,"runtime_id":1,"name":"user:newgoal","payload":["free-gamma [] [] X5"]}
+{"step":1,"kind":["Info"],"goal_id":27,"runtime_id":1,"name":"user:subgoal","payload":["29"]}
+{"step":1,"kind":["Info"],"goal_id":29,"runtime_id":1,"name":"user:newgoal","payload":["filter X4 (c0 \\ not (mem X5 c0)) X6"]}
+{"step":1,"kind":["Info"],"goal_id":27,"runtime_id":1,"name":"user:subgoal","payload":["30"]}
+{"step":1,"kind":["Info"],"goal_id":30,"runtime_id":1,"name":"user:newgoal","payload":["bind X6 [] (uvar frozen--452 [] ===> uvar frozen--452 []) X3"]}
+{"step":1,"kind":["Info"],"goal_id":27,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":2,"kind":["Info"],"goal_id":27,"runtime_id":1,"name":"user:curgoal","payload":["free-ty","free-ty (mono (uvar frozen--452 [] ===> uvar frozen--452 [])) [] X4"]}
+{"step":2,"kind":["Info"],"goal_id":27,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":2,"kind":["Info"],"goal_id":27,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 105, column 0, characters 2637-2673:"]}
+{"step":2,"kind":["Info"],"goal_id":27,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 105, column 0, characters 2637-2673:","(free-ty (mono A0) A1 A2) :- (free A0 A1 A2)."]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := []"]}
+{"step":2,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A2 := X4"]}
+{"step":2,"kind":["Info"],"goal_id":27,"runtime_id":1,"name":"user:subgoal","payload":["31"]}
+{"step":2,"kind":["Info"],"goal_id":31,"runtime_id":1,"name":"user:newgoal","payload":["free (uvar frozen--452 [] ===> uvar frozen--452 []) [] X4"]}
+{"step":2,"kind":["Info"],"goal_id":31,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":3,"kind":["Info"],"goal_id":31,"runtime_id":1,"name":"user:curgoal","payload":["free","free (uvar frozen--452 [] ===> uvar frozen--452 []) [] X4"]}
+{"step":3,"kind":["Info"],"goal_id":31,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":3,"kind":["Info"],"goal_id":31,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 117, column 0, characters 3023-3072:"]}
+{"step":3,"kind":["Info"],"goal_id":31,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 117, column 0, characters 3023-3072:","(free (A0 ===> A3) A1 A4) :- (free A0 A1 A2), (free A3 A2 A4)."]}
+{"step":3,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := uvar frozen--452 []"]}
+{"step":3,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A3 := uvar frozen--452 []"]}
+{"step":3,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := []"]}
+{"step":3,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A4 := X4"]}
+{"step":3,"kind":["Info"],"goal_id":31,"runtime_id":1,"name":"user:subgoal","payload":["32"]}
+{"step":3,"kind":["Info"],"goal_id":32,"runtime_id":1,"name":"user:newgoal","payload":["free (uvar frozen--452 []) [] X7"]}
+{"step":3,"kind":["Info"],"goal_id":32,"runtime_id":1,"name":"user:subgoal","payload":["33"]}
+{"step":3,"kind":["Info"],"goal_id":33,"runtime_id":1,"name":"user:newgoal","payload":["free (uvar frozen--452 []) X7 X4"]}
+{"step":3,"kind":["Info"],"goal_id":32,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":4,"kind":["Info"],"goal_id":32,"runtime_id":1,"name":"user:curgoal","payload":["free","free (uvar frozen--452 []) [] X7"]}
+{"step":4,"kind":["Info"],"goal_id":32,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":4,"kind":["Info"],"goal_id":32,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:"]}
+{"step":4,"kind":["Info"],"goal_id":32,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:","(free (as (uvar _ _) A1) A0 A2) :- (if (mem A0 A1) (A2 = A0) (A2 = [A1 | A0]))."]}
+{"step":4,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := uvar frozen--452 []"]}
+{"step":4,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := []"]}
+{"step":4,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A2 := X7"]}
+{"step":4,"kind":["Info"],"goal_id":32,"runtime_id":1,"name":"user:subgoal","payload":["34"]}
+{"step":4,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:newgoal","payload":["if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])"]}
+{"step":4,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":5,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:curgoal","payload":["if","if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])"]}
+{"step":5,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":5,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
+{"step":5,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","(if A0 A1 _) :- A0, !, A1."]}
+{"step":5,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := mem [] (uvar frozen--452 [])"]}
+{"step":5,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := X7 = []"]}
+{"step":5,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:subgoal","payload":["35"]}
+{"step":5,"kind":["Info"],"goal_id":35,"runtime_id":1,"name":"user:newgoal","payload":["mem [] (uvar frozen--452 [])"]}
+{"step":5,"kind":["Info"],"goal_id":35,"runtime_id":1,"name":"user:subgoal","payload":["36"]}
+{"step":5,"kind":["Info"],"goal_id":36,"runtime_id":1,"name":"user:newgoal","payload":["!"]}
+{"step":5,"kind":["Info"],"goal_id":35,"runtime_id":1,"name":"user:subgoal","payload":["37"]}
+{"step":5,"kind":["Info"],"goal_id":37,"runtime_id":1,"name":"user:newgoal","payload":["X7 = []"]}
+{"step":5,"kind":["Info"],"goal_id":35,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":6,"kind":["Info"],"goal_id":35,"runtime_id":1,"name":"user:curgoal","payload":["mem","mem [] (uvar frozen--452 [])"]}
+{"step":6,"kind":["Info"],"goal_id":35,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":6,"kind":["Info"],"goal_id":35,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
+{"step":6,"kind":["Info"],"goal_id":35,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
+{"step":6,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := []"]}
+{"step":6,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := frozen--452"]}
+{"step":6,"kind":["Info"],"goal_id":35,"runtime_id":1,"name":"user:subgoal","payload":["38"]}
+{"step":6,"kind":["Info"],"goal_id":38,"runtime_id":1,"name":"user:newgoal","payload":["mem! [] (uvar frozen--452 X8)"]}
+{"step":6,"kind":["Info"],"goal_id":38,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":7,"kind":["Info"],"goal_id":38,"runtime_id":1,"name":"user:curgoal","payload":["mem!","mem! [] (uvar frozen--452 X8)"]}
+{"step":7,"kind":["Info"],"goal_id":38,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":7,"kind":["Info"],"goal_id":38,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":7,"kind":["Info"],"goal_id":38,"runtime_id":1,"name":"user:rule:backchain","payload":["fail"]}
+{"step":8,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:curgoal","payload":["if","if (mem [] (uvar frozen--452 [])) (X7 = []) (X7 = [uvar frozen--452 []])"]}
+{"step":8,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":8,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
+{"step":8,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:","(if _ _ A0) :- A0."]}
+{"step":8,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := X7 = [uvar frozen--452 []]"]}
+{"step":8,"kind":["Info"],"goal_id":34,"runtime_id":1,"name":"user:subgoal","payload":["39"]}
+{"step":8,"kind":["Info"],"goal_id":39,"runtime_id":1,"name":"user:newgoal","payload":["X7 = [uvar frozen--452 []]"]}
+{"step":8,"kind":["Info"],"goal_id":39,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":9,"kind":["Info"],"goal_id":39,"runtime_id":1,"name":"user:curgoal","payload":["=","X7 = [uvar frozen--452 []]"]}
+{"step":9,"kind":["Info"],"goal_id":39,"runtime_id":1,"name":"user:rule","payload":["eq"]}
+{"step":9,"kind":["Info"],"goal_id":39,"runtime_id":1,"name":"user:rule:builtin:name","payload":["="]}
+{"step":9,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X7 := [uvar frozen--452 []]"]}
+{"step":9,"kind":["Info"],"goal_id":39,"runtime_id":1,"name":"user:rule:eq","payload":["success"]}
+{"step":10,"kind":["Info"],"goal_id":33,"runtime_id":1,"name":"user:curgoal","payload":["free","free (uvar frozen--452 []) [uvar frozen--452 []] X4"]}
+{"step":10,"kind":["Info"],"goal_id":33,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":10,"kind":["Info"],"goal_id":33,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:"]}
+{"step":10,"kind":["Info"],"goal_id":33,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 118, column 0, characters 3074-3137:","(free (as (uvar _ _) A1) A0 A2) :- (if (mem A0 A1) (A2 = A0) (A2 = [A1 | A0]))."]}
+{"step":10,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := uvar frozen--452 []"]}
+{"step":10,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := [uvar frozen--452 []]"]}
+{"step":10,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A2 := X4"]}
+{"step":10,"kind":["Info"],"goal_id":33,"runtime_id":1,"name":"user:subgoal","payload":["40"]}
+{"step":10,"kind":["Info"],"goal_id":40,"runtime_id":1,"name":"user:newgoal","payload":["if (mem [uvar frozen--452 []] (uvar frozen--452 [])) \n (X4 = [uvar frozen--452 []]) \n (X4 = [uvar frozen--452 [], uvar frozen--452 []])"]}
+{"step":10,"kind":["Info"],"goal_id":40,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":11,"kind":["Info"],"goal_id":40,"runtime_id":1,"name":"user:curgoal","payload":["if","if (mem [uvar frozen--452 []] (uvar frozen--452 [])) \n (X4 = [uvar frozen--452 []]) \n (X4 = [uvar frozen--452 [], uvar frozen--452 []])"]}
+{"step":11,"kind":["Info"],"goal_id":40,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":11,"kind":["Info"],"goal_id":40,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
+{"step":11,"kind":["Info"],"goal_id":40,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","(if A0 A1 _) :- A0, !, A1."]}
+{"step":11,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := mem [uvar frozen--452 []] (uvar frozen--452 [])"]}
+{"step":11,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := X4 = [uvar frozen--452 []]"]}
+{"step":11,"kind":["Info"],"goal_id":40,"runtime_id":1,"name":"user:subgoal","payload":["41"]}
+{"step":11,"kind":["Info"],"goal_id":41,"runtime_id":1,"name":"user:newgoal","payload":["mem [uvar frozen--452 []] (uvar frozen--452 [])"]}
+{"step":11,"kind":["Info"],"goal_id":41,"runtime_id":1,"name":"user:subgoal","payload":["42"]}
+{"step":11,"kind":["Info"],"goal_id":42,"runtime_id":1,"name":"user:newgoal","payload":["!"]}
+{"step":11,"kind":["Info"],"goal_id":41,"runtime_id":1,"name":"user:subgoal","payload":["43"]}
+{"step":11,"kind":["Info"],"goal_id":43,"runtime_id":1,"name":"user:newgoal","payload":["X4 = [uvar frozen--452 []]"]}
+{"step":11,"kind":["Info"],"goal_id":41,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":12,"kind":["Info"],"goal_id":41,"runtime_id":1,"name":"user:curgoal","payload":["mem","mem [uvar frozen--452 []] (uvar frozen--452 [])"]}
+{"step":12,"kind":["Info"],"goal_id":41,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":12,"kind":["Info"],"goal_id":41,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
+{"step":12,"kind":["Info"],"goal_id":41,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
+{"step":12,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := [uvar frozen--452 []]"]}
+{"step":12,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := frozen--452"]}
+{"step":12,"kind":["Info"],"goal_id":41,"runtime_id":1,"name":"user:subgoal","payload":["44"]}
+{"step":12,"kind":["Info"],"goal_id":44,"runtime_id":1,"name":"user:newgoal","payload":["mem! [uvar frozen--452 []] (uvar frozen--452 X9)"]}
+{"step":12,"kind":["Info"],"goal_id":44,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":13,"kind":["Info"],"goal_id":44,"runtime_id":1,"name":"user:curgoal","payload":["mem!","mem! [uvar frozen--452 []] (uvar frozen--452 X9)"]}
+{"step":13,"kind":["Info"],"goal_id":44,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":13,"kind":["Info"],"goal_id":44,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 143, column 0, characters 3903-3920:","File \"tests/sources/trace-w/main.elpi\", line 144, column 0, characters 3922-3948:"]}
+{"step":13,"kind":["Info"],"goal_id":44,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 143, column 0, characters 3903-3920:","(mem! [A0 | _] A0) :- !."]}
+{"step":13,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := uvar frozen--452 []"]}
+{"step":13,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X9 := []"]}
+{"step":13,"kind":["Info"],"goal_id":44,"runtime_id":1,"name":"user:subgoal","payload":["45"]}
+{"step":13,"kind":["Info"],"goal_id":45,"runtime_id":1,"name":"user:newgoal","payload":["!"]}
+{"step":13,"kind":["Info"],"goal_id":45,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":14,"kind":["Info"],"goal_id":45,"runtime_id":1,"name":"user:curgoal","payload":["!","!"]}
+{"step":14,"kind":["Info"],"goal_id":45,"runtime_id":1,"name":"user:rule","payload":["cut"]}
+{"step":14,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:rule:cut:branch","payload":["44","File \"tests/sources/trace-w/main.elpi\", line 144, column 0, characters 3922-3948:","(mem! [_ | A0] A1) :- (mem! A0 A1)."]}
+{"step":14,"kind":["Info"],"goal_id":45,"runtime_id":1,"name":"user:rule:cut","payload":["success"]}
+{"step":15,"kind":["Info"],"goal_id":42,"runtime_id":1,"name":"user:curgoal","payload":["!","!"]}
+{"step":15,"kind":["Info"],"goal_id":42,"runtime_id":1,"name":"user:rule","payload":["cut"]}
+{"step":15,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:rule:cut:branch","payload":["40","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:","(if _ _ A0) :- A0."]}
+{"step":15,"kind":["Info"],"goal_id":42,"runtime_id":1,"name":"user:rule:cut","payload":["success"]}
+{"step":16,"kind":["Info"],"goal_id":43,"runtime_id":1,"name":"user:curgoal","payload":["=","X4 = [uvar frozen--452 []]"]}
+{"step":16,"kind":["Info"],"goal_id":43,"runtime_id":1,"name":"user:rule","payload":["eq"]}
+{"step":16,"kind":["Info"],"goal_id":43,"runtime_id":1,"name":"user:rule:builtin:name","payload":["="]}
+{"step":16,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X4 := [uvar frozen--452 []]"]}
+{"step":16,"kind":["Info"],"goal_id":43,"runtime_id":1,"name":"user:rule:eq","payload":["success"]}
+{"step":17,"kind":["Info"],"goal_id":28,"runtime_id":1,"name":"user:curgoal","payload":["free-gamma","free-gamma [] [] X5"]}
+{"step":17,"kind":["Info"],"goal_id":28,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":17,"kind":["Info"],"goal_id":28,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 109, column 0, characters 2781-2798:"]}
+{"step":17,"kind":["Info"],"goal_id":28,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 109, column 0, characters 2781-2798:","(free-gamma [] A0 A0) :- ."]}
+{"step":17,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := []"]}
+{"step":17,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X5 := []"]}
+{"step":17,"kind":["Info"],"goal_id":28,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":18,"kind":["Info"],"goal_id":29,"runtime_id":1,"name":"user:curgoal","payload":["filter","filter [uvar frozen--452 []] (c0 \\ not (mem [] c0)) X6"]}
+{"step":18,"kind":["Info"],"goal_id":29,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":18,"kind":["Info"],"goal_id":29,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 139, column 0, characters 3789-3837:","File \"tests/sources/trace-w/main.elpi\", line 140, column 0, characters 3839-3875:"]}
+{"step":18,"kind":["Info"],"goal_id":29,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 139, column 0, characters 3789-3837:","(filter [A0 | A2] A1 [A0 | A3]) :- (A1 A0), !, (filter A2 A1 A3)."]}
+{"step":18,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := uvar frozen--452 []"]}
+{"step":18,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A2 := []"]}
+{"step":18,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := c0 \\\nnot (mem [] c0)"]}
+{"step":18,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X6 := [uvar frozen--452 [] | X10]"]}
+{"step":18,"kind":["Info"],"goal_id":29,"runtime_id":1,"name":"user:subgoal","payload":["46"]}
+{"step":18,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:newgoal","payload":["not (mem [] (uvar frozen--452 []))"]}
+{"step":18,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:subgoal","payload":["47"]}
+{"step":18,"kind":["Info"],"goal_id":47,"runtime_id":1,"name":"user:newgoal","payload":["!"]}
+{"step":18,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:subgoal","payload":["48"]}
+{"step":18,"kind":["Info"],"goal_id":48,"runtime_id":1,"name":"user:newgoal","payload":["filter [] (c0 \\ not (mem [] c0)) X10"]}
+{"step":18,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":19,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:curgoal","payload":["not","not (mem [] (uvar frozen--452 []))"]}
+{"step":19,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":19,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
+{"step":19,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 69, column 0, characters 1189-1208:","(not A0) :- A0, !, fail."]}
+{"step":19,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := mem [] (uvar frozen--452 [])"]}
+{"step":19,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:subgoal","payload":["49"]}
+{"step":19,"kind":["Info"],"goal_id":49,"runtime_id":1,"name":"user:newgoal","payload":["mem [] (uvar frozen--452 [])"]}
+{"step":19,"kind":["Info"],"goal_id":49,"runtime_id":1,"name":"user:subgoal","payload":["50"]}
+{"step":19,"kind":["Info"],"goal_id":50,"runtime_id":1,"name":"user:newgoal","payload":["!"]}
+{"step":19,"kind":["Info"],"goal_id":49,"runtime_id":1,"name":"user:subgoal","payload":["51"]}
+{"step":19,"kind":["Info"],"goal_id":51,"runtime_id":1,"name":"user:newgoal","payload":["fail"]}
+{"step":19,"kind":["Info"],"goal_id":49,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":20,"kind":["Info"],"goal_id":49,"runtime_id":1,"name":"user:curgoal","payload":["mem","mem [] (uvar frozen--452 [])"]}
+{"step":20,"kind":["Info"],"goal_id":49,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":20,"kind":["Info"],"goal_id":49,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
+{"step":20,"kind":["Info"],"goal_id":49,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
+{"step":20,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := []"]}
+{"step":20,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := frozen--452"]}
+{"step":20,"kind":["Info"],"goal_id":49,"runtime_id":1,"name":"user:subgoal","payload":["52"]}
+{"step":20,"kind":["Info"],"goal_id":52,"runtime_id":1,"name":"user:newgoal","payload":["mem! [] (uvar frozen--452 X11)"]}
+{"step":20,"kind":["Info"],"goal_id":52,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":21,"kind":["Info"],"goal_id":52,"runtime_id":1,"name":"user:curgoal","payload":["mem!","mem! [] (uvar frozen--452 X11)"]}
+{"step":21,"kind":["Info"],"goal_id":52,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":21,"kind":["Info"],"goal_id":52,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":21,"kind":["Info"],"goal_id":52,"runtime_id":1,"name":"user:rule:backchain","payload":["fail"]}
+{"step":22,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:curgoal","payload":["not","not (mem [] (uvar frozen--452 []))"]}
+{"step":22,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":22,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:"]}
+{"step":22,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 71, column 0, characters 1211-1216:","(not _) :- ."]}
+{"step":22,"kind":["Info"],"goal_id":46,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":23,"kind":["Info"],"goal_id":47,"runtime_id":1,"name":"user:curgoal","payload":["!","!"]}
+{"step":23,"kind":["Info"],"goal_id":47,"runtime_id":1,"name":"user:rule","payload":["cut"]}
+{"step":23,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:rule:cut:branch","payload":["29","File \"tests/sources/trace-w/main.elpi\", line 140, column 0, characters 3839-3875:","(filter [_ | A0] A1 A2) :- (filter A0 A1 A2)."]}
+{"step":23,"kind":["Info"],"goal_id":47,"runtime_id":1,"name":"user:rule:cut","payload":["success"]}
+{"step":24,"kind":["Info"],"goal_id":48,"runtime_id":1,"name":"user:curgoal","payload":["filter","filter [] (c0 \\ not (mem [] c0)) X10"]}
+{"step":24,"kind":["Info"],"goal_id":48,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":24,"kind":["Info"],"goal_id":48,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 138, column 0, characters 3773-3787:"]}
+{"step":24,"kind":["Info"],"goal_id":48,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 138, column 0, characters 3773-3787:","(filter [] _ []) :- ."]}
+{"step":24,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X10 := []"]}
+{"step":24,"kind":["Info"],"goal_id":48,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":25,"kind":["Info"],"goal_id":30,"runtime_id":1,"name":"user:curgoal","payload":["bind","bind [uvar frozen--452 []] [] (uvar frozen--452 [] ===> uvar frozen--452 []) \n X3"]}
+{"step":25,"kind":["Info"],"goal_id":30,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":25,"kind":["Info"],"goal_id":30,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 123, column 0, characters 3297-3418:"]}
+{"step":25,"kind":["Info"],"goal_id":30,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 123, column 0, characters 3297-3418:","(bind [A1 | A3] A0 A4 (all A2 (c0 \\ (A5 c0)))) :- (if (mem A0 A1) (A2 = eqt) \n                                                    (A2 = any)), \n (pi c0 \\ (copy A1 c0 => bind A3 A0 A4 (A5 c0)))."]}
+{"step":25,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := uvar frozen--452 []"]}
+{"step":25,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A3 := []"]}
+{"step":25,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := []"]}
+{"step":25,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A4 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
+{"step":25,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X3 := all X12 c0 \\ X13 c0"]}
+{"step":25,"kind":["Info"],"goal_id":30,"runtime_id":1,"name":"user:subgoal","payload":["53"]}
+{"step":25,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:newgoal","payload":["if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)"]}
+{"step":25,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:subgoal","payload":["54"]}
+{"step":25,"kind":["Info"],"goal_id":54,"runtime_id":1,"name":"user:newgoal","payload":["pi c0 \\\n copy (uvar frozen--452 []) c0 =>\n  bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
+{"step":25,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":26,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:curgoal","payload":["if","if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)"]}
+{"step":26,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":26,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
+{"step":26,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 536, column 0, characters 13943-13962:","(if A0 A1 _) :- A0, !, A1."]}
+{"step":26,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := mem [] (uvar frozen--452 [])"]}
+{"step":26,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := X12 = eqt"]}
+{"step":26,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:subgoal","payload":["55"]}
+{"step":26,"kind":["Info"],"goal_id":55,"runtime_id":1,"name":"user:newgoal","payload":["mem [] (uvar frozen--452 [])"]}
+{"step":26,"kind":["Info"],"goal_id":55,"runtime_id":1,"name":"user:subgoal","payload":["56"]}
+{"step":26,"kind":["Info"],"goal_id":56,"runtime_id":1,"name":"user:newgoal","payload":["!"]}
+{"step":26,"kind":["Info"],"goal_id":55,"runtime_id":1,"name":"user:subgoal","payload":["57"]}
+{"step":26,"kind":["Info"],"goal_id":57,"runtime_id":1,"name":"user:newgoal","payload":["X12 = eqt"]}
+{"step":26,"kind":["Info"],"goal_id":55,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":27,"kind":["Info"],"goal_id":55,"runtime_id":1,"name":"user:curgoal","payload":["mem","mem [] (uvar frozen--452 [])"]}
+{"step":27,"kind":["Info"],"goal_id":55,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":27,"kind":["Info"],"goal_id":55,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:"]}
+{"step":27,"kind":["Info"],"goal_id":55,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 148, column 0, characters 4032-4074:","(mem A0 (uvar A1 _)) :- (mem! A0 (uvar A1 A2))."]}
+{"step":27,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := []"]}
+{"step":27,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A1 := frozen--452"]}
+{"step":27,"kind":["Info"],"goal_id":55,"runtime_id":1,"name":"user:subgoal","payload":["58"]}
+{"step":27,"kind":["Info"],"goal_id":58,"runtime_id":1,"name":"user:newgoal","payload":["mem! [] (uvar frozen--452 X14)"]}
+{"step":27,"kind":["Info"],"goal_id":58,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":28,"kind":["Info"],"goal_id":58,"runtime_id":1,"name":"user:curgoal","payload":["mem!","mem! [] (uvar frozen--452 X14)"]}
+{"step":28,"kind":["Info"],"goal_id":58,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":28,"kind":["Info"],"goal_id":58,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":[]}
+{"step":28,"kind":["Info"],"goal_id":58,"runtime_id":1,"name":"user:rule:backchain","payload":["fail"]}
+{"step":29,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:curgoal","payload":["if","if (mem [] (uvar frozen--452 [])) (X12 = eqt) (X12 = any)"]}
+{"step":29,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":29,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:"]}
+{"step":29,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"builtin.elpi\", line 537, column 0, characters 13964-13977:","(if _ _ A0) :- A0."]}
+{"step":29,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := X12 = any"]}
+{"step":29,"kind":["Info"],"goal_id":53,"runtime_id":1,"name":"user:subgoal","payload":["59"]}
+{"step":29,"kind":["Info"],"goal_id":59,"runtime_id":1,"name":"user:newgoal","payload":["X12 = any"]}
+{"step":29,"kind":["Info"],"goal_id":59,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":30,"kind":["Info"],"goal_id":59,"runtime_id":1,"name":"user:curgoal","payload":["=","X12 = any"]}
+{"step":30,"kind":["Info"],"goal_id":59,"runtime_id":1,"name":"user:rule","payload":["eq"]}
+{"step":30,"kind":["Info"],"goal_id":59,"runtime_id":1,"name":"user:rule:builtin:name","payload":["="]}
+{"step":30,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X12 := any"]}
+{"step":30,"kind":["Info"],"goal_id":59,"runtime_id":1,"name":"user:rule:eq","payload":["success"]}
+{"step":31,"kind":["Info"],"goal_id":54,"runtime_id":1,"name":"user:curgoal","payload":["pi","pi c0 \\\n copy (uvar frozen--452 []) c0 =>\n  bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
+{"step":31,"kind":["Info"],"goal_id":54,"runtime_id":1,"name":"user:rule","payload":["pi"]}
+{"step":31,"kind":["Info"],"goal_id":54,"runtime_id":1,"name":"user:subgoal","payload":["60"]}
+{"step":31,"kind":["Info"],"goal_id":60,"runtime_id":1,"name":"user:newgoal","payload":["copy (uvar frozen--452 []) c0 =>\n bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
+{"step":31,"kind":["Info"],"goal_id":60,"runtime_id":1,"name":"user:new-quant","payload":["c0"]}
+{"step":31,"kind":["Info"],"goal_id":60,"runtime_id":1,"name":"user:rule:pi","payload":["success"]}
+{"step":32,"kind":["Info"],"goal_id":60,"runtime_id":1,"name":"user:curgoal","payload":["=>","copy (uvar frozen--452 []) c0 =>\n bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
+{"step":32,"kind":["Info"],"goal_id":60,"runtime_id":1,"name":"user:rule","payload":["implication"]}
+{"step":32,"kind":["Info"],"goal_id":60,"runtime_id":1,"name":"user:subgoal","payload":["61"]}
+{"step":32,"kind":["Info"],"goal_id":61,"runtime_id":1,"name":"user:newgoal","payload":["bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
+{"step":32,"kind":["Info"],"goal_id":61,"runtime_id":1,"name":"user:new-hyps","payload":["(copy (uvar frozen--452 []) c0) :- ."]}
+{"step":32,"kind":["Info"],"goal_id":61,"runtime_id":1,"name":"user:rule:implication","payload":["success"]}
+{"step":33,"kind":["Info"],"goal_id":61,"runtime_id":1,"name":"user:curgoal","payload":["bind","bind [] [] (uvar frozen--452 [] ===> uvar frozen--452 []) (X13 c0)"]}
+{"step":33,"kind":["Info"],"goal_id":61,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":33,"kind":["Info"],"goal_id":61,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, characters 3261-3295:"]}
+{"step":33,"kind":["Info"],"goal_id":61,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 122, column 0, characters 3261-3295:","(bind [] _ A0 (mono A1)) :- (copy A0 A1)."]}
+{"step":33,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := uvar frozen--452 [] ===> uvar frozen--452 []"]}
+{"step":33,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign:simplify:heap","payload":["X13 := c0 \\\nX15 c0"]}
+{"step":33,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X15^1 := mono X16^1"]}
+{"step":33,"kind":["Info"],"goal_id":61,"runtime_id":1,"name":"user:subgoal","payload":["62"]}
+{"step":33,"kind":["Info"],"goal_id":62,"runtime_id":1,"name":"user:newgoal","payload":["copy (uvar frozen--452 [] ===> uvar frozen--452 []) X16^1"]}
+{"step":33,"kind":["Info"],"goal_id":62,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":34,"kind":["Info"],"goal_id":62,"runtime_id":1,"name":"user:curgoal","payload":["copy","copy (uvar frozen--452 [] ===> uvar frozen--452 []) X16^1"]}
+{"step":34,"kind":["Info"],"goal_id":62,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":34,"kind":["Info"],"goal_id":62,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 130, column 0, characters 3475-3527:"]}
+{"step":34,"kind":["Info"],"goal_id":62,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 130, column 0, characters 3475-3527:","(copy (A0 ===> A2) (A1 ===> A3)) :- (copy A0 A1), (copy A2 A3)."]}
+{"step":34,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A0 := uvar frozen--452 []"]}
+{"step":34,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["A2 := uvar frozen--452 []"]}
+{"step":34,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X16^1 := X17^1 ===> X18^1"]}
+{"step":34,"kind":["Info"],"goal_id":62,"runtime_id":1,"name":"user:subgoal","payload":["63"]}
+{"step":34,"kind":["Info"],"goal_id":63,"runtime_id":1,"name":"user:newgoal","payload":["copy (uvar frozen--452 []) X17^1"]}
+{"step":34,"kind":["Info"],"goal_id":63,"runtime_id":1,"name":"user:subgoal","payload":["64"]}
+{"step":34,"kind":["Info"],"goal_id":64,"runtime_id":1,"name":"user:newgoal","payload":["copy (uvar frozen--452 []) X18^1"]}
+{"step":34,"kind":["Info"],"goal_id":63,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":35,"kind":["Info"],"goal_id":63,"runtime_id":1,"name":"user:curgoal","payload":["copy","copy (uvar frozen--452 []) X17^1"]}
+{"step":35,"kind":["Info"],"goal_id":63,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":35,"kind":["Info"],"goal_id":63,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/main.elpi\", line 133, column 0, characters 3621-3647:"]}
+{"step":35,"kind":["Info"],"goal_id":63,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","(copy (uvar frozen--452 []) c0) :- ."]}
+{"step":35,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X17^1 := c0"]}
+{"step":35,"kind":["Info"],"goal_id":63,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":36,"kind":["Info"],"goal_id":64,"runtime_id":1,"name":"user:curgoal","payload":["copy","copy (uvar frozen--452 []) X18^1"]}
+{"step":36,"kind":["Info"],"goal_id":64,"runtime_id":1,"name":"user:rule","payload":["backchain"]}
+{"step":36,"kind":["Info"],"goal_id":64,"runtime_id":1,"name":"user:rule:backchain:candidates","payload":["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/main.elpi\", line 133, column 0, characters 3621-3647:"]}
+{"step":36,"kind":["Info"],"goal_id":64,"runtime_id":1,"name":"user:rule:backchain:try","payload":["File \"(context step_id:32)\", line 1, column 0, characters 0-0:","(copy (uvar frozen--452 []) c0) :- ."]}
+{"step":36,"kind":["Info"],"goal_id":0,"runtime_id":1,"name":"user:assign","payload":["X18^1 := c0"]}
+{"step":36,"kind":["Info"],"goal_id":64,"runtime_id":1,"name":"user:rule:backchain","payload":["success"]}
+{"step":17,"kind":["Info"],"goal_id":25,"runtime_id":0,"name":"user:subgoal","payload":["65"]}
+{"step":17,"kind":["Info"],"goal_id":65,"runtime_id":0,"name":"user:newgoal","payload":["_ => X1 = all any c0 \\ mono (c0 ===> c0)"]}
+{"step":17,"kind":["Info"],"goal_id":25,"runtime_id":0,"name":"user:CHR:rule-fired","payload":["File \"tests/sources/trace-w/main.elpi\", line 85, column 36, characters 2027-2199:"]}
+{"step":17,"kind":["Info"],"goal_id":25,"runtime_id":0,"name":"user:CHR:rule-remove-constraints","payload":["25"]}
+{"step":17,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:CHR:store:before","payload":["25"," gammabar (mono (X5 ===> X5)) X1  /* suspended on X7 */"]}
+{"step":17,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:CHR:store:before","payload":["16"," theta []  /* suspended on X7 */"]}
+{"step":17,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:CHR:store:after","payload":["16"," theta []  /* suspended on X7 */"]}
+{"step":17,"kind":["Info"],"goal_id":65,"runtime_id":0,"name":"user:CHR:resumed","payload":["_ => X1 = all any c0 \\ mono (c0 ===> c0)"]}
+{"step":18,"kind":["Info"],"goal_id":65,"runtime_id":0,"name":"user:curgoal","payload":["=>","_ => X1 = all any c0 \\ mono (c0 ===> c0)"]}
+{"step":18,"kind":["Info"],"goal_id":65,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":18,"kind":["Info"],"goal_id":65,"runtime_id":0,"name":"user:subgoal","payload":["66"]}
+{"step":18,"kind":["Info"],"goal_id":66,"runtime_id":0,"name":"user:newgoal","payload":["X1 = all any c0 \\ mono (c0 ===> c0)"]}
+{"step":18,"kind":["Info"],"goal_id":66,"runtime_id":0,"name":"user:new-hyps","payload":[]}
+{"step":18,"kind":["Info"],"goal_id":66,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":19,"kind":["Info"],"goal_id":66,"runtime_id":0,"name":"user:curgoal","payload":["=","X1 = all any c0 \\ mono (c0 ===> c0)"]}
+{"step":19,"kind":["Info"],"goal_id":66,"runtime_id":0,"name":"user:rule","payload":["eq"]}
+{"step":19,"kind":["Info"],"goal_id":66,"runtime_id":0,"name":"user:rule:builtin:name","payload":["="]}
+{"step":19,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X1 := all any c0 \\ mono (c0 ===> c0)"]}
+{"step":19,"kind":["Info"],"goal_id":66,"runtime_id":0,"name":"user:rule:eq","payload":["success"]}
+{"step":20,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:curgoal","payload":["pi","pi c0 \\\n of c0 (all any c1 \\ mono (c1 ===> c1)) => of (app c0 (global [])) (mono X3)"]}
+{"step":20,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:rule","payload":["pi"]}
+{"step":20,"kind":["Info"],"goal_id":19,"runtime_id":0,"name":"user:subgoal","payload":["67"]}
+{"step":20,"kind":["Info"],"goal_id":67,"runtime_id":0,"name":"user:newgoal","payload":["of c0 (all any c1 \\ mono (c1 ===> c1)) => of (app c0 (global [])) (mono X3)"]}
+{"step":20,"kind":["Info"],"goal_id":67,"runtime_id":0,"name":"user:new-quant","payload":["c0"]}
+{"step":20,"kind":["Info"],"goal_id":67,"runtime_id":0,"name":"user:rule:pi","payload":["success"]}
+{"step":21,"kind":["Info"],"goal_id":67,"runtime_id":0,"name":"user:curgoal","payload":["=>","of c0 (all any c1 \\ mono (c1 ===> c1)) => of (app c0 (global [])) (mono X3)"]}
+{"step":21,"kind":["Info"],"goal_id":67,"runtime_id":0,"name":"user:rule","payload":["implication"]}
+{"step":21,"kind":["Info"],"goal_id":67,"runtime_id":0,"name":"user:subgoal","payload":["68"]}
+{"step":21,"kind":["Info"],"goal_id":68,"runtime_id":0,"name":"user:newgoal","payload":["of (app c0 (global [])) (mono X3)"]}
+{"step":21,"kind":["Info"],"goal_id":68,"runtime_id":0,"name":"user:new-hyps","payload":["(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."]}
+{"step":21,"kind":["Info"],"goal_id":68,"runtime_id":0,"name":"user:rule:implication","payload":["success"]}
+{"step":22,"kind":["Info"],"goal_id":68,"runtime_id":0,"name":"user:curgoal","payload":["of","of (app c0 (global [])) (mono X3)"]}
+{"step":22,"kind":["Info"],"goal_id":68,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":22,"kind":["Info"],"goal_id":68,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/hm.elpi\", line 4, column 0, characters 31-97:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
+{"step":22,"kind":["Info"],"goal_id":68,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/hm.elpi\", line 4, column 0, characters 31-97:","(of (app A0 A3) (mono A2)) :- (of A0 (mono (A1 ===> A2))), (of A3 (mono A1))."]}
+{"step":22,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := c0"]}
+{"step":22,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A3 := global []"]}
+{"step":22,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A2 := X3"]}
+{"step":22,"kind":["Info"],"goal_id":68,"runtime_id":0,"name":"user:subgoal","payload":["69"]}
+{"step":22,"kind":["Info"],"goal_id":69,"runtime_id":0,"name":"user:newgoal","payload":["of c0 (mono (X8^1 ===> X3))"]}
+{"step":22,"kind":["Info"],"goal_id":69,"runtime_id":0,"name":"user:subgoal","payload":["70"]}
+{"step":22,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:newgoal","payload":["of (global []) (mono X8^1)"]}
+{"step":22,"kind":["Info"],"goal_id":69,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":23,"kind":["Info"],"goal_id":69,"runtime_id":0,"name":"user:curgoal","payload":["of","of c0 (mono (X8^1 ===> X3))"]}
+{"step":23,"kind":["Info"],"goal_id":69,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":23,"kind":["Info"],"goal_id":69,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
+{"step":23,"kind":["Info"],"goal_id":69,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."]}
+{"step":23,"kind":["Info"],"goal_id":69,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify mono (X8^1 ===> X3) with all any c1 \\ mono (c1 ===> c1)"]}
+{"step":23,"kind":["Info"],"goal_id":69,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
+{"step":23,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := c0"]}
+{"step":23,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A3 := X8^1 ===> X3"]}
+{"step":23,"kind":["Info"],"goal_id":69,"runtime_id":0,"name":"user:subgoal","payload":["71"]}
+{"step":23,"kind":["Info"],"goal_id":71,"runtime_id":0,"name":"user:newgoal","payload":["of c0 (all X9^1 X10^1)"]}
+{"step":23,"kind":["Info"],"goal_id":71,"runtime_id":0,"name":"user:subgoal","payload":["72"]}
+{"step":23,"kind":["Info"],"goal_id":72,"runtime_id":0,"name":"user:newgoal","payload":["specialize (all X9^1 X10^1) (X8^1 ===> X3)"]}
+{"step":23,"kind":["Info"],"goal_id":71,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":24,"kind":["Info"],"goal_id":71,"runtime_id":0,"name":"user:curgoal","payload":["of","of c0 (all X9^1 X10^1)"]}
+{"step":24,"kind":["Info"],"goal_id":71,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":24,"kind":["Info"],"goal_id":71,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
+{"step":24,"kind":["Info"],"goal_id":71,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"(context step_id:21)\", line 1, column 0, characters 0-0:","(of c0 (all any (c1 \\ (mono (c1 ===> c1))))) :- ."]}
+{"step":24,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X9^1 := any"]}
+{"step":24,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X10^1 := c1 \\\nmono (c1 ===> c1)"]}
+{"step":24,"kind":["Info"],"goal_id":71,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":25,"kind":["Info"],"goal_id":72,"runtime_id":0,"name":"user:curgoal","payload":["specialize","specialize (all any c1 \\ mono (c1 ===> c1)) (X8^1 ===> X3)"]}
+{"step":25,"kind":["Info"],"goal_id":72,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":25,"kind":["Info"],"goal_id":72,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 57, column 0, characters 1282-1333:","File \"tests/sources/trace-w/main.elpi\", line 58, column 0, characters 1335-1398:"]}
+{"step":25,"kind":["Info"],"goal_id":72,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 57, column 0, characters 1282-1333:","(specialize (all any A1) A2) :- (specialize (A1 A0) A2)."]}
+{"step":25,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A1 := c1 \\\nmono (c1 ===> c1)"]}
+{"step":25,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A2 := X8^1 ===> X3"]}
+{"step":25,"kind":["Info"],"goal_id":72,"runtime_id":0,"name":"user:subgoal","payload":["73"]}
+{"step":25,"kind":["Info"],"goal_id":73,"runtime_id":0,"name":"user:newgoal","payload":["specialize (mono (X11^1 ===> X11^1)) (X8^1 ===> X3)"]}
+{"step":25,"kind":["Info"],"goal_id":73,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":26,"kind":["Info"],"goal_id":73,"runtime_id":0,"name":"user:curgoal","payload":["specialize","specialize (mono (X11^1 ===> X11^1)) (X8^1 ===> X3)"]}
+{"step":26,"kind":["Info"],"goal_id":73,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":26,"kind":["Info"],"goal_id":73,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 56, column 0, characters 1259-1280:"]}
+{"step":26,"kind":["Info"],"goal_id":73,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 56, column 0, characters 1259-1280:","(specialize (mono A0) A0) :- ."]}
+{"step":26,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := X11^1 ===> X11^1"]}
+{"step":26,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X11 c0 := X8 c0"]}
+{"step":26,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X8 c0 := X3"]}
+{"step":26,"kind":["Info"],"goal_id":73,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:curgoal","payload":["of","of (global []) (mono X3)"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","(of (global 1) (mono int)) :- ."]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global 1"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","(of (global 2) (mono int)) :- ."]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global 2"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","(of (global 3) (mono int)) :- ."]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global 3"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","(of (global plus) (mono (int ===> int ===> int))) :- ."]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global plus"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","(of (global []) (all any (c0 \\ (mono (list c0))))) :- ."]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:backchain:fail-to","payload":["unify mono X3 with all any c0 \\ mono (list c0)"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","(of (global ::) (all any (c0 \\ (mono (c0 ===> list c0 ===> list c0))))) :- ."]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global ::"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","(of (global size) (all any (c0 \\ (mono (list c0 ===> int))))) :- ."]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global size"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","(of (global undup) (all eqt (c0 \\ (mono (list c0 ===> list c0))))) :- ."]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global undup"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","(of (global ,) \n  (all any (c0 \\ (all any (c1 \\ (mono (c0 ===> c1 ===> pair c0 c1))))))) :- ."]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global ,"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
+{"step":27,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := global []"]}
+{"step":27,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A3 := X3"]}
+{"step":27,"kind":["Info"],"goal_id":70,"runtime_id":0,"name":"user:subgoal","payload":["74"]}
+{"step":27,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:newgoal","payload":["of (global []) (all X12^1 X13^1)"]}
+{"step":27,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:subgoal","payload":["75"]}
+{"step":27,"kind":["Info"],"goal_id":75,"runtime_id":0,"name":"user:newgoal","payload":["specialize (all X12^1 X13^1) X3"]}
+{"step":27,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:curgoal","payload":["of","of (global []) (all X12^1 X13^1)"]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:"]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 38, column 0, characters 656-687:","(of (global 1) (mono int)) :- ."]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global 1"]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 39, column 0, characters 689-720:","(of (global 2) (mono int)) :- ."]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global 2"]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 40, column 0, characters 722-753:","(of (global 3) (mono int)) :- ."]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global 3"]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 41, column 0, characters 755-806:","(of (global plus) (mono (int ===> int ===> int))) :- ."]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:backchain:fail-to","payload":["match global [] with global plus"]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 43, column 0, characters 809-855:","(of (global []) (all any (c0 \\ (mono (list c0))))) :- ."]}
+{"step":28,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X12^1 := any"]}
+{"step":28,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X13^1 := c1 \\\nmono (list c1)"]}
+{"step":28,"kind":["Info"],"goal_id":74,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":29,"kind":["Info"],"goal_id":75,"runtime_id":0,"name":"user:curgoal","payload":["specialize","specialize (all any c1 \\ mono (list c1)) X3"]}
+{"step":29,"kind":["Info"],"goal_id":75,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":29,"kind":["Info"],"goal_id":75,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 57, column 0, characters 1282-1333:","File \"tests/sources/trace-w/main.elpi\", line 58, column 0, characters 1335-1398:"]}
+{"step":29,"kind":["Info"],"goal_id":75,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 57, column 0, characters 1282-1333:","(specialize (all any A1) A2) :- (specialize (A1 A0) A2)."]}
+{"step":29,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A1 := c1 \\\nmono (list c1)"]}
+{"step":29,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A2 := X3"]}
+{"step":29,"kind":["Info"],"goal_id":75,"runtime_id":0,"name":"user:subgoal","payload":["76"]}
+{"step":29,"kind":["Info"],"goal_id":76,"runtime_id":0,"name":"user:newgoal","payload":["specialize (mono (list X14^1)) X3"]}
+{"step":29,"kind":["Info"],"goal_id":76,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":30,"kind":["Info"],"goal_id":76,"runtime_id":0,"name":"user:curgoal","payload":["specialize","specialize (mono (list X14^1)) X3"]}
+{"step":30,"kind":["Info"],"goal_id":76,"runtime_id":0,"name":"user:rule","payload":["backchain"]}
+{"step":30,"kind":["Info"],"goal_id":76,"runtime_id":0,"name":"user:rule:backchain:candidates","payload":["File \"tests/sources/trace-w/main.elpi\", line 56, column 0, characters 1259-1280:"]}
+{"step":30,"kind":["Info"],"goal_id":76,"runtime_id":0,"name":"user:rule:backchain:try","payload":["File \"tests/sources/trace-w/main.elpi\", line 56, column 0, characters 1259-1280:","(specialize (mono A0) A0) :- ."]}
+{"step":30,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["A0 := list X14^1"]}
+{"step":30,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign:expand","payload":["X14^1 := X15 c0"]}
+{"step":30,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign:restrict","payload":["0 X15 c0 := c0 \\\n.X16"]}
+{"step":30,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:assign","payload":["X3 := list X16"]}
+{"step":30,"kind":["Info"],"goal_id":76,"runtime_id":0,"name":"user:rule:backchain","payload":["success"]}
+{"step":31,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:curgoal","payload":["!","!"]}
+{"step":31,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule","payload":["cut"]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["75","File \"tests/sources/trace-w/main.elpi\", line 58, column 0, characters 1335-1398:","(specialize (all eqt A1) A2) :- (specialize (A1 A0) A2), (eqbar A0)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["74","File \"tests/sources/trace-w/main.elpi\", line 44, column 0, characters 857-922:","(of (global ::) (all any (c0 \\ (mono (c0 ===> list c0 ===> list c0))))) :- ."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["74","File \"tests/sources/trace-w/main.elpi\", line 45, column 0, characters 924-979:","(of (global size) (all any (c0 \\ (mono (list c0 ===> int))))) :- ."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["74","File \"tests/sources/trace-w/main.elpi\", line 46, column 0, characters 981-1039:","(of (global undup) (all eqt (c0 \\ (mono (list c0 ===> list c0))))) :- ."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["74","File \"tests/sources/trace-w/main.elpi\", line 48, column 0, characters 1042-1117:","(of (global ,) \n  (all any (c0 \\ (all any (c1 \\ (mono (c0 ===> c1 ===> pair c0 c1))))))) :- ."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["74","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["74","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["74","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["70","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["70","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["72","File \"tests/sources/trace-w/main.elpi\", line 58, column 0, characters 1335-1398:","(specialize (all eqt A1) A2) :- (specialize (A1 A0) A2), (eqbar A0)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["71","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["71","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["71","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["69","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["69","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["68","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["68","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["68","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["22","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["22","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["22","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["17","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["17","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["17","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["10","File \"tests/sources/trace-w/hm.elpi\", line 21, column 0, characters 368-429:","(of A0 (mono A3)) :- (of A0 (all A1 A2)), (specialize (all A1 A2) A3)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["10","File \"tests/sources/trace-w/main.elpi\", line 163, column 0, characters 4507-4576:","(of A0 (mono A2)) :- (not err), !, (err => of A0 (mono A1)), \n (assert A0 A1 A2)."]}
+{"step":31,"kind":["Info"],"goal_id":0,"runtime_id":0,"name":"user:rule:cut:branch","payload":["10","File \"tests/sources/trace-w/main.elpi\", line 164, column 0, characters 4578-4639:","(of A0 (mono _)) :- (print KO: term ( A0 ) has no type\n), halt."]}
+{"step":31,"kind":["Info"],"goal_id":11,"runtime_id":0,"name":"user:rule:cut","payload":["success"]}
+{"step":32,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:curgoal","payload":["print","print\n (let (lam c0 \\ c0) (all any c0 \\ mono (c0 ===> c0)) c0 \\ app c0 (global [])) \n  :  (mono (list X16))"]}
+{"step":32,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":32,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule:builtin:name","payload":["print"]}
+{"step":32,"kind":["Info"],"goal_id":12,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}
+{"step":33,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:curgoal","payload":["print","print"]}
+{"step":33,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule","payload":["builtin"]}
+{"step":33,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:builtin:name","payload":["print"]}
+{"step":33,"kind":["Info"],"goal_id":13,"runtime_id":0,"name":"user:rule:builtin","payload":["success"]}

--- a/trace/runtime/dune
+++ b/trace/runtime/dune
@@ -1,6 +1,6 @@
 (library
   (name trace_ppx_runtime)
   (public_name elpi.trace.runtime)
-  (libraries re)
+  (libraries re elpi.trace.atd)
   (modules runtime)
 )

--- a/trace/runtime/runtime.ml
+++ b/trace/runtime/runtime.ml
@@ -9,6 +9,8 @@ module IntMap = Map.Make(struct type t = int let compare x y = x - y end)
 module StrMap = Map.Make(String)
 module Str = Re.Str
 
+open Elpi_trace_atd
+
 let debug = ref false
 let where_loc = ref ("",0,max_int)
 let cur_step = ref IntMap.empty
@@ -32,6 +34,9 @@ type message = {
 }
 
 let printer : (message -> unit) ref = ref (fun _ -> assert false)
+
+let pp_j fmt = function
+  | J(pp,x) -> pp fmt x
 
 module Perf = struct
 
@@ -190,122 +195,23 @@ let exit ~runtime_id k tailcall e time =
   end
 
 (* Json *)
-let pp_s fmt s =
-  Format.fprintf fmt "%S" s
-
-let pp_i fmt i =
-  Format.fprintf fmt "%d" i
-
-let pp_f fmt f =
-  Format.fprintf fmt "%f" f
-
-let pp_kv fmt = function
-  | k, J(pp_v, v) -> F.fprintf fmt "%a : %a" pp_s k pp_v v
-
-let pp_j fmt = function
-  | J(pp,x) -> pp fmt x
-
-let rec pp_comma_l fmt pp = function
-  | [] -> ()
-  | x :: xs -> F.fprintf fmt ","; pp fmt x; pp_comma_l fmt pp xs
-
-let pp_a fmt (l : j list) =
-  F.fprintf fmt "[";
-  begin match l with
-  | [] -> ()
-  | x :: l -> pp_j fmt x; pp_comma_l fmt pp_j l
-  end;
-  F.fprintf fmt "]"
-
-
-module JSON_STRING_ENCODING = struct
-  (* This code is from Yojson *)
-
-  let hex n =
-    Char.chr (
-      if n < 10 then n + 48
-      else n + 87
-    )
-  
-  let write_special src start stop ob str =
-    Buffer.add_substring ob src !start (stop - !start);
-    Buffer.add_string ob str;
-    start := stop + 1
-  
-  let write_control_char src start stop ob c =
-    Buffer.add_substring ob src !start (stop - !start);
-    Buffer.add_string ob "\\u00";
-    Buffer.add_char ob (hex (Char.code c lsr 4));
-    Buffer.add_char ob (hex (Char.code c land 0xf));
-    start := stop + 1
-  
-  let finish_string src start ob =
-    try
-      Buffer.add_substring ob src !start (String.length src - !start)
-    with exc ->
-      Printf.eprintf "src=%S start=%i len=%i\n%!"
-        src !start (String.length src - !start);
-      raise exc
-  
-  let write_string_body ob s =
-    let start = ref 0 in
-    for i = 0 to String.length s - 1 do
-      match s.[i] with
-          '"' -> write_special s start i ob "\\\""
-        | '\\' -> write_special s start i ob "\\\\"
-        | '\b' -> write_special s start i ob "\\b"
-        | '\012' -> write_special s start i ob "\\f"
-        | '\n' -> write_special s start i ob "\\n"
-        | '\r' -> write_special s start i ob "\\r"
-        | '\t' -> write_special s start i ob "\\t"
-        | '\x00'..'\x1F'
-        | '\x7F' as c -> write_control_char s start i ob c
-        | _ -> ()
-    done;
-    finish_string s start ob
-
-end
-
-let pp_as fmt (l : j list) =
-  let pp_j fmt x =
-    let s = F.asprintf "%a" pp_j x in
-    let b = Buffer.create 64 in
-    JSON_STRING_ENCODING.write_string_body b s;
-    F.fprintf fmt "\"%s\"" (Buffer.contents b) in
-  F.fprintf fmt "[";
-  begin match l with
-  | [] -> ()
-  | x :: l ->
-     pp_j fmt x;
-     pp_comma_l fmt pp_j l
-  end;
-  F.fprintf fmt "]"
-
-
-let pp_d fmt (l : (string * j) list) =
-  F.fprintf fmt "{";
-  begin match l with
-  | [] -> ()
-  | x :: l -> pp_kv fmt x; pp_comma_l fmt pp_kv l
-  end;
-  F.fprintf fmt "}"
-
-let pp_kind fmt = function
-  | Start -> pp_a fmt [J(pp_s,"Start")]
-  | Info -> pp_a fmt [J(pp_s,"Info")]
-  | Stop { cause; time } -> pp_a fmt [J(pp_s,"Stop");J(pp_s,cause);J(pp_f,time)]
-
 let print_json fmt  = (); fun { runtime_id; goal_id; kind; name; step; payload } ->
-  pp_d fmt [
-    "step", J(pp_i,step);
-    "kind", J(pp_kind,kind);
-    "goal_id", J(pp_i,goal_id);
-    "runtime_id", J(pp_i,runtime_id);
-    "name", J(pp_s,name);
-    "payload", J(pp_as, payload)
-  ];
-  F.pp_print_newline fmt ();
-  F.pp_print_flush fmt ()
+  (* TODO: unwrap the singleton in the next breaking change *)
+  let kind : Trace_atd.kind list = [match kind with
+    | Start -> `Start
+    | Info -> `Info
+    | Stop { cause; time } -> `Stop { cause; time }] in
+  let payload =
+    let b = Buffer.create 100 in
+    let fmt = Format.formatter_of_buffer b in
+    payload |> List.map (fun i ->
+                   let () = pp_j fmt i in
+                   let () = Format.pp_print_flush fmt () in
+                   let s = Buffer.contents b in
+                   Buffer.reset b; s) in
+  let b = Buffer.create 100 in
+  let () = Trace_atd.write_item b { runtime_id; goal_id; kind; name; step; payload } in
+  Format.fprintf fmt "%s@." (Buffer.contents b)
 
 (* TTY *)
 let tty_formatter_maxcols = ref 80


### PR DESCRIPTION
Fixes #435 by implementing the last solution I proposed. This is technically a breaking change, but any code that would be affected was written against an undocumented divergence from the advertised JSON format caused by a bug, so I don't think it warrants a "formal" trace version bump.

You can check that the change to the JSON files is only whitespace by running `git diff -w` on them.