### PR TITLE
Temporarily remove coq-trocq-std from CI

### DIFF
--- a/.github/workflows/users.yml
+++ b/.github/workflows/users.yml
@@ -34,7 +34,7 @@ jobs:
         - run: opam pin --ignore-constraints-on elpi            add coq-elpi               https://github.com/LPCIC/coq-elpi.git#master
         - run: opam pin --ignore-constraints-on elpi            add rocq-stdlib            https://github.com/rocq-prover/stdlib.git#master
         - run: opam pin --ignore-constraints-on elpi            add coq-stdlib             https://github.com/rocq-prover/stdlib.git#master
-        - run: opam pin --ignore-constraints-on elpi,coq-stdlib add coq-trocq-std          https://github.com/rocq-community/trocq.git#master
+        #- run: opam pin --ignore-constraints-on elpi,coq-stdlib add coq-trocq-std          https://github.com/rocq-community/trocq.git#master
         - run: opam pin --ignore-constraints-on elpi            add rocq-hierarchy-builder https://github.com/math-comp/hierarchy-builder.git#master
         - run: opam pin --ignore-constraints-on elpi            add rocq-mathcomp-boot     https://github.com/math-comp/math-comp.git#master
         - run: opam pin --ignore-constraints-on elpi            add rocq-mathcomp-order    https://github.com/math-comp/math-comp.git#master


### PR DESCRIPTION
Trocq is apparently known to be currently broken [[1]]; among other things its opam file declares a dependency on
`"coq" {>= "9.0" & < "9.2"}`, while rocq-stdlib@master already dropped support for rocq < 9.2 [[2]].

Note also that ignoring the version range on "coq" doesn't help, since the "coq" package doesn't have a version for 9.2 in the opam repository (and doesn't exist in the rocq repository), as opposed to e.g. coq-core.

Removing Trocq makes the rest of the "test users" CI pass: https://github.com/VojtechStep/elpi/actions/runs/30910579757/job/91996039212

[1]: https://github.com/rocq-community/trocq/issues/86
[2]: https://github.com/rocq-prover/stdlib/pull/300