### PR TITLE
Don't depend on ANSITerminal on Windows, provide stub

### DIFF
--- a/elpi.opam
+++ b/elpi.opam
@@ -21,7 +21,7 @@ depends: [
   "menhir" {>= "20211230" }
   "re" {>= "1.7.2"}
   "ppx_deriving" {>= "4.3"}
-  "ANSITerminal" {with-test}
+  "ANSITerminal" {with-test & os != "win32"}
   "cmdliner"  {with-test & >= "2.0"}
   "fileutils" {with-test}
   "yojson" {with-test}

--- a/tests/ansi.dummy.ml
+++ b/tests/ansi.dummy.ml
@@ -1,0 +1,14 @@
+(* A stub module for ANSITerminal, to be expanded as necessary *)
+
+module ANSITerminal = struct
+  let green = ()
+  let red = ()
+  let blue = ()
+  let yellow = ()
+  let printf _ = Printf.printf
+
+  type loc = Eol
+
+  let move_bol () = Printf.printf "\n%!"
+  let erase _ = ()
+end

--- a/tests/dune
+++ b/tests/dune
@@ -1,11 +1,14 @@
 (executable
   (name test)
-  (modules test)
+  (modules test ansi)
   (optional)
   (promote)
   (libraries
+     (select ansi.ml from
+       (ANSITerminal -> ansi.real.ml)
+       (-> ansi.dummy.ml))
      (select test.ml from
-       (test_suite ANSITerminal cmdliner str unix -> test.real.ml)
+       (test_suite cmdliner str unix -> test.real.ml)
        (-> test.dummy.ml)))
 )
 (env
@@ -13,3 +16,5 @@
     (flags (:standard -w -9 -w -32 -w -27 -w -6 -w -37 -warn-error -A)))
   (fatalwarnings
     (flags (:standard -w -9 -w -32 -w -27 -w -6 -w -37 -warn-error +A))))
+
+(rule (write-file ansi.real.ml "module ANSITerminal = ANSITerminal"))

--- a/tests/test.real.ml
+++ b/tests/test.real.ml
@@ -3,6 +3,7 @@
 (* ------------------------------------------------------------------------- *)
 open Test_suite
 open Suite
+open Ansi
     
 module Printer : sig
 
@@ -93,17 +94,13 @@ let print_log ~ln_nb ~fname =
 
 end
 
-let aNSITerminal_move_bol () =
-  if Sys.win32 then ANSITerminal.printf [] "\n%!"
-  else ANSITerminal.move_bol ()
-
 let run stop_on_first_error timeout _seed sources promote env { Runner.run; test; executable }  =
 
   let { Test.name; description; _ } = test in
   let print = Printer.print ~executable:(Filename.basename executable) ~name ~description ~promote in
 
   print 0.0 0.0 0.0 0 `RUNNING;
-  aNSITerminal_move_bol ();
+  ANSITerminal.move_bol ();
 
   let rc = match run ~timeout ~env ~sources with
     | Runner.Skipped -> print 0.0 0.0 0.0 0 `SKIPPED; None


### PR DESCRIPTION
I believe this should fix the Windows issues (~~but only CI will tell...~~ it said yes 🥹).

`ANSITerminal` becomes an optional dependency of the test suite, with a stub provided for cases where it's not available.